### PR TITLE
Rename to Liberty Tools and bump version to 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Liberty Tools for IntelliJ
+# Liberty Tools for IntelliJ
 
 [plugin-repo]: https://plugins.jetbrains.com/plugin/14856-open-liberty-tools
 
@@ -19,17 +19,16 @@ workspace.
 Note that this extension requires the [Integrated Terminal plugin](https://plugins.jetbrains.com/plugin/13123-terminal)
 to be enabled.
 
-![Open Liberty Tools Extension](docs/images/open-liberty-tools.png)
+![Liberty Tools Extension](docs/images/open-liberty-tools.png)
 
 ## Quick Start
 
-- Install [_Open Liberty
-  Tools_ from the IntelliJ Marketplace](https://plugins.jetbrains.com/plugin/14856-open-liberty-tools).
+- Install [_Liberty Tools_ from the IntelliJ Marketplace](https://plugins.jetbrains.com/plugin/14856-open-liberty-tools).
 - Projects with the Liberty Maven Plugin or Liberty Gradle Plugin configured will appear in the Liberty tool window on
   the side bar. If not enabled by default, the tool window can be viewed by selecting **View > Tool Windows > Liberty**.
 - Select a project in the Liberty tool window to view the available commands.
 
-For more detailed instructions on your configuring your Open Liberty project and making use of the Open Liberty Tools
+For more detailed instructions on your configuring your Liberty project and making use of the Liberty Tools
 commands, check out [Getting Started](docs/GettingStarted.md).
 
 ## Features
@@ -59,7 +58,7 @@ the default `index.html` file.
 
 ## Contributing
 
-Contributions to the Open Liberty Tools extension are welcome!
+Contributions to the Liberty Tools extension are welcome!
 
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.
 
@@ -75,4 +74,4 @@ built-in [gradle-intellij-plugin](https://github.com/JetBrains/gradle-intellij-p
 ## Issues
 
 Please report bugs, issues and feature requests by creating
-a [GitHub issue](https://github.com/OpenLiberty/open-liberty-tools-intellij/issues)
+a [GitHub issue](https://github.com/OpenLiberty/liberty-tools-intellij/issues)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'io.openliberty.tools'
-version '0.0.6'
+version '0.0.7'
 
 sourceCompatibility = 1.8
 
@@ -30,6 +30,10 @@ intellij {
 
 patchPluginXml {
     changeNotes """
+        <b> 0.0.7 </b>
+        <ul>
+        <li> Rename plugin to Liberty Tools for IntelliJ
+        </ul>
         <b> 0.0.6 </b>
         <ul>
         <li> Fix release

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,11 +1,11 @@
 # Getting Started
 
-Detailed instructions on how to import and configure your Open Liberty Project to make use of the Open Liberty Tools
+Detailed instructions on how to import and configure your Liberty project to make use of the Liberty Tools
 IntelliJ Plugin.
 
-### Importing your Open Liberty project into IntelliJ
+### Importing your Liberty project into IntelliJ
 
-Startup IntelliJ IDEA and then choose "Import Project" from the main menu and select your Open Liberty project.
+Startup IntelliJ IDEA and then choose "Import Project" from the main menu and select your Liberty project.
 
 ![IntelliJ import project](images/IntelliJ_import_project.png)
 
@@ -39,13 +39,13 @@ buildscript {
 ```
 
 Ensure you can access the Liberty tool window in IntelliJ. This can be enabled by selecting **View > Tool Windows >
-Liberty**. Your Open Liberty project should appear in the Liberty tool window. If it does not, ensure you have properly
+Liberty**. Your Liberty project should appear in the Liberty tool window. If it does not, ensure you have properly
 configured the Liberty Maven Plugin or Liberty Gradle plugin and refresh the tool window.
-![Open Liberty tool window](images/Liberty_tool_window.png)
+![Liberty tool window](images/Liberty_tool_window.png)
 
 ### Running Liberty in dev mode
 
-When you run Open Liberty in dev mode, you can rapidly code, deploy, test, and debug your application.
+When you run Liberty in dev mode, you can rapidly code, deploy, test, and debug your application.
 
 **Starting Liberty dev mode**
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,14 +1,14 @@
 <idea-plugin>
     <id>open-liberty.intellij</id>
-    <name>Open Liberty Tools</name>
+    <name>Liberty Tools</name>
 
     <vendor url="https://openliberty.io/">Open-Liberty</vendor>
 
     <category>Framework Integration</category>
 
     <description><![CDATA[
-     Open Liberty Tools adds support in IntelliJ for your <a href="https://openliberty.io/">Open Liberty</a> projects.
-     Open Liberty development mode allows you to easily develop your cloud-native Jakarta EE and Java microservices (with MicroProfile) applications with hot reload and deployment.
+     Liberty Tools adds support in IntelliJ for your <a href="https://openliberty.io/">Open Liberty</a> projects.
+     Liberty dev mode allows you to easily develop your cloud-native Jakarta EE and Java microservices (with MicroProfile) applications with hot reload and deployment.
      <b>This is a preview release.</b>
      <br/>
      The following features are available through the Liberty tool window:


### PR DESCRIPTION
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

Fixes #64 


To test the name change, go to IntelliJ IDEA -> Preferences -> Plugins -> Gear icon -> Install plugin from disk and navigate to the zip file attached.
<img width="435" alt="image" src="https://user-images.githubusercontent.com/26146482/184375900-854172c6-e1d3-465d-9607-05b3806eaa75.png">

[open-liberty-tools-intellij-0.0.7.zip](https://github.com/OpenLiberty/liberty-tools-intellij/files/9318455/open-liberty-tools-intellij-0.0.7.zip)
