### PR TITLE
Maintenance and fixes for Liberty Dashboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group 'io.openliberty.tools'
 version '0.0.7'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 
 repositories {
     mavenCentral()
@@ -23,7 +23,7 @@ runIde {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.3.3'
+    version '2021.3.2'
     updateSinceUntilBuild false
     plugins 'terminal'
 }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -43,7 +43,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 public class LibertyExplorer extends SimpleToolWindowPanel {
-    private static Logger log = Logger.getInstance(LibertyExplorer.class);
+    private static Logger LOGGER = Logger.getInstance(LibertyExplorer.class);
 
     public LibertyExplorer(@NotNull Project project) {
         super(true, true);
@@ -93,7 +93,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             mavenBuildFiles = LibertyProjectUtil.getMavenBuildFiles(project);
             gradleBuildFiles = LibertyProjectUtil.getGradleBuildFiles(project);
         } catch (IOException | SAXException | ParserConfigurationException e) {
-            log.error("Could not find Open Liberty Maven or Gradle projects in workspace",
+            LOGGER.error("Could not find Open Liberty Maven or Gradle projects in workspace",
                     e.getMessage());
             return null;
         }
@@ -107,15 +107,15 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             String projectName = null;
             VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
-                log.error("Could not resolve current Maven project");
+                LOGGER.error("Could not resolve current Maven project");
             }
             LibertyProjectNode node;
             try {
                 projectName = LibertyMavenUtil.getProjectNameFromPom(virtualFile);
             } catch (Exception e) {
-                log.error("Could not resolve project name from pom.xml", e.getMessage());
+                LOGGER.error("Could not resolve project name from pom.xml", e.getMessage());
             }
-            log.info("Liberty Maven Project: " + psiFile);
+            LOGGER.info("Liberty Maven Project: " + psiFile);
             if (projectName == null) {
                 projectName = project.getName();
             }
@@ -148,15 +148,15 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             String projectName = null;
             VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
-                log.error("Could not resolve current Gradle project");
+                LOGGER.error("Could not resolve current Gradle project");
             }
             LibertyProjectNode node;
             try {
                 projectName = LibertyGradleUtil.getProjectName(virtualFile);
             } catch (Exception e) {
-                log.error("Could not resolve project name from settings.gradle", e.getMessage());
+                LOGGER.error("Could not resolve project name from settings.gradle", e.getMessage());
             }
-            log.info("Liberty Gradle Project: " + psiFile);
+            LOGGER.info("Liberty Gradle Project: " + psiFile);
             if (projectName == null) {
                 projectName = project.getName();
             }
@@ -290,7 +290,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
         if (node instanceof LibertyActionNode) {
             ActionManager am = ActionManager.getInstance();
             String actionNodeName = ((LibertyActionNode) node).getName();
-            log.debug("Selected: " + actionNodeName);
+            LOGGER.debug("Selected: " + actionNodeName);
             if (actionNodeName.equals(Constants.LIBERTY_DEV_START)) {
                 // calls action on double click
                 am.getAction(Constants.LIBERTY_DEV_START_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -160,7 +160,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             if (projectName == null) {
                 projectName = project.getName();
             }
-            node = new LibertyProjectNode(psiFile, project.getName(), Constants.LIBERTY_GRADLE_PROJECT, buildFile.isValidContainerVersion());
+            node = new LibertyProjectNode(psiFile, projectName, Constants.LIBERTY_GRADLE_PROJECT, buildFile.isValidContainerVersion());
 
             top.add(node);
             projectNames.add(projectName);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -67,7 +67,7 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
         if (widget == null) {
-            log.debug("Unable to start Liberty dev mode with custom parameters, could not get or create terminal widget for " + projectName);
+            LOGGER.debug("Unable to start Liberty dev mode with custom parameters, could not get or create terminal widget for " + projectName);
             return;
         }
         LibertyActionUtil.executeCommand(widget, startCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -40,7 +40,7 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
                     , NotificationType.WARNING
                     , NotificationListener.URL_OPENING_LISTENER);
             Notifications.Bus.notify(notif, project);
-            log.error("Cannot run tests, corresponding project terminal does not exist.");
+            LOGGER.error("Cannot run tests, corresponding project terminal does not exist.");
             return;
         }
         LibertyActionUtil.executeCommand(widget, runTestsCommand);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -32,7 +32,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             startCmd = "gradle libertyDev -b=" + buildFile.getCanonicalPath();
         }
         if (widget == null) {
-            log.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
+            LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
             return;
         }
         LibertyActionUtil.executeCommand(widget, startCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -32,7 +32,7 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
         if (widget == null) {
-            log.debug("Unable to start Liberty dev mode in a container, could not get or create terminal widget for " + projectName);
+            LOGGER.debug("Unable to start Liberty dev mode in a container, could not get or create terminal widget for " + projectName);
             return;
         }
         LibertyActionUtil.executeCommand(widget, startCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -39,7 +39,7 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
                     , NotificationType.WARNING
                     , NotificationListener.URL_OPENING_LISTENER);
             Notifications.Bus.notify(notif, project);
-            log.error("Cannot stop Liberty dev mode, corresponding project terminal does not exist.");
+            LOGGER.error("Cannot stop Liberty dev mode, corresponding project terminal does not exist.");
             return;
         }
         LibertyActionUtil.executeCommand(widget, stopCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class LibertyGeneralAction extends AnAction {
 
-    protected Logger log = Logger.getInstance(LibertyGeneralAction.class);
+    protected Logger LOGGER = Logger.getInstance(LibertyGeneralAction.class);
     protected Project project;
     protected String projectName;
     protected String projectType;
@@ -37,9 +37,10 @@ public class LibertyGeneralAction extends AnAction {
     public void actionPerformed(@NotNull AnActionEvent e) {
         project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) {
+            // TODO prompt user to select project
             String msg = LocalizedResourceUtil.getMessage("liberty.project.does.not.resolve", actionCmd);
             notifyError(msg);
-            log.debug(msg);
+            LOGGER.debug(msg);
             return;
         }
 
@@ -47,7 +48,7 @@ public class LibertyGeneralAction extends AnAction {
         if (buildFile == null) {
             String msg = LocalizedResourceUtil.getMessage("liberty.build.file.does.not.resolve", actionCmd, project.getName());
             notifyError(msg);
-            log.debug(msg);
+            LOGGER.debug(msg);
             return;
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -31,13 +31,13 @@ import javax.swing.*;
 import java.awt.*;
 
 public class RefreshLibertyToolbar extends AnAction {
-    Logger log = Logger.getInstance(RefreshLibertyToolbar.class);
+    Logger LOGGER = Logger.getInstance(RefreshLibertyToolbar.class);
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         final Project project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) {
-            log.debug("Unable to refresh Liberty toolbar, could not resolve project");
+            LOGGER.debug("Unable to refresh Liberty toolbar, could not resolve project");
             return;
         }
         ProjectView.getInstance(project).refresh();

--- a/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
@@ -27,7 +27,7 @@ import javax.swing.tree.TreePath;
 import java.awt.*;
 
 public class RunLibertyDevTask extends AnAction {
-    Logger log = Logger.getInstance(RunLibertyDevTask.class);
+    Logger LOGGER = Logger.getInstance(RunLibertyDevTask.class);
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -53,7 +53,7 @@ public class RunLibertyDevTask extends AnAction {
                         }
                     }
                 } else {
-                    log.debug("Tree view not built, no valid projects to run Liberty dev actions on");
+                    LOGGER.debug("Tree view not built, no valid projects to run Liberty dev actions on");
                 }
             }
         }
@@ -93,7 +93,7 @@ public class RunLibertyDevTask extends AnAction {
                     }
                 }
             } else {
-                log.debug("Tree view not built, no valid projects to run Liberty dev actions on");
+                LOGGER.debug("Tree view not built, no valid projects to run Liberty dev actions on");
             }
         }
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -46,7 +46,7 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
                     , NotificationType.ERROR
                     , NotificationListener.URL_OPENING_LISTENER);
             Notifications.Bus.notify(notif, project);
-            log.debug("Integration test report does not exist at : " + failsafeReportFile.getAbsolutePath());
+            LOGGER.debug("Integration test report does not exist at : " + failsafeReportFile.getAbsolutePath());
             return;
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -79,7 +79,7 @@ public class ViewTestReport extends LibertyGeneralAction {
                     , NotificationType.ERROR
                     , NotificationListener.URL_OPENING_LISTENER);
             Notifications.Bus.notify(notif, project);
-            log.debug("Gradle test report does not exist at : " + testReportFile.getAbsolutePath());
+            LOGGER.debug("Gradle test report does not exist at : " + testReportFile.getAbsolutePath());
             return;
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -45,7 +45,7 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
                     , NotificationType.ERROR
                     , NotificationListener.URL_OPENING_LISTENER);
             Notifications.Bus.notify(notif, project);
-            log.debug("Unit test report does not exist at : " + surefireReportFile.getAbsolutePath());
+            LOGGER.debug("Unit test report does not exist at : " + surefireReportFile.getAbsolutePath());
             return;
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
@@ -26,7 +26,7 @@ public class LibertyActionUtil {
      * @param cmd
      */
     public static void executeCommand(ShellTerminalWidget widget, String cmd) {
-        Logger log = Logger.getInstance(LibertyActionUtil.class);
+        Logger LOGGER = Logger.getInstance(LibertyActionUtil.class);
         try {
             widget.grabFocus();
             TtyConnector connector = widget.getTtyConnector();
@@ -41,7 +41,7 @@ public class LibertyActionUtil {
             result.append(cmd).append(enterCode);
             connector.write(result.toString());
         } catch (IOException ex) {
-            log.error(ex.getMessage());
+            LOGGER.error(ex.getMessage());
         }
 
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 public class LibertyGradleUtil {
-    private static Logger log = Logger.getInstance(LibertyGradleUtil.class);;
+    private static Logger LOGGER = Logger.getInstance(LibertyGradleUtil.class);;
     /**
      * Given the gradle build file get the project name
      * This method looks for a settings.gradle file in the same parent dir
@@ -46,7 +46,7 @@ public class LibertyGradleUtil {
                     return name.replaceAll("^[\"']+|[\"']+$", "");
                 }
             } catch (IOException e) {
-                log.error("Could not read " + settingsPath, e.getMessage());
+                LOGGER.error("Could not read " + settingsPath, e.getMessage());
             }
         }
         return null;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 public class LibertyProjectUtil {
-    private static Logger log = Logger.getInstance(LibertyProjectUtil.class);;
+    private static Logger LOGGER = Logger.getInstance(LibertyProjectUtil.class);;
 
     @Nullable
     public static Project getProject(DataContext context) {
@@ -106,7 +106,7 @@ public class LibertyProjectUtil {
                         buildFiles.add(buildFile);
                     }
                 } catch (Exception e) {
-                    log.error("Error parsing build.gradle", e.getMessage());
+                    LOGGER.error("Error parsing build.gradle", e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
Some general maintenance/fixes related to the Liberty dashboard code:
- Bump to IntelliJ 2021.3.2 and Java 11 (tried bumping to Java 17 but ran into errors, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/96#issuecomment-1267360719)
- Standardize logging naming
- Fix for Gradle project names

