### PR TITLE
Bump and temporarily remove junit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    //Add junit dependency back when tests are added
+    //testImplementation group: 'junit', name: 'junit', version: '4.13.1'
     implementation 'org.apache.maven:maven-artifact:3.6.3'
 }
 


### PR DESCRIPTION
Mend reported this CVE: https://github.com/advisories/GHSA-269g-pwp5-87pp
JUnit dependency should be bumped to version 4.13.1. 
We can also remove the JUnit dependency temporarily, since there are no automated tests yet.