### PR TITLE
Custom Start updates for user-defined build file/dir

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -30,10 +30,10 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
         String initialVal;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
             msg = LocalizedResourceUtil.getMessage("start.liberty.dev.custom.params.message.maven");
-            initialVal = "-DhotTests=true";
+            initialVal = "-f \"" + buildFile.getName() + "\"";
         } else {
             msg = LocalizedResourceUtil.getMessage("start.liberty.dev.custom.params.message.gradle");
-            initialVal = "--hotTests";
+            initialVal = "--project-dir=.";
         }
 
         InputValidator validator = new InputValidator() {
@@ -60,9 +60,9 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
             return;
         }
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev " + customParams + " -f \"" + buildFile.getCanonicalPath() + "\"";
+            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev " + customParams;
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDev " + customParams + " -b=" + buildFile.getCanonicalPath();
+            startCmd = "gradle libertyDev " + customParams;
         }
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -30,10 +30,10 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
         String initialVal;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
             msg = LocalizedResourceUtil.getMessage("start.liberty.dev.custom.params.message.maven");
-            initialVal = "-f \"" + buildFile.getName() + "\"";
+            initialVal = "";
         } else {
             msg = LocalizedResourceUtil.getMessage("start.liberty.dev.custom.params.message.gradle");
-            initialVal = "--project-dir=.";
+            initialVal = "";
         }
 
         InputValidator validator = new InputValidator() {
@@ -70,6 +70,8 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
             LOGGER.debug("Unable to start Liberty dev mode with custom parameters, could not get or create terminal widget for " + projectName);
             return;
         }
+        String cdToProjectCmd = "cd " + buildFile.getParent().getCanonicalPath();
+        LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -70,7 +70,7 @@ public class LibertyDevCustomStartAction extends LibertyGeneralAction {
             LOGGER.debug("Unable to start Liberty dev mode with custom parameters, could not get or create terminal widget for " + projectName);
             return;
         }
-        String cdToProjectCmd = "cd " + buildFile.getParent().getCanonicalPath();
+        String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -27,14 +27,16 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String startCmd = null;
 
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev -f \"" + buildFile.getCanonicalPath() + "\"";
+            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDev -b=" + buildFile.getCanonicalPath();
+            startCmd = "gradle libertyDev";
         }
         if (widget == null) {
             LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
             return;
         }
+        String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
+        LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -25,9 +25,9 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
     protected void executeLibertyAction() {
         String startCmd = null;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:devc -f \"" + buildFile.getCanonicalPath() + "\"";
+            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:devc";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDevc -b=" + buildFile.getCanonicalPath();
+            startCmd = "gradle libertyDevc";
         }
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
@@ -35,6 +35,8 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
             LOGGER.debug("Unable to start Liberty dev mode in a container, could not get or create terminal widget for " + projectName);
             return;
         }
+        String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
+        LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
     }
 }

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -45,8 +45,8 @@ liberty.action.cannot.start=Liberty action was not able to start
 # Custom start action
 start.liberty.dev.custom.params=start Liberty dev mode with custom parameters
 start.dev.custom.params=Start dev mode...
-start.liberty.dev.custom.params.message.maven=Specify custom parameters for the Liberty dev command (e.g. -DhotTests=true)
-start.liberty.dev.custom.params.message.gradle=Specify custom parameters for the Liberty dev command (e.g. --hotTests)
+start.liberty.dev.custom.params.message.maven=Specify custom parameters for mvn liberty:dev (e.g. -DhotTests=true)
+start.liberty.dev.custom.params.message.gradle=Specify custom parameters for gradle libertyDev (e.g. --hotTests)
 liberty.dev.custom.params=Liberty dev mode custom parameters
 
 # Start action


### PR DESCRIPTION
Resolves #107
Allow configuring build file/dir for custom start command. Update command description for custom start

- [x] Remove hardcoded buildfile from custom start command
- [x] Update the description of the command to "Specify custom parameters for" `mvn liberty:dev` OR `gradle libertyDev` depending on the type of project.
- [x] Set the working directory of the terminal to the selected project.

NOTE: Currently unable to test custom start command for Gradle because of #63