### PR TITLE
Build project in Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build Liberty-Tools-Intellij
+        run: gradle buildPlugin
+      - name: Archive jars
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: liberty-tools-intellij
+          path: ./**/*liberty-tools-intellij*.zip
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
+          cache: 'gradle'
       - name: Build Liberty-Tools-Intellij
         run: gradle buildPlugin
-      - name: Archive jars
+      - name: Archive artifacts
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
-          name: liberty-tools-intellij
+          name: liberty-tools-intellij-${{ github.sha }}
           path: ./**/*liberty-tools-intellij*.zip
           if-no-files-found: warn
           retention-days: 7

--- a/.run/liberty-tools-intellij [runIde].run.xml
+++ b/.run/liberty-tools-intellij [runIde].run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="open-liberty-tools-intellij [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="liberty-tools-intellij [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Open Liberty Tools IntelliJ
+# Contributing to Liberty Tools IntelliJ
 
 We welcome contributions, and request you follow these guidelines.
 
@@ -9,7 +9,7 @@ We welcome contributions, and request you follow these guidelines.
 
 ## Raising issues
 
-Please raise any bug reports on the [issue tracker](https://github.com/OpenLiberty/open-liberty-tools-intellij/issues). Be sure to search the list to see if your issue has already been raised.
+Please raise any bug reports on the [issue tracker](https://github.com/OpenLiberty/liberty-tools-intellij/issues). Be sure to search the list to see if your issue has already been raised.
 
 A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong. Provide as much context as possible so we can try to recreate the issue.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Liberty Tools for IntelliJ
 
-[plugin-repo]: https://plugins.jetbrains.com/plugin/14856-open-liberty-tools
+[plugin-repo]: https://plugins.jetbrains.com/plugin/14856-liberty-tools
 
-[plugin-version-svg]: https://img.shields.io/jetbrains/plugin/v/14856-open-liberty-tools.svg
+[plugin-version-svg]: https://img.shields.io/jetbrains/plugin/v/14856-liberty-tools.svg
 
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 [![JetBrains plugins][plugin-version-svg]][plugin-repo]
-![Downloads](https://img.shields.io/jetbrains/plugin/d/14856-open-liberty-tools)
+![Downloads](https://img.shields.io/jetbrains/plugin/d/14856-liberty-tools)
 
 An [Open Liberty](https://openliberty.io/) extension for IntelliJ. The extension will detect your Liberty Maven or
 Liberty Gradle project if it detects the `io.openliberty.tools:liberty-maven-plugin` in the `pom.xml` or
@@ -23,7 +23,7 @@ to be enabled.
 
 ## Quick Start
 
-- Install [_Liberty Tools_ from the IntelliJ Marketplace](https://plugins.jetbrains.com/plugin/14856-open-liberty-tools).
+- Install [_Liberty Tools_ from the IntelliJ Marketplace](https://plugins.jetbrains.com/plugin/14856-liberty-tools).
 - Projects with the Liberty Maven Plugin or Liberty Gradle Plugin configured will appear in the Liberty tool window on
   the side bar. If not enabled by default, the tool window can be viewed by selecting **View > Tool Windows > Liberty**.
 - Select a project in the Liberty tool window to view the available commands.
@@ -65,7 +65,7 @@ Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pul
 Developing this extension using the
 built-in [gradle-intellij-plugin](https://github.com/JetBrains/gradle-intellij-plugin/).
 
-1. Clone this repository: `git clone git@github.com:OpenLiberty/open-liberty-tools-intellij.git`
+1. Clone this repository: `git clone git@github.com:OpenLiberty/liberty-tools-intellij.git`
 2. Import this repository as a gradle project in IntelliJ IDEA
 3. Run `./gradlew buildPlugin` to build a `.zip` that can be imported as gradle plugin or run the following Gradle task
    to build and run an IntelliJ instance:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'open-liberty-tools-intellij'
-
+rootProject.name = 'liberty-tools-intellij'


### PR DESCRIPTION
Ensure the plugin builds correctly
Also fix name references from `open-liberty-tools-intellij` to `liberty-tools-intellij`

[Sample build](https://github.com/evie-lau/liberty-tools-intellij/actions/runs/3348698256)