### PR TITLE
Add support for "shift + shift" IntelliJ tool window.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -71,6 +71,10 @@ public class LibertyGeneralAction extends AnAction {
                     if (ret >= 0 && ret < buildFileInfoList.size()) {
                         buildFileInfoList.get(ret).writeTo(this);
                     }
+                    // The user pressed cancel on the dialog.
+                    else {
+                        return;
+                    }
                 }
             }
             if (buildFile == null) {
@@ -87,13 +91,21 @@ public class LibertyGeneralAction extends AnAction {
         executeLibertyAction();
     }
 
-    /* Returns an aggregated list containing info of all Maven and Gradle build files. */
+    /* Returns true if the specified project type applies to this action. */
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_MAVEN_PROJECT.equals(projectType) ||
+                Constants.LIBERTY_GRADLE_PROJECT.equals(projectType);
+    }
+
+    /* Returns an aggregated list containing info for all Maven and Gradle build files. */
     protected final List<BuildFileInfo> getBuildFileInfoList() {
         final List<BuildFile> mavenBuildFiles;
         final List<BuildFile> gradleBuildFiles;
         try {
-            mavenBuildFiles = LibertyProjectUtil.getMavenBuildFiles(project);
-            gradleBuildFiles = LibertyProjectUtil.getGradleBuildFiles(project);
+            mavenBuildFiles = isProjectTypeSupported(Constants.LIBERTY_MAVEN_PROJECT) ?
+                    LibertyProjectUtil.getMavenBuildFiles(project) : Collections.emptyList();
+            gradleBuildFiles = isProjectTypeSupported(Constants.LIBERTY_GRADLE_PROJECT) ?
+                    LibertyProjectUtil.getGradleBuildFiles(project) : Collections.emptyList();
         }
         catch (IOException | SAXException | ParserConfigurationException e) {
             LOGGER.error("Could not find Open Liberty Maven or Gradle projects in workspace",

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
@@ -11,12 +11,18 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 
 public class ViewEffectivePom extends LibertyGeneralAction {
 
     public ViewEffectivePom() {
         setActionCmd(LocalizedResourceUtil.getMessage("view.effective.pom"));
+    }
+
+    @Override
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_MAVEN_PROJECT.equals(projectType);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
@@ -11,12 +11,18 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 
 public class ViewGradleConfig extends LibertyGeneralAction {
 
     public ViewGradleConfig() {
         setActionCmd(LocalizedResourceUtil.getMessage("view.gradle.config.file"));
+    }
+
+    @Override
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_GRADLE_PROJECT.equals(projectType);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -30,6 +30,11 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
     }
 
     @Override
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_MAVEN_PROJECT.equals(projectType);
+    }
+
+    @Override
     protected void executeLibertyAction() {
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -40,6 +40,11 @@ public class ViewTestReport extends LibertyGeneralAction {
     }
 
     @Override
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_GRADLE_PROJECT.equals(projectType);
+    }
+
+    @Override
     protected void executeLibertyAction() {
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -30,6 +30,11 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
     }
 
     @Override
+    protected boolean isProjectTypeSupported(String projectType) {
+        return Constants.LIBERTY_MAVEN_PROJECT.equals(projectType);
+    }
+
+    @Override
     protected void executeLibertyAction() {
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -41,6 +41,8 @@ liberty.dev.not.started.notification.content=Liberty dev mode has not been start
 liberty.project.does.not.resolve=Unable to {0}: Could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
 liberty.build.file.does.not.resolve=Unable to {0}: Could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
 liberty.action.cannot.start=Liberty action was not able to start
+liberty.project.file.selection.dialog.title=Liberty project file
+liberty.project.file.selection.dialog.message=Select Liberty project file for {0}
 
 # Custom start action
 start.liberty.dev.custom.params=start Liberty dev mode with custom parameters

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -41,8 +41,8 @@ liberty.dev.not.started.notification.content=Liberty dev mode has not been start
 liberty.project.does.not.resolve=Unable to {0}: Could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
 liberty.build.file.does.not.resolve=Unable to {0}: Could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
 liberty.action.cannot.start=Liberty action was not able to start
-liberty.project.file.selection.dialog.title=Liberty project file
-liberty.project.file.selection.dialog.message=Select Liberty project file for {0}
+liberty.project.file.selection.dialog.title=Liberty project
+liberty.project.file.selection.dialog.message=Select Liberty project for {0}
 
 # Custom start action
 start.liberty.dev.custom.params=start Liberty dev mode with custom parameters


### PR DESCRIPTION
Resolves: https://github.com/OpenLiberty/liberty-tools-intellij/issues/79

With some refactoring, similar code for collecting the build files in LibertyExplorer could be shared, but I didn't attempt that in this PR. Not sure about the text for the labels on the dialog box. Please suggest improvements.