### PR TITLE
Allow github actions build on PRs for ls-integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [main]
+    branches: [main, ls-integration]
 
 jobs:
   build:


### PR DESCRIPTION
Adding this so we can make sure `gradle buildPlugin` works on PRs to `ls-integration` branch