### PR TITLE
Bump intellij version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,15 +14,25 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout liberty-tools-intellij
+        uses: actions/checkout@v3
+        with:
+          path: liberty-tools-intellij
+      - name: Checkout lsp4jakarta
+        uses: actions/checkout@v3
+        with:
+          repository: eclipse/lsp4jakarta
+          path: lsp4jakarta
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
       - name: Build Liberty-Tools-Intellij
-        run: gradle buildPlugin
+        run: |
+          gradle buildJakarta
+          gradle buildPlugin
       - name: Archive artifacts
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout liberty-tools-intellij
@@ -28,7 +25,23 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          cache: 'gradle'
+          cache: 'maven'
+      - name: Cache Maven
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Build Liberty-Tools-Intellij
         working-directory: ./liberty-tools-intellij
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: [main, ls-integration]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: 'gradle'
+      - name: Build Liberty-Tools-Intellij
+        run: gradle buildPlugin
+      - name: Archive artifacts
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: liberty-tools-intellij-${{ github.sha }}
+          path: ./**/*liberty-tools-intellij*.zip
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
           java-version: 17
           cache: 'gradle'
       - name: Build Liberty-Tools-Intellij
+        working-directory: ./liberty-tools-intellij
         run: |
           gradle buildJakarta
           gradle buildPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ runIde {
 }
 
 intellij {
-    version = '2020.2.4' //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
+    version = '2021.1.3' //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal']
     updateSinceUntilBuild = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,23 @@ runIde {
     jvmArgs '--add-exports', 'java.base/jdk.internal.vm=ALL-UNNAMED'
 }
 
+
+task buildJakartaCore(type: Exec) {
+    workingDir "../lsp4jakarta/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core"
+    commandLine 'mvn', 'clean', 'install'
+}
+
+task buildJakartaLs(type: Exec) {
+    workingDir "../lsp4jakarta/jakarta.ls"
+    commandLine 'mvn',  'clean', 'install'
+}
+
+task buildJakarta {
+    dependsOn 'buildJakartaCore'
+    dependsOn 'buildJakartaLs'
+    tasks.findByName('buildJakartaLs').mustRunAfter 'buildJakartaCore'
+}
+
 intellij {
     version = '2021.1.3' //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal']

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.6.5'
+    id 'org.jetbrains.intellij' version '1.9.0'
 }
 
 group 'io.openliberty.tools'
@@ -101,7 +101,7 @@ intellij {
 }
 
 patchPluginXml {
-    changeNotes """
+    changeNotes = """
         <b> 0.0.7 </b>
         <ul>
         <li> Rename plugin to Liberty Tools for IntelliJ

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
     maven {
         url 'https://repo.eclipse.org/content/repositories/lemminx-releases'
     }
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
     mavenLocal() // TODO remove once Liberty LS is publicly available
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,7 @@
     <depends>com.intellij.modules.java</depends>
     <depends>com.intellij.properties</depends>
 
-    <idea-version since-build="193"/>
+    <idea-version since-build="211"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"


### PR DESCRIPTION
To build the plugin successfully from scratch, needed to use Java 17 for building `lsp4jakarta`.
Then, to build the plugin itself with Java 17, had to bump a few versions for the IntelliJ platform.
Added GHA build to test.