### PR TITLE
Return filetype languages for bootstrap and MP config files

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/BootstrapPropertiesFileType.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/BootstrapPropertiesFileType.java
@@ -33,7 +33,7 @@ public class BootstrapPropertiesFileType extends LanguageFileType implements Fil
     public static final String BOOTSTRAP_GLOB_PATTERN = "**/{src/main/liberty/config,usr/servers/**}/bootstrap.properties";
 
     private BootstrapPropertiesFileType() {
-        super(BootstrapPropertiesLanguage.INSTANCE, true);
+        super(BootstrapPropertiesLanguage.INSTANCE);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileConfigFileType.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileConfigFileType.java
@@ -25,7 +25,7 @@ public class MicroProfileConfigFileType extends LanguageFileType {
     public static final MicroProfileConfigFileType INSTANCE = new MicroProfileConfigFileType();
 
     protected MicroProfileConfigFileType() {
-        super(MicroProfileConfigLanguage.INSTANCE, true);
+        super(MicroProfileConfigLanguage.INSTANCE);
     }
 
     @Override

--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -40,6 +40,7 @@
         <fileType name="microprofile-config.properties file"
                   implementationClass="io.openliberty.tools.intellij.lsp4mp.lsp.MicroProfileConfigFileType"
                   fieldName="INSTANCE"
+                  language="MicroProfileConfigProperties"
                   patterns="microprofile-config.properties;microprofile-config-?*.properties"/>
 
         <!-- bootstrap.properties for Liberty LS -->


### PR DESCRIPTION
Followup on #134, ran into an exception when launching the plugin
```
com.intellij.diagnostic.PluginException: Incorrect language specified in <fileType> for bootstrap.properties file, should be null, actual BootstrapProperties [Plugin: open-liberty.intellij]
```

- Fix BootstrapPropertiesFileType to return its language for our filtered `bootstrap.properties` files
- Assign `MicroProfileConfigProperties` as language type for its respective files

Since MP Config properties is already specifically filtered to `microprofile-config*.properties` files, there seems to be no risk of incorrect language assignment to other `.properties` files