### PR TITLE
Support for maven and gradle wrappers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ runIde {
 intellij {
     version '2021.3.2'
     updateSinceUntilBuild false
-    plugins 'terminal'
+    plugins 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle'
 }
 
 patchPluginXml {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -9,12 +9,33 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import io.openliberty.tools.intellij.util.Constants;
-import io.openliberty.tools.intellij.util.LibertyActionUtil;
-import io.openliberty.tools.intellij.util.LibertyProjectUtil;
-import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.SystemInfo;
+import io.openliberty.tools.intellij.util.*;
+import org.jetbrains.idea.maven.config.MavenConfig;
+import org.jetbrains.idea.maven.model.MavenConstants;
+import org.jetbrains.idea.maven.project.MavenGeneralSettings;
+import org.jetbrains.idea.maven.project.MavenGeneralSettingsWatcher;
+import org.jetbrains.idea.maven.project.MavenWorkspaceSettings;
+import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
+import org.jetbrains.plugins.gradle.service.settings.GradleSystemSettingsControl;
+import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
+import org.jetbrains.plugins.gradle.settings.GradleSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import com.intellij.openapi.project.Project;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.jetbrains.idea.maven.server.MavenServerManager;
+
+//import org.jetbrains.plugins.maven;
+//import org.jetbrains.idea.maven.server.*;
+//
 public class LibertyDevStartAction extends LibertyGeneralAction {
 
     public LibertyDevStartAction() {
@@ -27,9 +48,9 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String startCmd = null;
 
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev";
+            startCmd = getMavenConfigPreference(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDev";
+            startCmd = getGradleConfigPreference(project) + " libertyDev";
         }
         if (widget == null) {
             LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
@@ -38,5 +59,51 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
+    }
+
+    private String getGradleConfigPreference(Project project) {
+//        GradleSystemSettingsControl gradleSettings = GradleSystemSettingsControl;
+        GradleSettings gradleSettings = GradleSettings.getInstance(project);
+//        gradleSettings.myLinkedProjectsSettings
+        GradleProjectSettings gradleProjectSettings = gradleSettings.getLinkedProjectSettings(project.getBasePath());
+
+        return "gradle";
+    }
+
+    private String getMavenConfigPreference(Project project) {
+        MavenServerManager mavenManager = MavenServerManager.getInstance();
+        MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
+        String mavenHome = mavenSettings.getMavenHome();
+
+        if (mavenManager.WRAPPED_MAVEN.equals(mavenHome)) {
+            // it is set to use the wrapper
+            String mvnwPath = getLocalMavenWrapper(project);
+            if (mvnwPath != null) {
+                return mvnwPath;
+            }
+        } else {
+            // try to use maven home path defined in the settings
+            File mavenHomeFile = getCustomMavenPath(mavenHome);
+            if (mavenHomeFile != null) {
+                return mavenHomeFile.getAbsolutePath();
+            }
+        }
+        // default maven
+        return "mvn";
+    }
+
+    private String getLocalMavenWrapper(Project project) {
+        String mvnw = SystemInfo.isWindows ? "mvnw.cmd" : "./mvnw";
+        File file = new File(project.getBasePath() + File.separator + mvnw);
+        return file.exists() ? mvnw : null;
+    }
+
+    private File getCustomMavenPath(String customMavenHome) {
+        File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
+        if (mavenHomeFile != null) {
+            File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
+            return file.exists() ? file : null;
+        }
+        return null;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -9,33 +9,9 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.util.SystemInfo;
 import io.openliberty.tools.intellij.util.*;
-import org.jetbrains.idea.maven.config.MavenConfig;
-import org.jetbrains.idea.maven.model.MavenConstants;
-import org.jetbrains.idea.maven.project.MavenGeneralSettings;
-import org.jetbrains.idea.maven.project.MavenGeneralSettingsWatcher;
-import org.jetbrains.idea.maven.project.MavenWorkspaceSettings;
-import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
-import org.jetbrains.plugins.gradle.service.settings.GradleSystemSettingsControl;
-import org.jetbrains.plugins.gradle.settings.GradleProjectSettings;
-import org.jetbrains.plugins.gradle.settings.GradleSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import com.intellij.openapi.project.Project;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-
-import org.jetbrains.idea.maven.server.MavenServerManager;
-
-//import org.jetbrains.plugins.maven;
-//import org.jetbrains.idea.maven.server.*;
-//
 public class LibertyDevStartAction extends LibertyGeneralAction {
 
     public LibertyDevStartAction() {
@@ -48,9 +24,9 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String startCmd = null;
 
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = getMavenConfigPreference(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
+            startCmd = LibertyMavenUtil.getMavenConfigPreference(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = getGradleConfigPreference(project) + " libertyDev";
+            startCmd = LibertyGradleUtil.getGradleConfigPreference(project) + " libertyDev";
         }
         if (widget == null) {
             LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
@@ -59,51 +35,5 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
-    }
-
-    private String getGradleConfigPreference(Project project) {
-//        GradleSystemSettingsControl gradleSettings = GradleSystemSettingsControl;
-        GradleSettings gradleSettings = GradleSettings.getInstance(project);
-//        gradleSettings.myLinkedProjectsSettings
-        GradleProjectSettings gradleProjectSettings = gradleSettings.getLinkedProjectSettings(project.getBasePath());
-
-        return "gradle";
-    }
-
-    private String getMavenConfigPreference(Project project) {
-        MavenServerManager mavenManager = MavenServerManager.getInstance();
-        MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
-        String mavenHome = mavenSettings.getMavenHome();
-
-        if (mavenManager.WRAPPED_MAVEN.equals(mavenHome)) {
-            // it is set to use the wrapper
-            String mvnwPath = getLocalMavenWrapper(project);
-            if (mvnwPath != null) {
-                return mvnwPath;
-            }
-        } else {
-            // try to use maven home path defined in the settings
-            File mavenHomeFile = getCustomMavenPath(mavenHome);
-            if (mavenHomeFile != null) {
-                return mavenHomeFile.getAbsolutePath();
-            }
-        }
-        // default maven
-        return "mvn";
-    }
-
-    private String getLocalMavenWrapper(Project project) {
-        String mvnw = SystemInfo.isWindows ? "mvnw.cmd" : "./mvnw";
-        File file = new File(project.getBasePath() + File.separator + mvnw);
-        return file.exists() ? mvnw : null;
-    }
-
-    private File getCustomMavenPath(String customMavenHome) {
-        File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
-        if (mavenHomeFile != null) {
-            File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
-            return file.exists() ? file : null;
-        }
-        return null;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -24,9 +24,9 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String startCmd = null;
 
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = LibertyMavenUtil.getMavenConfigPreference(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
+            startCmd = LibertyMavenUtil.getMavenSettingsCmd(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = LibertyGradleUtil.getGradleConfigPreference(project) + " libertyDev";
+            startCmd = LibertyGradleUtil.getGradleSettingsCmd(project) + " libertyDev";
         }
         if (widget == null) {
             LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -9,7 +9,12 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import io.openliberty.tools.intellij.util.*;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyActionUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
+import io.openliberty.tools.intellij.util.LibertyGradleUtil;
+import io.openliberty.tools.intellij.util.LibertyMavenUtil;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStartAction extends LibertyGeneralAction {

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -183,7 +183,7 @@ public class LibertyGradleUtil {
 
     private static String getLocalGradleWrapperPath(Project project) {
         String gradlew = SystemInfo.isWindows ? ".\\gradlew.bat" : "./gradlew";
-        File file = new File(project.getBasePath() + File.separator + gradlew);
+        File file = new File(project.getBasePath(), gradlew);
         return file.exists() ? gradlew : null;
     }
 
@@ -193,7 +193,7 @@ public class LibertyGradleUtil {
         if (gradleHomeFile != null) {
             // When a custom gradle is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/gradle in order to execute gradle.
-            File file = new File(gradleHomeFile.getAbsolutePath() + File.separator + "bin"+ File.separator + "gradle");
+            File file = new File(gradleHomeFile.getAbsolutePath(), "bin"+ File.separator + "gradle");
             return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
         }
         return null;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -182,18 +182,19 @@ public class LibertyGradleUtil {
     }
 
     private static String getLocalGradleWrapperPath(Project project) {
-        String gradlew = SystemInfo.isWindows ? "gradlew.bat" : "./gradlew";
+        String gradlew = SystemInfo.isWindows ? ".\\gradlew.bat" : "./gradlew";
         File file = new File(project.getBasePath() + File.separator + gradlew);
         return file.exists() ? gradlew : null;
     }
 
     private static String getCustomGradlePath (String customGradleHome) {
+        String additionalCMD = SystemInfo.isWindows ? "cmd /K " : ""; // without it, a new terminal window is opened
         File gradleHomeFile = new File(customGradleHome);
         if (gradleHomeFile != null) {
             // When a custom gradle is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/gradle in order to execute gradle.
             File file = new File(gradleHomeFile.getAbsolutePath() + File.separator + "bin"+ File.separator + "gradle");
-            return file.exists() ? file.getAbsolutePath() : null;
+            return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
         }
         return null;
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -158,13 +158,12 @@ public class LibertyGradleUtil {
         return false;
     }
 
-    public static String getGradleConfigPreference(Project project) {
+    public static String getGradleSettingsCmd(Project project) {
         GradleProjectSettings gradleProjectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(project.getBasePath());
 
-        // To know all gradle options available for settings, look at org.jetbrains.plugins.gradle.settings.DistributionType
         if (gradleProjectSettings.getDistributionType().isWrapped()) {
             // a wrapper will be used
-            String wrapperPath = getLocalGradleWrapper(project);
+            String wrapperPath = getLocalGradleWrapperPath(project);
             if (wrapperPath != null) {
                 return wrapperPath;
             }
@@ -173,24 +172,26 @@ public class LibertyGradleUtil {
             // local gradle to be used
             String gradleHome = gradleProjectSettings.getGradleHome(); //it is null when the path to gradle is invalid
             if (gradleHome != null) {
-                return gradleHome + File.separator + "bin"+ File.separator + "gradle";
+                String gradlePath = getCustomGradlePath(gradleHome);
+                if (gradlePath != null) {
+                    return gradlePath;
+                }
             }
         }
-
-        return "gradle";
+        return "gradle"; // default gradle
     }
 
-    private static String getLocalGradleWrapper(Project project) {
+    private static String getLocalGradleWrapperPath(Project project) {
         String gradlew = SystemInfo.isWindows ? "gradlew.bat" : "./gradlew";
         File file = new File(project.getBasePath() + File.separator + gradlew);
         return file.exists() ? gradlew : null;
     }
 
-    private static File getCustomGradlePath (String customGradleHome) {
+    private static String getCustomGradlePath (String customGradleHome) {
         File gradleHomeFile = new File(customGradleHome);
         if (gradleHomeFile != null) {
-            File file = new File(gradleHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "gradle");
-            return file.exists() ? file : null;
+            File file = new File(gradleHomeFile.getAbsolutePath() + File.separator + "bin"+ File.separator + "gradle");
+            return file.exists() ? file.getAbsolutePath() : null;
         }
         return null;
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -190,6 +190,8 @@ public class LibertyGradleUtil {
     private static String getCustomGradlePath (String customGradleHome) {
         File gradleHomeFile = new File(customGradleHome);
         if (gradleHomeFile != null) {
+            // When a custom gradle is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
+            // and consequently, it will return null. For this reason, we need to use ./bin/gradle in order to execute gradle.
             File file = new File(gradleHomeFile.getAbsolutePath() + File.separator + "bin"+ File.separator + "gradle");
             return file.exists() ? file.getAbsolutePath() : null;
         }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -9,8 +9,13 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.util;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import org.jetbrains.idea.maven.project.MavenGeneralSettings;
+import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
+import org.jetbrains.idea.maven.server.MavenServerManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -181,4 +186,40 @@ public class LibertyMavenUtil {
         }
     }
 
+    public static String getMavenConfigPreference(Project project) {
+        MavenServerManager mavenManager = MavenServerManager.getInstance();
+        MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
+        String mavenHome = mavenSettings.getMavenHome();
+
+        if (mavenManager.WRAPPED_MAVEN.equals(mavenHome)) {
+            // it is set to use the wrapper
+            String mvnwPath = getLocalMavenWrapper(project);
+            if (mvnwPath != null) {
+                return mvnwPath;
+            }
+        } else {
+            // try to use maven home path defined in the settings
+            File mavenHomeFile = getCustomMavenPath(mavenHome);
+            if (mavenHomeFile != null) {
+                return mavenHomeFile.getAbsolutePath();
+            }
+        }
+        // default maven
+        return "mvn";
+    }
+
+    private static String getLocalMavenWrapper(Project project) {
+        String mvnw = SystemInfo.isWindows ? "mvnw.cmd" : "./mvnw";
+        File file = new File(project.getBasePath() + File.separator + mvnw);
+        return file.exists() ? mvnw : null;
+    }
+
+    private static File getCustomMavenPath(String customMavenHome) {
+        File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
+        if (mavenHomeFile != null) {
+            File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
+            return file.exists() ? file : null;
+        }
+        return null;
+    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -208,18 +208,19 @@ public class LibertyMavenUtil {
     }
 
     private static String getLocalMavenWrapper(Project project) {
-        String mvnw = SystemInfo.isWindows ? "mvnw.cmd" : "./mvnw";
+        String mvnw = SystemInfo.isWindows ? ".\\mvnw.cmd" : "./mvnw";
         File file = new File(project.getBasePath() + File.separator + mvnw);
         return file.exists() ? mvnw : null;
     }
 
     private static String getCustomMavenPath(String customMavenHome) {
+        String additionalCMD = SystemInfo.isWindows ? "cmd /K " : ""; // without it, a new terminal window is opened
         File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
         if (mavenHomeFile != null) {
             // When a custom maven is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/mvn in order to execute maven.
             File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
-            return file.exists() ? file.getAbsolutePath() : null;
+            return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
         }
         return null;
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -216,6 +216,8 @@ public class LibertyMavenUtil {
     private static String getCustomMavenPath(String customMavenHome) {
         File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
         if (mavenHomeFile != null) {
+            // When a custom maven is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
+            // and consequently, it will return null. For this reason, we need to use ./bin/mvn in order to execute maven.
             File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
             return file.exists() ? file.getAbsolutePath() : null;
         }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -186,7 +186,7 @@ public class LibertyMavenUtil {
         }
     }
 
-    public static String getMavenConfigPreference(Project project) {
+    public static String getMavenSettingsCmd(Project project) {
         MavenServerManager mavenManager = MavenServerManager.getInstance();
         MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
         String mavenHome = mavenSettings.getMavenHome();
@@ -199,13 +199,12 @@ public class LibertyMavenUtil {
             }
         } else {
             // try to use maven home path defined in the settings
-            File mavenHomeFile = getCustomMavenPath(mavenHome);
-            if (mavenHomeFile != null) {
-                return mavenHomeFile.getAbsolutePath();
+            String mavenPath = getCustomMavenPath(mavenHome);
+            if (mavenPath != null) {
+                return mavenPath;
             }
         }
-        // default maven
-        return "mvn";
+        return "mvn"; // default maven
     }
 
     private static String getLocalMavenWrapper(Project project) {
@@ -214,11 +213,11 @@ public class LibertyMavenUtil {
         return file.exists() ? mvnw : null;
     }
 
-    private static File getCustomMavenPath(String customMavenHome) {
+    private static String getCustomMavenPath(String customMavenHome) {
         File mavenHomeFile = MavenServerManager.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
         if (mavenHomeFile != null) {
             File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
-            return file.exists() ? file : null;
+            return file.exists() ? file.getAbsolutePath() : null;
         }
         return null;
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -209,7 +209,7 @@ public class LibertyMavenUtil {
 
     private static String getLocalMavenWrapper(Project project) {
         String mvnw = SystemInfo.isWindows ? ".\\mvnw.cmd" : "./mvnw";
-        File file = new File(project.getBasePath() + File.separator + mvnw);
+        File file = new File(project.getBasePath(), mvnw);
         return file.exists() ? mvnw : null;
     }
 
@@ -219,7 +219,7 @@ public class LibertyMavenUtil {
         if (mavenHomeFile != null) {
             // When a custom maven is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/mvn in order to execute maven.
-            File file = new File(mavenHomeFile.getAbsolutePath() + File.separator + "bin" + File.separator + "mvn");
+            File file = new File(mavenHomeFile.getAbsolutePath(), "bin" + File.separator + "mvn");
             return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
         }
         return null;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,12 +24,18 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.plugins.terminal</depends>
+    <depends>org.jetbrains.idea.maven</depends>
+    <depends>com.intellij.gradle</depends>
 
-    <idea-version since-build="193"/>
+<!--    <idea-version since-build="193"/>-->
+    <idea-version since-build="194"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"
                     factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>
+
+        <applicationService
+                serviceImplementation="io.openliberty.tools.intellij.actions.AppSettingsState"/>
     </extensions>
 
     <!-- Default resource location for localizing Liberty actions strings -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,15 +27,11 @@
     <depends>org.jetbrains.idea.maven</depends>
     <depends>com.intellij.gradle</depends>
 
-<!--    <idea-version since-build="193"/>-->
-    <idea-version since-build="194"/>
+    <idea-version since-build="193"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"
                     factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>
-
-        <applicationService
-                serviceImplementation="io.openliberty.tools.intellij.actions.AppSettingsState"/>
     </extensions>
 
     <!-- Default resource location for localizing Liberty actions strings -->


### PR DESCRIPTION
This task adds the features for Gradle and Maven settings for Intellij #39 . 

## Maven

![image](https://user-images.githubusercontent.com/7606936/202223590-452731fb-bc2c-4728-8c78-06a3281efeec.png)

allows end-users specify:
- Bundled (use default mvn)
- Maven wrapper (use mvnw)
- "..." -> Custom maven

## Gradle

![image](https://user-images.githubusercontent.com/7606936/202224154-b395fb23-afb1-44c2-8fe8-e07d659722f0.png)

allows end-users specify:
- "wrappers" -> gradle-wrapper / wrapper
- "Specific location" -> Custom/Default Gradle

## Tests

- All tests so far were done on Mac. It's necessary to cover Windows and Linux environments!