### PR TITLE
Check for null due to bad package name.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -68,10 +68,12 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
 
             PsiPackage psiPackage = JavaPsiFacade.getInstance(unit.getProject())
                     .findPackage(unit.getPackageName());
-            PsiAnnotation[] pkgAnnotations = psiPackage.getAnnotations();
-            for (PsiAnnotation annotation : pkgAnnotations) {
-                if (isValidAnnotation(annotation.getQualifiedName(), validAnnotations))
-                    annotatables.add(new Tuple.Two<>(annotation, psiPackage));
+            if (psiPackage != null) {
+                PsiAnnotation[] pkgAnnotations = psiPackage.getAnnotations();
+                for (PsiAnnotation annotation : pkgAnnotations) {
+                    if (isValidAnnotation(annotation.getQualifiedName(), validAnnotations))
+                        annotatables.add(new Tuple.Two<>(annotation, psiPackage));
+                }
             }
 
             PsiClass[] types = unit.getClasses();


### PR DESCRIPTION
When package name is invalid findPackage() returns null. Skip and continue finding diagnostics.
Fixes #144 and maybe #132