### PR TITLE
In isValidAnnotation() check for null in input.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -228,9 +228,11 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
     }
 
     private static boolean isValidAnnotation(String annotationName, String[] validAnnotations) {
-        for (String fqName : validAnnotations) {
-            if (fqName.endsWith(annotationName)) {
-                return true;
+        if (annotationName != null) {
+            for (String fqName : validAnnotations) {
+                if (fqName.endsWith(annotationName)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
I wasn't able to reproduce the issue but this is the fix required by the `suffix` exception. This method is called in other situations so it is best to fix it on the called side rather than the calling side.
Fixes #148
