### PR TITLE
Including double quotes to escape spaces in paths

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -194,7 +194,7 @@ public class LibertyGradleUtil {
             // When a custom gradle is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/gradle in order to execute gradle.
             File file = new File(gradleHomeFile.getAbsolutePath(), "bin"+ File.separator + "gradle");
-            return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
+            return file.exists() ? additionalCMD + "\"" + file.getAbsolutePath() + "\"" : null;
         }
         return null;
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -220,7 +220,7 @@ public class LibertyMavenUtil {
             // When a custom maven is specified, IntelliJ settings force it to point to the root folder and consider the subfolders invalid,
             // and consequently, it will return null. For this reason, we need to use ./bin/mvn in order to execute maven.
             File file = new File(mavenHomeFile.getAbsolutePath(), "bin" + File.separator + "mvn");
-            return file.exists() ? additionalCMD + file.getAbsolutePath() : null;
+            return file.exists() ? additionalCMD + "\"" + file.getAbsolutePath() + "\"" : null;
         }
         return null;
     }


### PR DESCRIPTION
This is a fix for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/154

Including double quotes, we allow spaces in the path for Gradle/Maven executables.

This was tested over Mac and Windows environments.