### PR TITLE
Liberty run and debug configuration

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -94,8 +94,8 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             mavenBuildFiles = LibertyProjectUtil.getMavenBuildFiles(project);
             gradleBuildFiles = LibertyProjectUtil.getGradleBuildFiles(project);
         } catch (IOException | SAXException | ParserConfigurationException e) {
-            LOGGER.error("Could not find Open Liberty Maven or Gradle projects in workspace",
-                    e.getMessage());
+            LOGGER.warn("Could not find Liberty Maven or Gradle projects in workspace",
+                    e);
             return null;
         }
 
@@ -109,13 +109,14 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             String projectName = null;
             VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
-                LOGGER.error("Could not resolve current Maven project");
+                LOGGER.error(String.format("Could not resolve current Maven project %s", psiFile));
+                break;
             }
             LibertyModuleNode node;
             try {
                 projectName = LibertyMavenUtil.getProjectNameFromPom(virtualFile);
             } catch (Exception e) {
-                LOGGER.error("Could not resolve project name from pom.xml", e.getMessage());
+                LOGGER.warn(String.format("Could not resolve project name from build file: %s", virtualFile), e);
             }
             if (projectName == null) {
                 projectName = project.getName();
@@ -150,13 +151,14 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             String projectName = null;
             VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
-                LOGGER.error("Could not resolve current Gradle project");
+                LOGGER.error(String.format("Could not resolve current Gradle project %s", buildFile));
+                break;
             }
             LibertyModuleNode node;
             try {
                 projectName = LibertyGradleUtil.getProjectName(virtualFile);
             } catch (Exception e) {
-                LOGGER.error("Could not resolve project name from settings.gradle", e.getMessage());
+                LOGGER.warn(String.format("Could not resolve project name for project %s", virtualFile), e);
             }
             if (projectName == null) {
                 projectName = project.getName();
@@ -312,7 +314,6 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                 action = (LibertyGeneralAction) am.getAction(Constants.VIEW_GRADLE_TEST_REPORT_ACTION_ID);
             }
             if (action != null) {
-                // TODO set Liberty module for the corresponding action
                 action.setLibertyModule(module);
                 // calls action on double click
                 action.actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -25,8 +25,21 @@ public class LibertyModule {
     private String name;
     private boolean validContainerVersion;
 
-    public LibertyModule(Project project, VirtualFile buildFile, String name, String projectType, boolean validContainerVersion) {
+    private String customStartParams;
+    // FIXME not currently being used, need to enable runInContainer checkbox in LibertyRunConfiguration see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
+    private boolean runInContainer;
+
+    private boolean debugMode;
+
+    public LibertyModule(Project project) {
         this.project = project;
+        this.customStartParams = "";
+        this.runInContainer = false;
+        this.debugMode = false;
+    }
+
+    public LibertyModule(Project project, VirtualFile buildFile, String name, String projectType, boolean validContainerVersion) {
+        this(project);
         this.buildFile = buildFile;
         this.name = name;
         this.projectType = projectType;
@@ -34,7 +47,7 @@ public class LibertyModule {
     }
 
     public LibertyModule(Project project, BuildFile buildFile) {
-        this.project = project;
+        this(project);
         this.buildFile = buildFile.getBuildFile().getVirtualFile();
         this.name = buildFile.getProjectName();
         this.projectType = buildFile.getProjectType();
@@ -79,5 +92,36 @@ public class LibertyModule {
 
     public void setProject(Project project) {
         this.project = project;
+    }
+
+    public String getCustomStartParams() {
+        if (customStartParams == null) {
+            clearCustomStartParams();
+        }
+        return customStartParams;
+    }
+
+    public void setCustomStartParams(String customStartParams) {
+        this.customStartParams = customStartParams;
+    }
+
+    public void clearCustomStartParams() {
+        customStartParams = "";
+    }
+
+    public boolean runInContainer() {
+        return runInContainer;
+    }
+
+    public void setRunInContainer(boolean runInContainer) {
+        this.runInContainer = runInContainer;
+    }
+
+    public boolean isDebugMode() {
+        return debugMode;
+    }
+
+    public void setDebugMode(boolean debugMode) {
+        this.debugMode = debugMode;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 public class LibertyModuleNode extends DefaultMutableTreeNode {
-    private LibertyModule libertyModule;
+    private final LibertyModule libertyModule;
 
     public LibertyModuleNode(LibertyModule libertyModule) {
         super(libertyModule.getName());

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -40,6 +40,7 @@ public class LibertyModules {
 
     /**
      * Add tracked Liberty project to workspace
+     *
      * @param module LibertyModule
      */
     public void addLibertyModule(LibertyModule module) {
@@ -48,6 +49,7 @@ public class LibertyModules {
 
     /**
      * Get a Liberty module associated with the corresponding build file
+     *
      * @param buildFile build file
      * @return LibertyModule
      */
@@ -69,6 +71,7 @@ public class LibertyModules {
 
     /**
      * Returns all build files associated with a Liberty project
+     *
      * @return List<VirtualFile> Liberty project build files
      */
     public List<VirtualFile> getLibertyBuildFiles() {
@@ -79,6 +82,7 @@ public class LibertyModules {
 
     /**
      * Returns all Liberty modules in the workspace
+     *
      * @return List<LibertyModule> Liberty project modules
      */
     public List<LibertyModule> getLibertyModules() {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -9,14 +9,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import io.openliberty.tools.intellij.LibertyPluginIcons;
-import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyActionUtil;
-import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
@@ -29,18 +22,8 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
     @Override
     protected void executeLibertyAction() {
         String runTestsCommand = " ";
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, false);
-
+        ShellTerminalWidget widget = getTerminalWidget(false);
         if (widget == null) {
-            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID
-                    , LibertyPluginIcons.libertyIcon
-                    , LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.title")
-                    , ""
-                    , LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.content", projectName)
-                    , NotificationType.WARNING
-                    , NotificationListener.URL_OPENING_LISTENER);
-            Notifications.Bus.notify(notif, project);
-            LOGGER.error("Cannot run tests, corresponding project terminal does not exist.");
             return;
         }
         LibertyActionUtil.executeCommand(widget, runTestsCommand);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -10,13 +10,18 @@
 package io.openliberty.tools.intellij.actions;
 
 import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.DebugModeHandler;
 import io.openliberty.tools.intellij.util.LibertyActionUtil;
-import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import io.openliberty.tools.intellij.util.LibertyGradleUtil;
 import io.openliberty.tools.intellij.util.LibertyMavenUtil;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
+import java.io.IOException;
+
+/**
+ * Runs the dev mode start command on the corresponding Liberty module.
+ */
 public class LibertyDevStartAction extends LibertyGeneralAction {
 
     public LibertyDevStartAction() {
@@ -25,20 +30,42 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
     
     @Override
     protected void executeLibertyAction() {
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
         String startCmd = null;
-
-        if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = LibertyMavenUtil.getMavenSettingsCmd(project) + " io.openliberty.tools:liberty-maven-plugin:dev";
-        } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = LibertyGradleUtil.getGradleSettingsCmd(project) + " libertyDev";
+        int debugPort = -1;
+        DebugModeHandler debugHandler = new DebugModeHandler();
+        String start = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) + Constants.LIBERTY_MAVEN_START_CMD : LibertyGradleUtil.getGradleSettingsCmd(project) + Constants.LIBERTY_GRADLE_START_CMD;
+        String startInContainer = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : LibertyGradleUtil.getGradleSettingsCmd(project) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
+        startCmd = libertyModule.runInContainer() ? startInContainer : start;
+        startCmd += libertyModule.getCustomStartParams();
+        if (libertyModule.isDebugMode()) {
+            try {
+                String debugParam = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? Constants.LIBERTY_MAVEN_DEBUG_PARAM : Constants.LIBERTY_GRADLE_DEBUG_PARAM;
+                debugPort = debugHandler.getDebugPort(libertyModule);
+                String debugStr = debugParam + debugPort;
+                // do not append if debug port is already specified as part of start command
+                if (!startCmd.contains(debugStr)) {
+                    startCmd += " " + debugParam + debugPort;
+                }
+            } catch (IOException e) {
+                String msg = LocalizedResourceUtil.getMessage("liberty.debug.port.unresolved", actionCmd, projectName);
+                notifyError(msg);
+                LOGGER.error(msg);
+            }
         }
+
+        ShellTerminalWidget widget = getTerminalWidget(true);
         if (widget == null) {
-            LOGGER.debug("Unable to start Liberty dev mode, could not get or create terminal widget for " + projectName);
             return;
         }
+
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
+        if (libertyModule.isDebugMode() && debugPort != -1) {
+            // Create remote configuration to attach debugger
+            debugHandler.createDebugConfiguration(libertyModule, debugPort);
+            libertyModule.setDebugMode(false);
+        }
     }
+
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -64,7 +64,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         LibertyActionUtil.executeCommand(widget, startCmd);
         if (libertyModule.isDebugMode() && debugPort != -1) {
             // Create remote configuration to attach debugger
-            debugHandler.createDebugConfiguration(libertyModule, debugPort);
+            debugHandler.createAndRunDebugConfiguration(libertyModule, debugPort);
             libertyModule.setDebugMode(false);
         }
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -33,8 +33,9 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         String startCmd = null;
         int debugPort = -1;
         DebugModeHandler debugHandler = new DebugModeHandler();
-        String start = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) + Constants.LIBERTY_MAVEN_START_CMD : LibertyGradleUtil.getGradleSettingsCmd(project) + Constants.LIBERTY_GRADLE_START_CMD;
-        String startInContainer = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : LibertyGradleUtil.getGradleSettingsCmd(project) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
+        String buildSettingsCmd = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) : LibertyGradleUtil.getGradleSettingsCmd(project);
+        String start = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CMD;
+        String startInContainer = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
         startCmd = libertyModule.runInContainer() ? startInContainer : start;
         startCmd += libertyModule.getCustomStartParams();
         if (libertyModule.isDebugMode()) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -9,10 +9,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import io.openliberty.tools.intellij.util.Constants;
-import io.openliberty.tools.intellij.util.LibertyActionUtil;
-import io.openliberty.tools.intellij.util.LibertyProjectUtil;
-import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
+import io.openliberty.tools.intellij.util.*;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStartContainerAction extends LibertyGeneralAction {
@@ -23,16 +20,9 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
 
     @Override
     protected void executeLibertyAction() {
-        String startCmd = null;
-        if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:devc";
-        } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDevc";
-        }
-
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
+        String startCmd = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? LibertyMavenUtil.getMavenSettingsCmd(project) + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : LibertyGradleUtil.getGradleSettingsCmd(project) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
+        ShellTerminalWidget widget = getTerminalWidget(true);
         if (widget == null) {
-            LOGGER.debug("Unable to start Liberty dev mode in a container, could not get or create terminal widget for " + projectName);
             return;
         }
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -9,14 +9,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import io.openliberty.tools.intellij.LibertyPluginIcons;
-import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyActionUtil;
-import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
@@ -28,18 +21,9 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
 
     @Override
     protected void executeLibertyAction() {
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, false);
+        ShellTerminalWidget widget = getTerminalWidget(false);
         String stopCmd = "q";
         if (widget == null) {
-            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID
-                    , LibertyPluginIcons.libertyIcon
-                    , LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.title")
-                    , ""
-                    , LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.content", projectName)
-                    , NotificationType.WARNING
-                    , NotificationListener.URL_OPENING_LISTENER);
-            Notifications.Bus.notify(notif, project);
-            LOGGER.error("Cannot stop Liberty dev mode, corresponding project terminal does not exist.");
             return;
         }
         LibertyActionUtil.executeCommand(widget, stopCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -26,6 +26,7 @@ import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +43,7 @@ public class LibertyGeneralAction extends AnAction {
 
     /**
      * Set the LibertyModule that the action should run on
+     *
      * @param libertyModule
      */
     public void setLibertyModule(LibertyModule libertyModule) {
@@ -61,7 +63,7 @@ public class LibertyGeneralAction extends AnAction {
                 // TODO prompt user to select project
                 String msg = LocalizedResourceUtil.getMessage("liberty.project.does.not.resolve", actionCmd);
                 notifyError(msg);
-                LOGGER.debug(msg);
+                LOGGER.warn(msg);
                 return;
             }
         }
@@ -69,8 +71,7 @@ public class LibertyGeneralAction extends AnAction {
             buildFile = (VirtualFile) e.getDataContext().getData(Constants.LIBERTY_BUILD_FILE);
             // if still null, prompt for user to select
             if (buildFile == null) {
-                List<LibertyModule> libertyModules = LibertyModules.getInstance()
-                        .getLibertyModules(getSupportedProjectTypes());
+                List<LibertyModule> libertyModules = LibertyModules.getInstance().getLibertyModules(getSupportedProjectTypes());
                 if (!libertyModules.isEmpty()) {
                     // Only one project. Select it.
                     if (libertyModules.size() == 1) {
@@ -79,12 +80,7 @@ public class LibertyGeneralAction extends AnAction {
                     // Multiple projects. Pop up dialog for user to select.
                     else {
                         final String[] projectNames = toProjectNames(libertyModules);
-                        final int ret = Messages.showChooseDialog(project,
-                                LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
-                                LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"),
-                                LibertyPluginIcons.libertyIcon_40,
-                                projectNames,
-                                projectNames[0]);
+                        final int ret = Messages.showChooseDialog(project, LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd), LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"), LibertyPluginIcons.libertyIcon_40, projectNames, projectNames[0]);
                         if (ret >= 0 && ret < libertyModules.size()) {
                             setLibertyModule(libertyModules.get(ret));
                         }
@@ -98,7 +94,7 @@ public class LibertyGeneralAction extends AnAction {
                 if (buildFile == null) {
                     String msg = LocalizedResourceUtil.getMessage("liberty.build.file.does.not.resolve", actionCmd, project.getName());
                     notifyError(msg);
-                    LOGGER.debug(msg);
+                    LOGGER.warn(msg);
                     return;
                 }
             }
@@ -109,13 +105,18 @@ public class LibertyGeneralAction extends AnAction {
         if (projectType == null) {
             projectType = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_TYPE);
         }
+        if (projectType == null || (!projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) && !projectType.equals(Constants.LIBERTY_GRADLE_PROJECT))) {
+            String msg = LocalizedResourceUtil.getMessage("liberty.project.type.invalid", actionCmd, projectName);
+            notifyError(msg);
+            LOGGER.warn(msg);
+            return;
+        }
         executeLibertyAction();
     }
 
     /* Returns project type(s) applicable to this action. */
     protected List<String> getSupportedProjectTypes() {
-        return Arrays.asList(
-                Constants.LIBERTY_MAVEN_PROJECT, Constants.LIBERTY_GRADLE_PROJECT);
+        return Arrays.asList(Constants.LIBERTY_MAVEN_PROJECT, Constants.LIBERTY_GRADLE_PROJECT);
 
     }
 
@@ -136,14 +137,35 @@ public class LibertyGeneralAction extends AnAction {
         // must be implemented by individual actions
     }
 
+    /**
+     * Displays error message dialog to user
+     *
+     * @param errMsg
+     */
     protected void notifyError(String errMsg) {
-        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
-                LibertyPluginIcons.libertyIcon,
-                LocalizedResourceUtil.getMessage("liberty.action.cannot.start"),
-                "",
-                errMsg,
-                NotificationType.WARNING,
-                NotificationListener.URL_OPENING_LISTENER);
+        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID, LibertyPluginIcons.libertyIcon, LocalizedResourceUtil.getMessage("liberty.action.cannot.start"), "", errMsg, NotificationType.WARNING, NotificationListener.URL_OPENING_LISTENER);
         Notifications.Bus.notify(notif, project);
+    }
+
+    /**
+     * Returns the IntelliJ terminal widget for the corresponding Liberty module
+     *
+     * @param createWidget create terminal widget if it does not already exist
+     * @return ShellTerminalWidget
+     */
+    protected ShellTerminalWidget getTerminalWidget(boolean createWidget) {
+        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, createWidget);
+        if (widget == null) {
+            String msg;
+            if (createWidget) {
+                msg = LocalizedResourceUtil.getMessage("liberty.terminal.cannot.resolve", actionCmd, projectName);
+            } else {
+                msg = LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.content", actionCmd, projectName);
+            }
+            notifyError(msg);
+            LOGGER.warn(msg);
+            return null;
+        }
+        return widget;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -80,7 +80,12 @@ public class LibertyGeneralAction extends AnAction {
                     // Multiple projects. Pop up dialog for user to select.
                     else {
                         final String[] projectNames = toProjectNames(libertyModules);
-                        final int ret = Messages.showChooseDialog(project, LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd), LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"), LibertyPluginIcons.libertyIcon_40, projectNames, projectNames[0]);
+                        final int ret = Messages.showChooseDialog(project,
+                                LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
+                                LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"),
+                                LibertyPluginIcons.libertyIcon_40,
+                                projectNames,
+                                projectNames[0]);
                         if (ret >= 0 && ret < libertyModules.size()) {
                             setLibertyModule(libertyModules.get(ret));
                         }
@@ -143,7 +148,13 @@ public class LibertyGeneralAction extends AnAction {
      * @param errMsg
      */
     protected void notifyError(String errMsg) {
-        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID, LibertyPluginIcons.libertyIcon, LocalizedResourceUtil.getMessage("liberty.action.cannot.start"), "", errMsg, NotificationType.WARNING, NotificationListener.URL_OPENING_LISTENER);
+        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                LibertyPluginIcons.libertyIcon,
+                LocalizedResourceUtil.getMessage("liberty.action.cannot.start"),
+                "",
+                errMsg,
+                NotificationType.WARNING,
+                NotificationListener.URL_OPENING_LISTENER);
         Notifications.Bus.notify(notif, project);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -134,7 +134,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         // FIXME implement runInContainer checkbox from run config see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
         // libertyModule.setRunInContainer(runInContainer());
 
-        if (executor.getId() == DefaultDebugExecutor.EXECUTOR_ID) {
+        if (executor.getId().equals(DefaultDebugExecutor.EXECUTOR_ID)) {
             libertyModule.setDebugMode(true);
         }
         action.actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(null), ActionPlaces.UNKNOWN, new Presentation(), ActionManager.getInstance(), 0));

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -111,6 +111,14 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         return new LibertyRunSettingsEditor(getProject());
     }
 
+    /**
+     * Runs when users select "Run" or "Debug" on a Liberty  run configuration
+     *
+     * @param executor the execution mode selected by the user (run, debug, profile etc.)
+     * @param environment the environment object containing additional settings for executing the configuration.
+     * @return
+     * @throws ExecutionException
+     */
     @Nullable
     @Override
     public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
@@ -138,6 +146,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
             libertyModule.setDebugMode(true);
         }
         action.actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(null), ActionPlaces.UNKNOWN, new Presentation(), ActionManager.getInstance(), 0));
+        // return null because we are not plugging into "Run" tool window in IntelliJ, just terminal and Debug
         return null;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.*;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import io.openliberty.tools.intellij.LibertyModule;
+import io.openliberty.tools.intellij.LibertyModules;
+import io.openliberty.tools.intellij.actions.LibertyDevStartAction;
+import io.openliberty.tools.intellij.util.Constants;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.MalformedURLException;
+import java.util.Collection;
+
+/**
+ * Defines a Liberty run & debug configuration. Each configuration is tied to a Liberty module
+ */
+public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigurationModule, LibertyRunConfigurationOptions> {
+    protected static Logger LOGGER = Logger.getInstance(LibertyRunConfiguration.class);
+
+    private final LibertyModules libertyModules;
+    private LibertyModule libertyModule;
+
+    public LibertyRunConfiguration(Project project, ConfigurationFactory factory, String name) {
+        super(name, getRunConfigurationModule(project), factory);
+        this.libertyModules = LibertyModules.getInstance();
+    }
+
+    @NotNull
+    private static RunConfigurationModule getRunConfigurationModule(Project project) {
+        RunConfigurationModule module = new RunConfigurationModule(project);
+        // TODO set module to first valid Liberty module?
+        module.setModuleToAnyFirstIfNotSpecified();
+        return module;
+    }
+
+    public Module getModule() {
+        return getConfigurationModule().getModule();
+    }
+
+    public void setModule(Module module) {
+        getConfigurationModule().setModule(module);
+    }
+
+    public String getParams() {
+        return getOptions().getParams();
+    }
+
+    public void setParams(String params) {
+        getOptions().setParams(params);
+    }
+
+    public String getBuildFile() {
+        return getOptions().getBuildFile();
+    }
+
+    public void setBuildFile(String buildFile) {
+        getOptions().setBuildFile(buildFile);
+    }
+
+    // FIXME runInContainer, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
+    public Boolean runInContainer() {
+        return getOptions().runInContainer();
+    }
+
+    public void setRunInContainer(Boolean runInContainer) {
+        getOptions().setRunInContainer(runInContainer);
+    }
+
+    @Override
+    public Collection<Module> getValidModules() {
+        // TODO return only valid Liberty modules?
+        return getAllModules();
+    }
+
+    @NotNull
+    @Override
+    protected LibertyRunConfigurationOptions getOptions() {
+        return (LibertyRunConfigurationOptions) super.getOptions();
+    }
+
+    @Override
+    public void checkConfiguration() throws RuntimeConfigurationException {
+        if (getModule() == null) {
+            throw new RuntimeConfigurationException("No module selected", "Liberty configuration");
+        }
+        // TODO do we need additional checking here?
+    }
+
+    @NotNull
+    @Override
+    public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+        return new LibertyRunSettingsEditor(getProject());
+    }
+
+    @Nullable
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+        try {
+            libertyModule = libertyModules.getLibertyProjectFromString(getBuildFile());
+        } catch (MalformedURLException e) {
+            LOGGER.error(String.format("Could not resolve the Liberty module associated with build file: %s", getBuildFile()));
+            throw new ExecutionException(e);
+        }
+
+        // run the start dev mode action
+        AnAction action = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_START_ACTION_ID);
+        LibertyDevStartAction libAction = (LibertyDevStartAction) action;
+        libAction.setLibertyModule(libertyModule);
+        // set custom start params
+        if (getParams() != null) {
+            libertyModule.setCustomStartParams(getParams());
+        } else {
+            libertyModule.setCustomStartParams("");
+        }
+        // FIXME implement runInContainer checkbox from run config see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
+        // libertyModule.setRunInContainer(runInContainer());
+
+        if (executor.getId() == DefaultDebugExecutor.EXECUTOR_ID) {
+            libertyModule.setDebugMode(true);
+        }
+        action.actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(null), ActionPlaces.UNKNOWN, new Presentation(), ActionManager.getInstance(), 0));
+        return null;
+    }
+
+}

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationFactory.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationFactory.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.components.BaseState;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class LibertyRunConfigurationFactory extends ConfigurationFactory {
+    public LibertyRunConfigurationFactory(ConfigurationType type) {
+        super(type);
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return getType().getId();
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+        return new LibertyRunConfiguration(project, this, "Liberty");
+    }
+
+    @Nullable
+    @Override
+    public Class<? extends BaseState> getOptionsClass() {
+        return LibertyRunConfigurationOptions.class;
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationOptions.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationOptions.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.execution.configurations.ModuleBasedConfigurationOptions;
+import com.intellij.openapi.components.StoredProperty;
+import com.intellij.openapi.diagnostic.Logger;
+
+/**
+ * Defines options that can be configured for each Liberty run & debug configuration
+ */
+public class LibertyRunConfigurationOptions extends ModuleBasedConfigurationOptions {
+    protected static Logger LOGGER = Logger.getInstance(LibertyRunConfigurationOptions.class);
+    private final StoredProperty<String> paramsProperty = string("").provideDelegate(this, "params");
+
+    private final StoredProperty<String> buildFileProperty = string("").provideDelegate(this, "buildFile");
+
+    private final StoredProperty<Boolean> runInContainerProperty = property(false).provideDelegate(this, "runInContainer");
+
+    public String getParams() {
+        return paramsProperty.getValue(this);
+    }
+
+    public void setParams(String params) {
+        paramsProperty.setValue(this, params);
+    }
+
+    public String getBuildFile() {
+        return buildFileProperty.getValue(this);
+    }
+
+    public void setBuildFile(String buildFile) {
+        buildFileProperty.setValue(this, buildFile);
+    }
+
+    public Boolean runInContainer() {
+        return runInContainerProperty.getValue(this);
+    }
+
+    public void setRunInContainer(Boolean runInContainer) {
+        runInContainerProperty.setValue(this, runInContainer);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationType.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfigurationType.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.ConfigurationTypeUtil;
+import io.openliberty.tools.intellij.LibertyPluginIcons;
+import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class LibertyRunConfigurationType implements ConfigurationType {
+    public static final String ID = "Liberty";
+
+    public static LibertyRunConfigurationType getInstance() {
+        return ConfigurationTypeUtil.findConfigurationType(LibertyRunConfigurationType.class);
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Liberty";
+    }
+
+    @Nls
+    @Override
+    public String getConfigurationTypeDescription() {
+        return LocalizedResourceUtil.getMessage("liberty.run.config.title");
+    }
+
+    @Override
+    public Icon getIcon() {
+        return LibertyPluginIcons.libertyIcon;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public ConfigurationFactory[] getConfigurationFactories() {
+        return new ConfigurationFactory[]{new LibertyRunConfigurationFactory(this)};
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.execution.RunManagerListener;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.LibertyModule;
+import io.openliberty.tools.intellij.LibertyModules;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Listens to creation/deletion of Liberty run configurations
+ */
+public class LibertyRunManagerListener implements RunManagerListener {
+
+    protected static Logger LOGGER = Logger.getInstance(LibertyRunManagerListener.class);
+
+    /**
+     * When a Liberty run configuration is removed, clear custom start parameters from Liberty module
+     *
+     * @param settings
+     */
+    @Override
+    public void runConfigurationRemoved(@NotNull RunnerAndConfigurationSettings settings) {
+        if (settings.getConfiguration() instanceof LibertyRunConfiguration) {
+            LibertyRunConfiguration runConfig = (LibertyRunConfiguration) settings.getConfiguration();
+            LibertyModules libertyModules = LibertyModules.getInstance();
+            try {
+                VirtualFile vBuildFile = VfsUtil.findFileByURL(new URL(runConfig.getBuildFile()));
+                LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
+                if (libertyModule != null && libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
+                    libertyModule.clearCustomStartParams();
+                }
+            } catch (MalformedURLException e) {
+                LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty project associated with Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
+            }
+
+        }
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -45,7 +45,7 @@ public class LibertyRunManagerListener implements RunManagerListener {
                     libertyModule.clearCustomStartParams();
                 }
             } catch (MalformedURLException e) {
-                LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty project associated with Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
+                LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
             }
 
         }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.openliberty.tools.intellij.runConfiguration.LibertyRunSettingsEditor">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="ae643" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/LibertyBundles" key="specify.custom.parameters.for.the.mvn.liberty.dev.command"/>
+        </properties>
+      </component>
+      <component id="d3c7e" class="com.intellij.openapi.ui.LabeledComponent" binding="editableParams" custom-create="true">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <componentClass value="com.intellij.ui.EditorTextField"/>
+          <labelLocation value="West"/>
+          <text resource-bundle="messages/LibertyBundles" key="run.config.start.parameters"/>
+          <toolTipText resource-bundle="messages/LibertyBundles" key="run.config.start.parameters.tool.tip"/>
+        </properties>
+      </component>
+      <component id="c4371" class="com.intellij.openapi.ui.LabeledComponent" binding="libertyModule" custom-create="true">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <componentClass value="com.intellij.openapi.ui.ComboBox"/>
+          <labelLocation value="West"/>
+          <text resource-bundle="messages/LibertyBundles" key="run.config.liberty.project"/>
+          <toolTipText resource-bundle="messages/LibertyBundles" key="run.config.liberty.project.tool.tip"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.runConfiguration;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.LabeledComponent;
+import com.intellij.ui.EditorTextField;
+import io.openliberty.tools.intellij.LibertyModules;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * Editor associated with Liberty run & debug configurations. Defines when configuration changes are updated, default values, etc.
+ */
+public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfiguration> {
+
+    private JPanel root;
+    private LabeledComponent<EditorTextField> editableParams;
+    private LabeledComponent<ComboBox> libertyModule;
+
+    // FIXME runInContainer
+    // private LabeledComponent<StateRestoringCheckBox> runInContainer;
+
+    public LibertyRunSettingsEditor(Project project) {
+        libertyModule.getComponent().setModel(new DefaultComboBoxModel(LibertyModules.getInstance().getLibertyBuildFiles().toArray()));
+    }
+
+    @Override
+    protected void resetEditorFrom(@NotNull LibertyRunConfiguration configuration) {
+
+        String buildFile = configuration.getBuildFile();
+        for (int i = 0; i < libertyModule.getComponent().getItemCount(); i++) {
+            String libertyModuleBuildFile = libertyModule.getComponent().getItemAt(i).toString();
+            if (buildFile.equals(libertyModuleBuildFile)) {
+                // need to use setSelectedIndex instead of setSelectedItem, setSelectedItem(buildFile) results in no behaviour change
+                libertyModule.getComponent().setSelectedIndex(i);
+                break;
+            }
+        }
+        // FIXME runInContainer state is not being saved, cannot "Apply" run in container checkbox change to run config, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
+        // runInContainer.getComponent().setSelected(configuration.runInContainer());
+        editableParams.getComponent().setText(configuration.getParams());
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull LibertyRunConfiguration configuration) throws ConfigurationException {
+        configuration.setParams(editableParams.getComponent().getText());
+        configuration.setBuildFile(String.valueOf(libertyModule.getComponent().getSelectedItem()));
+        // FIXME runInContainer
+        // configuration.setRunInContainer(runInContainer.getComponent().isSelected());
+    }
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        return root;
+    }
+
+    public void createUIComponents() {
+        ComboBox comboBox = new ComboBox();
+        libertyModule = new LabeledComponent<>();
+        libertyModule.setComponent(comboBox);
+        editableParams = new LabeledComponent<>();
+        editableParams.setComponent(new EditorTextField());
+        // FIXME runInContainer
+        // runInContainer = new LabeledComponent<>();
+        // runInContainer.setComponent(new StateRestoringCheckBox());
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -16,6 +16,10 @@ public final class Constants {
     public static final String LIBERTY_GRADLE_PROJECT = "Liberty Gradle Project";
     public static final String LIBERTY_MAVEN_PROJECT = "Liberty Maven Project";
 
+    public static final String LIBERTY_MAVEN_START_CMD = " io.openliberty.tools:liberty-maven-plugin:dev ";
+    public static final String LIBERTY_MAVEN_START_CONTAINER_CMD = " io.openliberty.tools:liberty-maven-plugin:devc ";
+    public static final String LIBERTY_GRADLE_START_CMD = " libertyDev ";
+    public static final String LIBERTY_GRADLE_START_CONTAINER_CMD = " libertyDevc ";
     public static final String LIBERTY_DEV_START = LocalizedResourceUtil.getMessage("start.dev");
     public static final String LIBERTY_DEV_CUSTOM_START = LocalizedResourceUtil.getMessage("start.dev.custom.params");
     public static final String LIBERTY_DEV_START_CONTAINER = LocalizedResourceUtil.getMessage("start.dev.container");
@@ -26,11 +30,14 @@ public final class Constants {
     public static final String VIEW_INTEGRATION_TEST_REPORT = LocalizedResourceUtil.getMessage("action.io.openliberty.tools.intellij.actions.ViewIntegrationTestReport.text");
     public static final String VIEW_UNIT_TEST_REPORT = LocalizedResourceUtil.getMessage("action.io.openliberty.tools.intellij.actions.ViewUnitTestReport.text");
     public static final String LIBERTY_MAVEN_PLUGIN_CONTAINER_VERSION = "3.3-M1";
+    public static final String LIBERTY_MAVEN_DEBUG_PARAM = "-DdebugPort=";
 
     // Gradle
     public static final String VIEW_GRADLE_TEST_REPORT = LocalizedResourceUtil.getMessage("action.io.openliberty.tools.intellij.actions.ViewTestReport.text");
     public static final String TEST_REPORT_STRING = LocalizedResourceUtil.getMessage("test.summary");
     public static final String LIBERTY_GRADLE_PLUGIN_CONTAINER_VERSION = "3.1-M1";
+    public static final String LIBERTY_GRADLE_DEBUG_PARAM = "--libertyDebugPort=";
+
 
     public static final String LIBERTY_TREE = "LibertyTree";
 
@@ -75,20 +82,5 @@ public final class Constants {
         fullActionsMap.put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
         fullActionsMap.put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
         return fullActionsMap;
-    }
-
-    public static HashMap<String, String> getMavenMap() {
-        HashMap<String, String> mavenActionsMap = new HashMap<>();
-        mavenActionsMap.putAll(CORE_ACTIONS_MAP);
-        mavenActionsMap.put(VIEW_UNIT_TEST_REPORT, VIEW_UNIT_TEST_REPORT_ACTION_ID);
-        mavenActionsMap.put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
-        return mavenActionsMap;
-    }
-
-    public static HashMap<String, String> getGradleMap() {
-        HashMap<String, String> gradleActionsMap = new HashMap<>();
-        gradleActionsMap.putAll(CORE_ACTIONS_MAP);
-        gradleActionsMap.put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
-        return gradleActionsMap;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -129,12 +129,12 @@ public class DebugModeHandler {
             RemoteConfiguration remoteConfiguration = (RemoteConfiguration) settings.getConfiguration();
             remoteConfiguration.PORT = debugPortStr;
             long groupId = ExecutionEnvironment.getNextUnusedExecutionId();
-            LOGGER.debug(String.format("%s: attempting to attach debugger to port %s"), libertyModule.getName(), debugPortStr);
+            LOGGER.debug(String.format("%s: attempting to attach debugger to port %s", libertyModule.getName(), debugPortStr));
             ExecutionUtil.runConfiguration(settings, DefaultDebugExecutor.getDebugExecutorInstance(), DefaultExecutionTarget.INSTANCE, groupId);
         } catch (Exception e) {
             // do not show error if debug attachment was cancelled by user
             if (!(e instanceof ProcessCanceledException)) {
-                LOGGER.error(String.format("Cannot connect debugger to port %s", debugPort), e);
+                LOGGER.error(String.format("Cannot connect debugger to port %d", debugPort), e);
                 ApplicationManager.getApplication().invokeLater(() -> Messages.showErrorDialog(LocalizedResourceUtil.getMessage("cannot.connect.debug.port", debugPort), "Liberty"));
             }
         }

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.util;
+
+import com.intellij.execution.DefaultExecutionTarget;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.remote.RemoteConfiguration;
+import com.intellij.execution.remote.RemoteConfigurationType;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.ExecutionUtil;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.ui.Messages;
+import io.openliberty.tools.intellij.LibertyModule;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Used for creating a debug configuration, connecting IntelliJ debugger to Liberty server JVM
+ */
+public class DebugModeHandler {
+
+    protected static Logger LOGGER = Logger.getInstance(DebugModeHandler.class);
+
+    // Default host name
+    private static String DEFAULT_ATTACH_HOST = "localhost";
+
+    // Regex captures the debug port value from the custom Maven parameters input
+    private static final Pattern MAVEN_DEBUG_REGEX = Pattern.compile("(?<=" + Constants.LIBERTY_MAVEN_DEBUG_PARAM + ")([^\\s]+)");
+
+    // Regex captures the debug port value from the custom Gradle parameters input
+    private static final Pattern GRADLE_DEBUG_REGEX = Pattern.compile("(?<=" + Constants.LIBERTY_GRADLE_DEBUG_PARAM + ")([^\\s]+)");
+
+    // Debug address key in Liberty server.env files
+    private static String WLP_ENV_DEBUG_ADDRESS = "WLP_DEBUG_ADDRESS";
+
+    /**
+     * Gets a debug port for the Liberty module. First checks if the debug port was specified as part of the start parameters,
+     * otherwise allocates a random port.
+     *
+     * @param libertyModule Liberty module
+     * @return JVM port to connect to
+     * @throws IOException
+     */
+    public int getDebugPort(LibertyModule libertyModule) throws IOException {
+        // 1. Check if debug port was specified as part of start parameters, if so try that port first
+        String configParams = libertyModule.getCustomStartParams();
+        Matcher m;
+        if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            m = MAVEN_DEBUG_REGEX.matcher(configParams);
+        } else {
+            m = GRADLE_DEBUG_REGEX.matcher(configParams);
+        }
+        if (m.find()) {
+            // get first match only, if for some reason more than one debug port is specified in the params, try with the first port
+            String userDebugPortStr = m.group(1);
+            if (userDebugPortStr != null) {
+                try {
+                    return Integer.parseInt(userDebugPortStr);
+                } catch (NumberFormatException e) {
+                    LOGGER.warn(String.format("Unable to parse debug port from user configured params: %s",userDebugPortStr));
+                }
+            }
+        }
+
+        // 2. Get a random port that is not in use
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    /**
+     * Creates a new debug configuration for the corresponding Liberty module
+     *
+     * @param libertyModule Liberty module
+     * @param debugPort JVM port to connect to
+     */
+    public void createDebugConfiguration(LibertyModule libertyModule, int debugPort) {
+        ProgressManager.getInstance().run(new Task.Backgroundable(libertyModule.getProject(), LocalizedResourceUtil.getMessage("liberty.run.config.title"), true) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                createDebugConfiguration(indicator, libertyModule, debugPort);
+            }
+        });
+    }
+
+    /**
+     * Creates a new remote Java application debug configuration
+     *
+     * @param indicator progress monitor
+     * @param libertyModule Liberty module
+     * @param debugPort JVM port to connect to
+     */
+    private void createDebugConfiguration(ProgressIndicator indicator, LibertyModule libertyModule, int debugPort) {
+        indicator.setText(LocalizedResourceUtil.getMessage("attaching.debugger"));
+        try {
+            String debugPortStr = waitForSocketActivation(indicator, libertyModule, DEFAULT_ATTACH_HOST, debugPort);
+            RunnerAndConfigurationSettings settings = RunManager.getInstance(libertyModule.getProject()).createConfiguration(libertyModule.getName() + " (Remote)", RemoteConfigurationType.class);
+            RemoteConfiguration remoteConfiguration = (RemoteConfiguration) settings.getConfiguration();
+            remoteConfiguration.PORT = debugPortStr;
+            long groupId = ExecutionEnvironment.getNextUnusedExecutionId();
+            LOGGER.debug(String.format("%s: attempting to attach debugger to port %s"), libertyModule.getName(), debugPortStr);
+            ExecutionUtil.runConfiguration(settings, DefaultDebugExecutor.getDebugExecutorInstance(), DefaultExecutionTarget.INSTANCE, groupId);
+        } catch (Exception e) {
+            // do not show error if debug attachment was cancelled by user
+            if (!(e instanceof ProcessCanceledException)) {
+                LOGGER.error(String.format("Cannot connect debugger to port %s", debugPort), e);
+                ApplicationManager.getApplication().invokeLater(() -> Messages.showErrorDialog(LocalizedResourceUtil.getMessage("cannot.connect.debug.port", debugPort), "Liberty"));
+            }
+        }
+    }
+
+    /**
+     * Waits for the JDWP socket on the JVM to start listening for connections
+     *
+     * @param monitor progress monitor
+     * @param libertyModule Liberty module
+     * @param host JVM host to connect to
+     * @param debugPort JVM port to connect to
+     * @return debug port as a String
+     * @throws Exception
+     */
+    private String waitForSocketActivation(ProgressIndicator monitor, LibertyModule libertyModule, String host, int debugPort) throws Exception {
+        byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
+        int retryLimit = 120;
+        int envReadMinLimit = 30;
+        int envReadMaxLimit = 60;
+        int envReadInterval = 5;
+
+        Path serverEnvPath = getServerEnvPath(libertyModule);
+
+        for (int retryCount = 0; retryCount < retryLimit; retryCount++) {
+            // check if cancelled
+            if (monitor.isCanceled()) {
+                return null;
+            }
+
+            if (serverEnvPath == null) {
+                serverEnvPath = getServerEnvPath(libertyModule);
+                TimeUnit.SECONDS.sleep(1);
+                continue;
+            }
+
+            // Check the server.env at the default location for any updates to WLP_DEBUG_ADDRESS for any changes.
+            // There is a small window in which the allocated port could have been taken by another process.
+            // If the port is already in use, dev mode will allocate a random port and reflect that by updating the server.env file.
+            if (retryCount >= envReadMinLimit && retryCount < envReadMaxLimit && (retryCount % envReadInterval == 0)) {
+                String envPortStr = readDebugPortFromServerEnv(serverEnvPath.toFile());
+                if (envPortStr != null) {
+                    int envPort = Integer.parseInt(envPortStr);
+                    if (envPort != debugPort) {
+                        debugPort = envPort;
+                    }
+                }
+            }
+
+            try (Socket socket = new Socket(host, debugPort)) {
+                socket.getOutputStream().write(handshakeString);
+                return String.valueOf(debugPort);
+            } catch (ConnectException e) {
+                TimeUnit.SECONDS.sleep(1);
+            }
+        }
+
+        throw new Exception(String.format("Unable to connect to JVM on host: %s and port: %s", host, debugPort));
+    }
+
+    /**
+     * Returns the default path of the server.env file after Liberty server deployment.
+     *
+     * @param libertyModule The Liberty module for which this operations is being performed.
+     *
+     * @return The default path of the server.env file after Liberty server deployment.
+     *
+     * @throws Exception
+     */
+    private Path getServerEnvPath(LibertyModule libertyModule) throws Exception {
+        String projectPath = libertyModule.getBuildFile().getParent().getPath();
+        Path basePath = null;
+        if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            basePath = Paths.get(projectPath, "target", "liberty", "wlp", "usr", "servers");
+        } else if (libertyModule.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
+            basePath = Paths.get(projectPath, "build", "wlp", "usr", "servers");
+        } else {
+            throw new Exception(String.format("Unexpected project build type: %s. Liberty module %s does not appear to be a Maven or Gradle built project",
+                    libertyModule.getProjectType(), libertyModule.getName()));
+        }
+
+        // Make sure the base path exists. If not return null.
+        File basePathFile = new File(basePath.toString());
+        if (!basePathFile.exists()) {
+            return null;
+        }
+
+        try (Stream<Path> matchedStream = Files.find(basePath, 2, (path, basicFileAttribute) -> {
+            if (basicFileAttribute.isRegularFile()) {
+                return path.getFileName().toString().equalsIgnoreCase("server.env");
+            }
+            return false;
+        });) {
+            List<Path> matchedPaths = matchedStream.collect(Collectors.toList());
+            int numberOfFilesFound = matchedPaths.size();
+
+            if (numberOfFilesFound != 1) {
+                if (numberOfFilesFound == 0) {
+                    LOGGER.trace(String.format("Unable to find the server.env file for project %s", libertyModule.getName()));
+                    return null;
+                } else {
+                    throw new Exception(String.format("More than one server.env files were found for project %s. Unable to determine the server.env file to use", libertyModule.getName()));
+                }
+            }
+            return matchedPaths.get(0);
+        }
+    }
+
+    /**
+     * Returns the last debug port entry in server.env. Null if not found.
+     *
+     * @param serverEnv The server.env file object.
+     *
+     * @return The last debug port entry in server.env. Null if not found.]]
+     *
+     * @throws Exception
+     */
+    private String readDebugPortFromServerEnv(File serverEnv) throws Exception {
+        String port = null;
+
+        if (serverEnv.exists()) {
+            try (BufferedReader reader = new BufferedReader(new FileReader(serverEnv))) {
+                String line = null;
+                String lastEntry = null;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains(WLP_ENV_DEBUG_ADDRESS)) {
+                        lastEntry = line;
+                    }
+                }
+                if (lastEntry != null) {
+                    String[] parts = lastEntry.split("=");
+                    port = parts[1].trim();
+                }
+            }
+        }
+        return port;
+    }
+}
+

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -266,7 +266,9 @@ public class DebugModeHandler {
                 }
                 if (lastEntry != null) {
                     String[] parts = lastEntry.split("=");
-                    port = parts[1].trim();
+                    if (parts.length > 1) {
+                        port = parts[1].trim();
+                    }
                 }
             }
         }

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -100,16 +100,16 @@ public class DebugModeHandler {
     }
 
     /**
-     * Creates a new debug configuration for the corresponding Liberty module
+     * Creates and runs new debug configuration for the corresponding Liberty module
      *
      * @param libertyModule Liberty module
      * @param debugPort JVM port to connect to
      */
-    public void createDebugConfiguration(LibertyModule libertyModule, int debugPort) {
+    public void createAndRunDebugConfiguration(LibertyModule libertyModule, int debugPort) {
         ProgressManager.getInstance().run(new Task.Backgroundable(libertyModule.getProject(), LocalizedResourceUtil.getMessage("liberty.run.config.title"), true) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
-                createDebugConfiguration(indicator, libertyModule, debugPort);
+                createAndRunDebugConfiguration(indicator, libertyModule, debugPort);
             }
         });
     }
@@ -121,7 +121,7 @@ public class DebugModeHandler {
      * @param libertyModule Liberty module
      * @param debugPort JVM port to connect to
      */
-    private void createDebugConfiguration(ProgressIndicator indicator, LibertyModule libertyModule, int debugPort) {
+    private void createAndRunDebugConfiguration(ProgressIndicator indicator, LibertyModule libertyModule, int debugPort) {
         indicator.setText(LocalizedResourceUtil.getMessage("attaching.debugger"));
         try {
             String debugPortStr = waitForSocketActivation(indicator, libertyModule, DEFAULT_ATTACH_HOST, debugPort);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
@@ -40,8 +40,8 @@ public class LibertyActionUtil {
             StringBuilder result = new StringBuilder();
             result.append(cmd).append(enterCode);
             connector.write(result.toString());
-        } catch (IOException ex) {
-            LOGGER.error(ex.getMessage());
+        } catch (IOException e) {
+            LOGGER.error(String.format("Failed to execute command: %s", cmd), e);
         }
 
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -51,7 +51,7 @@ public class LibertyGradleUtil {
                     return name.replaceAll("^[\"']+|[\"']+$", "");
                 }
             } catch (IOException e) {
-                LOGGER.error("Could not read " + settingsPath, e.getMessage());
+                LOGGER.error(String.format("Could not read project name from file %s", settingsPath), e);
             }
         }
         return null;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -192,7 +192,7 @@ public class LibertyProjectUtil {
                         buildFiles.add(buildFile);
                     }
                 } catch (Exception e) {
-                    LOGGER.error("Error parsing build.gradle", e.getMessage());
+                    LOGGER.error(String.format("Error parsing build.gradle %s", gradleFile), e.getMessage());
                 }
             }
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,13 +29,13 @@
     <depends>com.intellij.properties</depends>
     <depends>org.jetbrains.idea.maven</depends>
     <depends>com.intellij.gradle</depends>
-
     <idea-version since-build="222"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"
                     factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>
         <projectService serviceImplementation="io.openliberty.tools.intellij.LibertyProjectSettings" />
+        <configurationType implementation="io.openliberty.tools.intellij.runConfiguration.LibertyRunConfigurationType"/>
     </extensions>
 
     <extensionPoints>
@@ -111,6 +111,10 @@
             <attribute name="maxRetries" range="-1" /> <!-- x >=0 -->
         </javaASTValidator.annotationValidator>
     </extensions>
+
+    <projectListeners>
+        <listener class="io.openliberty.tools.intellij.runConfiguration.LibertyRunManagerListener" topic="com.intellij.execution.RunManagerListener"/>
+    </projectListeners>
 
     <!-- Default resource location for localizing Liberty actions strings -->
     <resource-bundle>messages.LibertyBundles</resource-bundle>

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -40,11 +40,12 @@ action.io.openliberty.tools.intellij.actions.RemoveLibertyProjectAction.descript
 
 # Messages for Liberty actions and pop-up dialog
 no.liberty.projects.detected=No Liberty Maven or Liberty Gradle projects detected in this workspace.
-liberty.dev.not.started.notification.title=Liberty dev mode has not been started
-liberty.dev.not.started.notification.content=Liberty dev mode has not been started on {0}. \nStart Liberty dev mode from the Liberty tool window.
-liberty.project.does.not.resolve=Unable to {0}: Could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
-liberty.build.file.does.not.resolve=Unable to {0}: Could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
-liberty.action.cannot.start=Liberty action was not able to start
+liberty.dev.not.started.notification.content=Unable to {0}: Liberty dev mode may not have been started on {1}. \nStart Liberty dev mode from the Liberty tool window.
+liberty.project.does.not.resolve=Unable to {0}: could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
+liberty.build.file.does.not.resolve=Unable to {0}: could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
+liberty.project.type.invalid=Unable to {0}: could not resolve Liberty project type for {1}.
+liberty.terminal.cannot.resolve=Unable to {0}: could not resolve an IntelliJ terminal for {1}.
+liberty.action.cannot.start=Liberty action was not able to run
 liberty.project.file.selection.dialog.title=Liberty project
 liberty.project.file.selection.dialog.message=Select Liberty project for {0}
 
@@ -106,4 +107,13 @@ test.summary=Test Summary
 view.unit.test.report=view unit test report
 unit.test.report.does.not.exist=Unit Test Report Does Not Exist
 
-
+# Run & Debug Configuration
+liberty.run.config.title=Liberty Run Configuration
+liberty.debug.port.unresolved=Unable to {0} in debug mode: could not resolve debug port for {1}.
+attaching.debugger=Attaching Debugger to Liberty Server JVM...
+cannot.connect.debug.port=Cannot connect debugger to port {0}.
+run.config.liberty.project=Liberty Project
+run.config.liberty.project.tool.tip=Select the build file for your Liberty project
+run.config.start.parameters=Start Parameters
+run.config.start.parameters.tool.tip=eg. -DhotTests=true (Maven) --hotTests=true (Gradle)
+specify.custom.parameters.for.the.mvn.liberty.dev.command=Specify custom parameters for the mvn liberty:dev command


### PR DESCRIPTION
Fixes #110 and #108 

Contributes new Liberty run/debug config
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/26146482/203869066-fae286c2-44f6-4636-b8f2-2aa36ad98e55.png">


Start... command will now open a new run config, which will allow users to specify custom parameters. 

Opened #160, #163 and #167 for enhancements

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>