### PR TITLE
Persist manually added/removed projects across IntelliJ sessions.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyProjectSettings.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyProjectSettings.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2022 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@State(
+        name = "LibertyProjectSettings",
+        storages = @Storage("liberty-project-settings.xml")
+)
+public class LibertyProjectSettings implements PersistentStateComponent<LibertyProjectSettings> {
+
+    private volatile Set<String> customLibertyProjects = Collections.synchronizedSet(new HashSet<>());
+
+    public static LibertyProjectSettings getInstance(Project project) {
+        return project.getService(LibertyProjectSettings.class);
+    }
+
+    public synchronized Set<String> getCustomLibertyProjects() {
+        if (customLibertyProjects == null) {
+            customLibertyProjects = Collections.synchronizedSet(new HashSet<>());
+        }
+        return customLibertyProjects;
+    }
+
+    public synchronized void setCustomLibertyProjects(Set<String> customLibertyProjects) {
+        this.customLibertyProjects = customLibertyProjects;
+    }
+
+    @Nullable
+    @Override
+    public LibertyProjectSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull LibertyProjectSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/LibertyProjectSettings.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyProjectSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2022 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"
                     factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>
+        <projectService serviceImplementation="io.openliberty.tools.intellij.LibertyProjectSettings" />
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
Resolves: https://github.com/OpenLiberty/liberty-tools-intellij/issues/129

Example of `liberty-project-settings.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>
<project version="4">
  <component name="LibertyProjectSettings">
    <option name="customLibertyProjects">
      <set>
        <option value="$PROJECT_DIR$/start/pom.xml" />
      </set>
    </option>
  </component>
</project>
```

IntelliJ is parameterizing the path value when it saves it to the file. This should mean that the user can move their IntelliJ project to another directory after they've manually added/removed Liberty projects and it should still be able to resolve the persisted path.
