### PR TITLE
Track terminal for each Liberty module

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -13,6 +13,7 @@ package io.openliberty.tools.intellij;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.util.BuildFile;
+import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 /**
  * Represents a Liberty server module
@@ -30,12 +31,14 @@ public class LibertyModule {
     private boolean runInContainer;
 
     private boolean debugMode;
+    private ShellTerminalWidget shellWidget;
 
     public LibertyModule(Project project) {
         this.project = project;
         this.customStartParams = "";
         this.runInContainer = false;
         this.debugMode = false;
+        this.shellWidget = null;
     }
 
     public LibertyModule(Project project, VirtualFile buildFile, String name, String projectType, boolean validContainerVersion) {
@@ -123,5 +126,13 @@ public class LibertyModule {
 
     public void setDebugMode(boolean debugMode) {
         this.debugMode = debugMode;
+    }
+
+    public ShellTerminalWidget getShellWidget() {
+        return shellWidget;
+    }
+
+    public void setShellWidget(ShellTerminalWidget shellWidget) {
+        this.shellWidget = shellWidget;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -166,7 +166,6 @@ public class LibertyGeneralAction extends AnAction {
      */
     protected ShellTerminalWidget getTerminalWidget(boolean createWidget) {
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget);
-        libertyModule.setShellWidget(widget);
         if (widget == null || (!createWidget && !widget.hasRunningCommands())) {
             String msg;
             if (createWidget) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -166,6 +166,7 @@ public class LibertyGeneralAction extends AnAction {
      */
     protected ShellTerminalWidget getTerminalWidget(boolean createWidget) {
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget);
+        // Shows error for actions where terminal widget does not exist or action requires a terminal to already exist and expects "Start" to be running
         if (widget == null || (!createWidget && !widget.hasRunningCommands())) {
             String msg;
             if (createWidget) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -159,14 +159,15 @@ public class LibertyGeneralAction extends AnAction {
     }
 
     /**
-     * Returns the IntelliJ terminal widget for the corresponding Liberty module
+     * Returns the Terminal widget for the corresponding Liberty module
      *
-     * @param createWidget create terminal widget if it does not already exist
+     * @param createWidget create Terminal widget if it does not already exist
      * @return ShellTerminalWidget
      */
     protected ShellTerminalWidget getTerminalWidget(boolean createWidget) {
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, createWidget);
-        if (widget == null) {
+        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget);
+        libertyModule.setShellWidget(widget);
+        if (widget == null || (!createWidget && !widget.hasRunningCommands())) {
             String msg;
             if (createWidget) {
                 msg = LocalizedResourceUtil.getMessage("liberty.terminal.cannot.resolve", actionCmd, projectName);
@@ -177,6 +178,8 @@ public class LibertyGeneralAction extends AnAction {
             LOGGER.warn(msg);
             return null;
         }
+        widget.getComponent().setVisible(true);
+        widget.getComponent().requestFocus();
         return widget;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -152,7 +152,9 @@ public class LibertyProjectUtil {
         ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
         if (widget == null && createWidget) {
             // create a new terminal tab
-            return terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
+            ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
+            libertyModule.setShellWidget(newTerminal);
+            return newTerminal;
         }
         return widget;
     }
@@ -217,6 +219,7 @@ public class LibertyProjectUtil {
                 }
             }
         }
+        libertyModule.setShellWidget(null);
         return null;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -13,27 +13,26 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.terminal.JBTerminalWidget;
-import com.intellij.ui.content.Content;
 import com.sun.istack.Nullable;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyProjectSettings;
-import org.jetbrains.plugins.terminal.LocalTerminalDirectRunner;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import org.jetbrains.plugins.terminal.TerminalTabState;
 import org.jetbrains.plugins.terminal.TerminalView;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 public class LibertyProjectUtil {
     private static Logger LOGGER = Logger.getInstance(LibertyProjectUtil.class);;
@@ -140,31 +139,22 @@ public class LibertyProjectUtil {
     }
 
     /**
-     * Get the terminal widget for the current project
+     * Get the Terminal widget for corresponding Liberty module
+     *
      * @param project
-     * @param projectName
-     * @param createWidget true if a new widget should be created
-     * @return ShellTerminalWidget object
+     * @param libertyModule
+     * @param createWidget  true if a new widget should be created
+     * @return ShellTerminalWidget or null if it does not exist
      */
-    public static ShellTerminalWidget getTerminalWidget(Project project, String projectName, boolean createWidget) {
-        ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
-        ToolWindow terminalWindow = toolWindowManager.getToolWindow("Terminal");
-
+    public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget) {
+        TerminalView terminalView = TerminalView.getInstance(project);
         // look for existing terminal tab
-        ShellTerminalWidget widget = getTerminalWidget(terminalWindow, projectName);
-        if (widget != null) {
-            return widget;
-        } else if (createWidget) {
+        ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
+        if (widget == null && createWidget) {
             // create a new terminal tab
-            TerminalView terminalView = TerminalView.getInstance(project);
-            LocalTerminalDirectRunner terminalRun = new LocalTerminalDirectRunner(project);
-            TerminalTabState tabState = new TerminalTabState();
-            tabState.myTabName = projectName;
-            tabState.myWorkingDirectory = project.getBasePath();
-            terminalView.createNewSession(terminalRun, tabState);
-            return getTerminalWidget(terminalWindow, projectName);
+            return terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
         }
-        return null;
+        return widget;
     }
 
     // returns valid build files for the current project
@@ -209,18 +199,27 @@ public class LibertyProjectUtil {
         return new File(rootDir, "src/main/liberty/config/server.xml").exists();
     }
 
-    private static ShellTerminalWidget getTerminalWidget(ToolWindow terminalWindow, String projectName) {
-        Content[] terminalContents = terminalWindow.getContentManager().getContents();
-        for (int i = 0; i < terminalContents.length; i++) {
-            // TODO use LibertyModule rather than projectName see https://github.com/OpenLiberty/liberty-tools-intellij/issues/143
-            if (terminalContents[i].getTabName().equals(projectName)) {
-                JBTerminalWidget widget = TerminalView.getWidgetByContent(terminalContents[i]);
-                ShellTerminalWidget shellWidget = (ShellTerminalWidget) Objects.requireNonNull(widget);
-                return shellWidget;
+    /**
+     * Get the Terminal widget for the corresponding Liberty module. Will check if the Terminal widget
+     * exists in the Terminal view.
+     *
+     * @param libertyModule
+     * @param terminalView
+     * @return ShellTerminalWidget or null if it does not exist
+     */
+    private static ShellTerminalWidget getTerminalWidget(LibertyModule libertyModule, TerminalView terminalView) {
+        ShellTerminalWidget widget = libertyModule.getShellWidget();
+        // check if widget exists in terminal view
+        if (widget != null) {
+            for (JBTerminalWidget terminalWidget : terminalView.getWidgets()) {
+                if (widget.equals(terminalWidget)) {
+                    return widget;
+                }
             }
         }
         return null;
     }
+
 
 
 


### PR DESCRIPTION
Fixes #143 

Associates each Liberty module with a ShellTerminalWidget (terminal instance). 

Also improved the check for whether we should run the stop dev mode and run tests action by using `widget.hasRunningCommands()`.  This returns true if there are running commands on the corresponding terminal instance. 

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>