### PR TITLE
Check for null before using messageBusConnection.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
@@ -136,7 +136,7 @@ public class LanguageServerWrapper {
     }
 
     private Listener fileBufferListener = new Listener();
-    private MessageBusConnection messageBusConnection;
+    private MessageBusConnection messageBusConnection = null;
 
     @Nonnull
     public final LanguageServersRegistry.LanguageServerDefinition serverDefinition;
@@ -428,7 +428,9 @@ public class LanguageServerWrapper {
         this.languageServer = null;
 
         EditorFactory.getInstance().getEventMulticaster().removeDocumentListener(fileBufferListener);
-        messageBusConnection.disconnect();
+        if (messageBusConnection != null) {
+            messageBusConnection.disconnect();
+        }
     }
 
     /**


### PR DESCRIPTION
Exception on line 342 will cause messageBusConnection to be used before being set.

![image](https://user-images.githubusercontent.com/24705144/205109879-430a836e-4f54-4270-9bfc-2f1019ea48f8.png)


Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>