### PR TITLE
Including an exception for when gradle settings is null

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -169,7 +169,7 @@ public class LibertyGradleUtil {
         GradleProjectSettings gradleProjectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(project.getBasePath());
         if (gradleProjectSettings == null) {
             String translatedMessage = LocalizedResourceUtil.getMessage("gradle.settings.is.null");
-            throw new LibertyException("Cannot execute project because there is an error with configured Gradle. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.", translatedMessage);
+            throw new LibertyException("Could not execute action because there is an error with Gradle configuration. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.", translatedMessage);
         }
         else if (gradleProjectSettings.getDistributionType().isWrapped()) {
             // a wrapper will be used

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -167,7 +167,11 @@ public class LibertyGradleUtil {
      */
     public static String getGradleSettingsCmd(Project project) throws LibertyException {
         GradleProjectSettings gradleProjectSettings = GradleSettings.getInstance(project).getLinkedProjectSettings(project.getBasePath());
-        if (gradleProjectSettings.getDistributionType().isWrapped()) {
+        if (gradleProjectSettings == null) {
+            String translatedMessage = LocalizedResourceUtil.getMessage("gradle.settings.is.null");
+            throw new LibertyException("Cannot execute project because there is an error with configured Gradle. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.", translatedMessage);
+        }
+        else if (gradleProjectSettings.getDistributionType().isWrapped()) {
             // a wrapper will be used
             return getLocalGradleWrapperPath(project);
         }

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -138,4 +138,4 @@ gradle.wrapper.cannot.execute=Could not execute Gradle wrapper because the proce
 gradle.invalid.build.preference=Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.
 gradle.cannot.execute=Could not execute Gradle from {0} because the process does not have permission to execute it. Consider giving executable permission for the Gradle executable or configure IntelliJ to use the Gradle wrapper.
 gradle.does.not.exist=Could not execute the Gradle executable {0}. Make sure a valid path is configured inside IntelliJ Gradle preferences.
-gradle.settings.is.null=Cannot execute project because there is an error with configured Gradle. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.
+gradle.settings.is.null=Could not execute action because there is an error with Gradle configuration. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -135,3 +135,4 @@ gradle.wrapper.cannot.execute=Could not execute Gradle wrapper because the proce
 gradle.invalid.build.preference=Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.
 gradle.cannot.execute=Could not execute Gradle from {0} because the process does not have permission to execute it. Consider giving executable permission for the Gradle executable or configure IntelliJ to use the Gradle wrapper.
 gradle.does.not.exist=Could not execute the Gradle executable {0}. Make sure a valid path is configured inside IntelliJ Gradle preferences.
+gradle.settings.is.null=Cannot execute project because there is an error with configured Gradle. Make sure to configure a valid path for Gradle inside IntelliJ Gradle preferences.


### PR DESCRIPTION
This is a fix for https://github.com/OpenLiberty/liberty-tools-intellij/issues/197 following the strategy we agreed during scrum, that is, throw a nice message error in the case gradle settings is null.