### PR TITLE
Use lsp4jakarta extended API to specify package and class names required for a new class snippet

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
@@ -12,14 +12,10 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.libraries.Library;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.JavaPsiFacade;
-import com.intellij.psi.search.GlobalSearchScope;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PropertiesManagerForJakarta;
 import io.openliberty.tools.intellij.lsp4mp.MicroProfileProjectService;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageClientImpl;
@@ -27,19 +23,19 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4jakarta.api.JakartaLanguageClientAPI;
 import org.eclipse.lsp4jakarta.commons.JakartaClasspathParams;
 import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Adapted from https://github.com/redhat-developer/intellij-quarkus/blob/2585eb422beeb69631076d2c39196d6eca2f5f2e/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
- * to start LSP4MP, Language Server for MicroProfile
+ * to match LSP4MP, Language Server for MicroProfile
  */
 public class JakartaLanguageClient extends LanguageClientImpl implements JakartaLanguageClientAPI, MicroProfileProjectService.Listener {
   private static final Logger LOGGER = LoggerFactory.getLogger(JakartaLanguageClient.class);
@@ -51,23 +47,12 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
   // Support the message "jakarta/java/classpath"
   @Override
   public CompletableFuture<List<String>> getContextBasedFilter(JakartaClasspathParams classpathParams) {
+    String uri = classpathParams.getUri();
     List<String> snippetContexts = classpathParams.getSnippetCtx();
-    // ask the Java component if the classpath of the current module contains the specified Jakarta types.
-    JavaPsiFacade javaFacade = JavaPsiFacade.getInstance(getProject());
-    GlobalSearchScope scope = GlobalSearchScope.allScope(getProject());
-    List<String> validCtx = new ArrayList<String>();
-    if (javaFacade != null && scope != null) {
-      for (String typeCtx : snippetContexts) {
-        Object type = ApplicationManager.getApplication().runReadAction((Computable<Object>) () -> javaFacade.findClass(typeCtx, scope));
-        validCtx.add(type != null ? typeCtx : null); // list will be the same size as input
-      }
-    } else {
-      // Error: none of these contexts will add to the completions
-      for (String typeCtx : snippetContexts) {
-        validCtx.add(null); // list will be the same size as input
-      }
-    }
-    return CompletableFuture.completedFuture(validCtx);
+    Project project = getProject();
+    return CompletableFutures.computeAsync((cancelChecker) -> {
+              return PropertiesManagerForJakarta.getInstance().getExistingContextsFromClassPath(uri, snippetContexts, project);
+            });
   }
 
   // Support the message "jakarta/java/diagnostics"

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -15,9 +15,13 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
+import com.intellij.psi.search.GlobalSearchScope;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanDiagnosticsCollector;
@@ -33,11 +37,13 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ListenerDiagnost
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ServletDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4mp.commons.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,6 +125,73 @@ public class PropertiesManagerForJakarta {
     }
 
     /**
+     * @brief Gets all snippet contexts that exist in the current project classpath
+     * @param uri             - String representing file from which to derive project
+     *                        classpath
+     * @param snippetContexts - get all the context fields from the snippets and
+     *                        check if they exist in this method
+     * @param project         - the IntelliJ project containing the uri
+     * @return List<String>
+     */
+    public List<String> getExistingContextsFromClassPath(String uri, List<String> snippetContexts, Project project) {
+        // ask the Java component if the classpath of the current module contains the specified Jakarta types.
+        JavaPsiFacade javaFacade = JavaPsiFacade.getInstance(project);
+        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
+        List<String> validCtx = new ArrayList<String>();
+        if (javaFacade != null && scope != null) {
+            for (String typeCtx : snippetContexts) {
+                Object type = ApplicationManager.getApplication().runReadAction((Computable<Object>) () -> javaFacade.findClass(typeCtx, scope));
+                validCtx.add(type != null ? typeCtx : null); // list will be the same size as input
+            }
+        } else {
+            // Error: none of these contexts will add to the completions
+            for (String typeCtx : snippetContexts) {
+                validCtx.add(null); // list will be the same size as input
+            }
+        }
+
+        // FOR NOW, append package name and class name to the list in order for LS to
+        // resolve ${packagename} and ${classname} variables
+        PsiFile typeRoot = ApplicationManager.getApplication().runReadAction((Computable<PsiFile>) () -> resolveTypeRoot(uri, project));
+        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+            String className = "className";
+            String packageName = "packageName";
+            if (typeRoot instanceof PsiJavaFile) {
+                PsiJavaFile javaFile = (PsiJavaFile)typeRoot;
+                PsiClass[] classes = javaFile.getClasses();
+                if (classes.length > 0) {
+                    className = classes[0].getName();
+                } else {
+                    className = javaFile.getName();
+                    if (className.endsWith(".java") == true) {
+                        className = className.substring(0, className.length() - 5);
+                    }
+                }
+                packageName = javaFile.getPackageName();
+                if (packageName == null || packageName.isEmpty()) {
+                    String path = javaFile.getParent().getVirtualFile().getCanonicalPath(); // f=/U/me/proj/src/main/java/pkg  not /cls.java
+                    VirtualFile[] contentRoots = ProjectRootManager.getInstance(project).getContentSourceRoots();
+                    for (VirtualFile vf : contentRoots) {
+                        String vfp = vf.getCanonicalPath();
+                        if (path.startsWith(vfp)) {
+                            path = path.substring(vfp.length()); // remove the project part of the path
+                            break;
+                        }
+                    }
+                    if (path.startsWith(File.separator)) {
+                        path = path.substring(File.separator.length()); // remove leading File.separator
+                    }
+                    packageName = path.replace(File.separator, "."); // convert pkg1/pkg2
+                }
+            }
+            validCtx.add(packageName);
+            validCtx.add(className);
+            });
+
+        return validCtx;
+    }
+
+    /**
      * Given the uri returns a {@link PsiFile}. May return null if it can not
      * associate the uri with a Java file ot class file.
      *
@@ -127,6 +200,11 @@ public class PropertiesManagerForJakarta {
      * @return compilation unit
      */
     private static PsiFile resolveTypeRoot(String uri, IPsiUtils utils) {
+        return utils.resolveCompilationUnit(uri);
+    }
+
+    private static PsiFile resolveTypeRoot(String uri, Project project) {
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(project);
         return utils.resolveCompilationUnit(uri);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -169,19 +170,16 @@ public class PropertiesManagerForJakarta {
                 }
                 packageName = javaFile.getPackageName();
                 if (packageName == null || packageName.isEmpty()) {
-                    String path = javaFile.getParent().getVirtualFile().getCanonicalPath(); // f=/U/me/proj/src/main/java/pkg  not /cls.java
+                    Path path = javaFile.getParent().getVirtualFile().toNioPath(); // f=/U/me/proj/src/main/java/pkg  not /cls.java
                     VirtualFile[] contentRoots = ProjectRootManager.getInstance(project).getContentSourceRoots();
                     for (VirtualFile vf : contentRoots) {
-                        String vfp = vf.getCanonicalPath();
+                        Path vfp = vf.toNioPath();
                         if (path.startsWith(vfp)) {
-                            path = path.substring(vfp.length()); // remove the project part of the path
+                            path = vfp.relativize(path); // remove the project part of the path
                             break;
                         }
                     }
-                    if (path.startsWith(File.separator)) {
-                        path = path.substring(File.separator.length()); // remove leading File.separator
-                    }
-                    packageName = path.replace(File.separator, "."); // convert pkg1/pkg2
+                    packageName = path.toString().replace(File.separator, "."); // convert pkg1/pkg2
                 }
             }
             validCtx.add(packageName);


### PR DESCRIPTION
In this pull request I've refactored the code to look more like the lsp4mp and lsp4jakarta clients. This should make comparing the code bases easier in the future when we need to scan one looking for fixes to apply to the other. Or, if performing dual maintenance, the code can more easily be ported across.

Also, note a functional change. Formerly the classpath request handled on the communication thread since the work appeared small. Now we move the work to the completable futures thread pool like it is handled on the other language server clients.

Fixes #191

Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>