### PR TITLE
Enable run liberty action from go to action menu

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -321,7 +321,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             LibertyModule module = ((LibertyActionNode) node).getLibertyModule();
             LOGGER.debug("Selected: " + actionNodeName);
             // calls action on double click
-            String actionId = Constants.getFullActionMap().get(actionNodeName);
+            String actionId = Constants.FULL_ACTIONS_MAP.get(actionNodeName);
             if (actionId == null) {
                 LOGGER.error("Could not find action ID for action name: " + actionNodeName);
             }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -69,8 +69,11 @@ public class LibertyGeneralAction extends AnAction {
         }
         if (buildFile == null) {
             buildFile = (VirtualFile) e.getDataContext().getData(Constants.LIBERTY_BUILD_FILE);
+            if (buildFile != null && libertyModule == null) {
+                setLibertyModule(LibertyModules.getInstance().getLibertyModule(buildFile));
+            }
         }
-        boolean isActionFromShiftShift = "GoToAction".equalsIgnoreCase(e.getPlace());
+        boolean isActionFromShiftShift = Constants.GO_TO_ACTION_TRIGGERED.equalsIgnoreCase(e.getPlace());
         // if still null, or it is from shift-shift, then prompt for the user to select
         if (isActionFromShiftShift || buildFile == null) {
             List<LibertyModule> libertyModules = LibertyModules.getInstance().getLibertyModules(project, getSupportedProjectTypes());

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -174,7 +174,7 @@ public class LibertyGeneralAction extends AnAction {
             if (createWidget) {
                 msg = LocalizedResourceUtil.getMessage("liberty.terminal.cannot.resolve", actionCmd, projectName);
             } else {
-                msg = LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.content", actionCmd, projectName);
+                msg = LocalizedResourceUtil.getMessage("liberty.dev.not.started.notification.content", actionCmd, projectName, System.lineSeparator());
             }
             notifyError(msg);
             LOGGER.warn(msg);

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -9,7 +9,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.util;
 
-import java.util.HashMap;
+import java.util.*;
 
 public final class Constants {
     public static final String LIBERTY_DEV_DASHBOARD_ID = "Liberty";
@@ -65,22 +65,19 @@ public final class Constants {
     public static final String VIEW_GRADLE_CONFIG_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewGradleConfig";
     public static final String VIEW_EFFECTIVE_POM_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewEffectivePom";
 
-    private static final HashMap<String, String> CORE_ACTIONS_MAP = new HashMap<String, String>() {
+    // action triggered from shift-shift "Search Everywhere" IntelliJ menu or "cmd/ctl + shift + A" Actions menu
+    public static final String GO_TO_ACTION_TRIGGERED = "GoToAction";
+
+    public static final LinkedHashMap<String, String> FULL_ACTIONS_MAP = new LinkedHashMap<String, String>() {
         {
             put(LIBERTY_DEV_START, LIBERTY_DEV_START_ACTION_ID);
-            put(LIBERTY_DEV_STOP, LIBERTY_DEV_STOP_ACTION_ID);
             put(LIBERTY_DEV_CUSTOM_START, LIBERTY_DEV_CUSTOM_START_ACTION_ID);
             put(LIBERTY_DEV_START_CONTAINER, LIBERTY_DEV_START_CONTAINER_ACTION_ID);
             put(LIBERTY_DEV_TESTS, LIBERTY_DEV_TESTS_ACTION_ID);
+            put(LIBERTY_DEV_STOP, LIBERTY_DEV_STOP_ACTION_ID);
+            put(VIEW_UNIT_TEST_REPORT, VIEW_UNIT_TEST_REPORT_ACTION_ID);
+            put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
+            put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
         }
     };
-
-    public static HashMap<String, String> getFullActionMap() {
-        HashMap<String, String> fullActionsMap = new HashMap<>();
-        fullActionsMap.putAll(CORE_ACTIONS_MAP);
-        fullActionsMap.put(VIEW_UNIT_TEST_REPORT, VIEW_UNIT_TEST_REPORT_ACTION_ID);
-        fullActionsMap.put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
-        fullActionsMap.put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
-        return fullActionsMap;
-    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -68,16 +68,16 @@ public final class Constants {
     // action triggered from shift-shift "Search Everywhere" IntelliJ menu or "cmd/ctl + shift + A" Actions menu
     public static final String GO_TO_ACTION_TRIGGERED = "GoToAction";
 
-    public static final LinkedHashMap<String, String> FULL_ACTIONS_MAP = new LinkedHashMap<String, String>() {
-        {
-            put(LIBERTY_DEV_START, LIBERTY_DEV_START_ACTION_ID);
-            put(LIBERTY_DEV_CUSTOM_START, LIBERTY_DEV_CUSTOM_START_ACTION_ID);
-            put(LIBERTY_DEV_START_CONTAINER, LIBERTY_DEV_START_CONTAINER_ACTION_ID);
-            put(LIBERTY_DEV_TESTS, LIBERTY_DEV_TESTS_ACTION_ID);
-            put(LIBERTY_DEV_STOP, LIBERTY_DEV_STOP_ACTION_ID);
-            put(VIEW_UNIT_TEST_REPORT, VIEW_UNIT_TEST_REPORT_ACTION_ID);
-            put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
-            put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
-        }
-    };
+    public static final Map<String, String> FULL_ACTIONS_MAP = Collections.unmodifiableMap(new LinkedHashMap<String, String>() {
+                {
+                    put(LIBERTY_DEV_START, LIBERTY_DEV_START_ACTION_ID);
+                    put(LIBERTY_DEV_START_CONTAINER, LIBERTY_DEV_START_CONTAINER_ACTION_ID);
+                    put(LIBERTY_DEV_CUSTOM_START, LIBERTY_DEV_CUSTOM_START_ACTION_ID);
+                    put(LIBERTY_DEV_TESTS, LIBERTY_DEV_TESTS_ACTION_ID);
+                    put(LIBERTY_DEV_STOP, LIBERTY_DEV_STOP_ACTION_ID);
+                    put(VIEW_UNIT_TEST_REPORT, VIEW_UNIT_TEST_REPORT_ACTION_ID);
+                    put(VIEW_INTEGRATION_TEST_REPORT, VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
+                    put(VIEW_GRADLE_TEST_REPORT, VIEW_GRADLE_TEST_REPORT_ACTION_ID);
+                }
+            });
 }

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -40,7 +40,7 @@ action.io.openliberty.tools.intellij.actions.RemoveLibertyProjectAction.descript
 
 # Messages for Liberty actions and pop-up dialog
 no.liberty.projects.detected=No Liberty Maven or Liberty Gradle projects detected in this workspace.
-liberty.dev.not.started.notification.content=Unable to {0}. Liberty dev mode may not have been started on {1}. \nUse the Liberty tool window to start Liberty dev mode.
+liberty.dev.not.started.notification.content=Unable to {0}. Liberty dev mode may not have been started on {1}. {2}Use the Liberty tool window to start Liberty dev mode.
 liberty.project.does.not.resolve=Unable to {0}: could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
 liberty.build.file.does.not.resolve=Unable to {0}: could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
 liberty.project.type.invalid=Unable to {0}: could not resolve Liberty project type for {1}.
@@ -94,7 +94,7 @@ view.gradle.config.file=view Gradle configuration file
 liberty.tool.window.display.name=Projects
 
 # Test report actions
-test.report.does.not.exist=Test report ({0}) does not exist.  Run tests to generate a test report.  Ensure your test report is generating at the correct location.
+test.report.does.not.exist=Test report ({0}) does not exist. Run tests to generate a test report. Ensure your test report is generating at the correct location.
 
 # View integration test report action
 view.integration.test.report=view integration test report

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -40,7 +40,7 @@ action.io.openliberty.tools.intellij.actions.RemoveLibertyProjectAction.descript
 
 # Messages for Liberty actions and pop-up dialog
 no.liberty.projects.detected=No Liberty Maven or Liberty Gradle projects detected in this workspace.
-liberty.dev.not.started.notification.content=Unable to {0}: Liberty dev mode may not have been started on {1}. \nUse the Liberty tool window to start Liberty dev mode.
+liberty.dev.not.started.notification.content=Unable to {0}. Liberty dev mode may not have been started on {1}. \nUse the Liberty tool window to start Liberty dev mode.
 liberty.project.does.not.resolve=Unable to {0}: could not resolve project. Ensure you run the Liberty action from the Liberty tool window.
 liberty.build.file.does.not.resolve=Unable to {0}: could not resolve build file for {1}. Ensure you run the Liberty action from the Liberty tool window.
 liberty.project.type.invalid=Unable to {0}: could not resolve Liberty project type for {1}.
@@ -48,6 +48,8 @@ liberty.terminal.cannot.resolve=Unable to {0}: could not resolve an IntelliJ ter
 liberty.action.cannot.start=Liberty action was not able to run
 liberty.project.file.selection.dialog.title=Liberty project
 liberty.project.file.selection.dialog.message=Select Liberty project for {0}
+liberty.action.selection.dialog.title=Liberty action
+liberty.action.selection.dialog.message=Select Liberty action to run
 
 # Messages for Liberty add and remove project actions
 liberty.project.add=add Liberty project


### PR DESCRIPTION
Fixes #190 

Through the shift+shift/go to action IntelliJ menu, always enable the "Liberty: Run Liberty action" action. 
When running through the shift+shift/go to action IntelliJ menu, prompt users with a selection of available Liberty actions:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/26146482/206538056-9a6cec6a-8642-4cf1-8ffa-cea8f4a77499.png">

Then, users are prompted with the project they want to run the previously selected action on:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/26146482/206538986-2186cb66-78f4-4f2a-8a07-c1b6870238c8.png">

Also fixed the bug where when the user runs an action using the "Run" icon from the tool window for the first time, it no longer fails with an NPE.


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>