### PR TITLE
Check for null when language is not found.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServersRegistry.java
@@ -214,9 +214,11 @@ public class LanguageServersRegistry {
 
     private Set<LanguageServerDefinition> getAvailableLSFor(Language language) {
         Set<LanguageServerDefinition> res = new HashSet<>();
-        for (ContentTypeToLanguageServerDefinition mapping : this.connections) {
-            if (language.isKindOf(mapping.getKey())) {
-                res.add(mapping.getValue());
+        if (language != null) {
+            for (ContentTypeToLanguageServerDefinition mapping : this.connections) {
+                if (language.isKindOf(mapping.getKey())) {
+                    res.add(mapping.getValue());
+                }
             }
         }
         return res;


### PR DESCRIPTION
No exceptions when typing ctrl-space before the language servers start up.

Fixes #181

Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>