### PR TITLE
Disable go-to handler

### DIFF
--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -63,8 +63,9 @@
 <!--        <inspectionToolProvider-->
 <!--                implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.diagnostics.LSPInspectionToolProvider"/>-->
         <projectService serviceImplementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageServiceAccessor"/>
-        <gotoDeclarationHandler
-                implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.navigation.LSPGotoDeclarationHandler"/>
+        <!-- TODO re-enable goto handler -->
+        <!-- <gotoDeclarationHandler
+                implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.navigation.LSPGotoDeclarationHandler"/> -->
 
         <!-- MicroProfile -->
         <lang.documentationProvider id="LSPTextHoverProperties" language="Properties"


### PR DESCRIPTION
Temp fixes for NPEs from #168

Will need to be re-enabled once we fix using custom languages with `<fileType>`