### PR TITLE
Enable hover for server.xml files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.10.0'
+    id 'org.jetbrains.intellij' version '1.11.0'
 }
 
 group 'io.openliberty.tools'

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
@@ -151,7 +151,7 @@ public class LSPTextHover extends DocumentationProviderEx implements ExternalDoc
         if (editor != null) {
             initiateHoverRequest(elem, editor);
             try {
-                String result = request.get(1, TimeUnit.SECONDS).stream()
+                String result = request.get(5, TimeUnit.SECONDS).stream()
                         .filter(Objects::nonNull)
                         .map(LSPTextHover::getHoverString)
                         .filter(Objects::nonNull)

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
@@ -140,9 +140,13 @@ public class LSPTextHover extends DocumentationProviderEx implements ExternalDoc
     @Nullable
     @Override
     public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
-        PsiElement elem = element;
-        Editor editor = LSPIJUtils.editorForElement(elem);
-        if (editor == null) {
+        PsiElement elem = null;
+        Editor editor = null;
+        if (element != null) {
+            elem = element;
+            editor = LSPIJUtils.editorForElement(elem);
+        }
+        if (editor == null && originalElement != null) {
             // for some files (e.g. xml) element cannot resolve the associated VirtualFile and Editor, so we try to resolve again with originalElement
             editor = LSPIJUtils.editorForElement(originalElement);
             elem = originalElement;
@@ -162,7 +166,7 @@ public class LSPTextHover extends DocumentationProviderEx implements ExternalDoc
                 }
             } catch (ExecutionException | TimeoutException e) {
                 String fileName = elem.getContainingFile().getVirtualFile() != null ? String.valueOf(elem.getContainingFile().getVirtualFile()) : String.valueOf(elem.getContainingFile());
-                LOGGER.warn(String.format("Unable to generate documentation for %s. ", fileName) +  e.getLocalizedMessage(), e);
+                LOGGER.warn(String.format("Unable to generate documentation for %s. ", fileName) + e.getLocalizedMessage(), e);
             } catch (InterruptedException e) {
                 LOGGER.warn(e.getLocalizedMessage(), e);
                 Thread.currentThread().interrupt();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/hover/LSPTextHover.java
@@ -273,7 +273,10 @@ public class LSPTextHover extends DocumentationProviderEx implements ExternalDoc
     public boolean handleExternalLink(PsiManager psiManager, String link, PsiElement context) {
         VirtualFile file = getFile(link);
         if (file != null) {
-            FileEditorManager.getInstance(psiManager.getProject()).openFile(file, true, true);
+            // use invokeLater to avoid write-unsafe context error
+            ApplicationManager.getApplication().invokeLater(()->{
+                FileEditorManager.getInstance(psiManager.getProject()).openFile(file, true, true);
+                }, psiManager.getProject().getDisposed());
             return true;
         }
         return false;

--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -67,6 +67,10 @@
         <!-- <gotoDeclarationHandler
                 implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.navigation.LSPGotoDeclarationHandler"/> -->
 
+        <!-- Hover for LemMinX + Liberty LemMinX ext -->
+        <lang.documentationProvider id="LSPTextHoverXML" language="XML"
+                                    implementationClass="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.hover.LSPTextHover"
+                                    order="first"/>
         <!-- MicroProfile -->
         <lang.documentationProvider id="LSPTextHoverProperties" language="Properties"
                                     implementationClass="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.hover.LSPTextHover"


### PR DESCRIPTION
Part of #147 
- Enables hover from LemMinX + Liberty LemMinX extension. 
- Fixes write-unsafe context error when opening external links (e.g. server.xsd) from hover
- Bump IntelliJ Gradle plugin to latest version
- Fixes https://github.com/OpenLiberty/liberty-tools-intellij/issues/242, TimeoutException occurs on first hover in a fresh IntelliJ session.

Hover on server.xml schema elements. Note server.xsd is a click-able link, will open server.xsd file in-editor.
![image](https://user-images.githubusercontent.com/26146482/211379567-05ee5efa-6ce6-4a50-b769-6d0ebf9f3c76.png)

Hover on feature names for feature description.
![image](https://user-images.githubusercontent.com/26146482/211379598-27dbdba7-1fe5-4589-a779-766b8926ba59.png)

Alternatively, users can select the 3 dots -> "Open in documentation tool window" (native IntelliJ mechanism).
![image](https://user-images.githubusercontent.com/26146482/211379889-e7b4cf1f-2aea-420b-bcb5-b931169eda47.png)

Now hover text shows up in documentation tool window rather than over the file itself.
![image](https://user-images.githubusercontent.com/26146482/211379835-5c32a2fc-6024-44bd-8d59-ddb1151df362.png)


I did not observe any conflicts between the native IntelliJ hover support in existing xml files, such as pom.xml, and LemMinX.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>