### PR TITLE
Add code to instruct the language server to exit gracefully …

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JakartaLanguageServer extends ProcessStreamConnectionProvider {
     private static final String JAR_DIR = "lib/server/";
@@ -45,6 +47,10 @@ public class JakartaLanguageServer extends ProcessStreamConnectionProvider {
 
     @Override
     public Object getInitializationOptions(URI rootUri) {
-        return super.getInitializationOptions(rootUri);
+        Map<String, Object> root = new HashMap<>();
+        Map<String, Object> extendedClientCapabilities = new HashMap<>();
+        extendedClientCapabilities.put("shouldLanguageServerExitOnShutdown", Boolean.TRUE);
+        root.put("extendedClientCapabilities", extendedClientCapabilities);
+        return root;
     }
 }


### PR DESCRIPTION
…when the connection is closed. This mirrors other language servers e.g. lsp4mp.

The existing code eventually returns null.

Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>