### PR TITLE
Update Gradle project name

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -120,8 +120,13 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                 LOGGER.warn(String.format("Could not resolve project name from build file: %s", virtualFile), e);
             }
             if (projectName == null) {
-                projectName = project.getName();
+                if (virtualFile.getParent() != null) {
+                    projectName = virtualFile.getParent().getName();
+                } else {
+                    projectName = project.getName();
+                }
             }
+
             boolean validContainerVersion = buildFile.isValidContainerVersion();
             LibertyModule module = libertyModules.addLibertyModule(new LibertyModule(project, psiFile.getVirtualFile(), projectName, Constants.LIBERTY_MAVEN_PROJECT, validContainerVersion));
             node = new LibertyModuleNode(module);
@@ -161,7 +166,11 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                 LOGGER.warn(String.format("Could not resolve project name for project %s", virtualFile), e);
             }
             if (projectName == null) {
-                projectName = project.getName();
+                if (virtualFile.getParent() != null) {
+                    projectName = virtualFile.getParent().getName();
+                } else {
+                    projectName = project.getName();
+                }
             }
 
             boolean validContainerVersion = buildFile.isValidContainerVersion();

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -54,7 +54,7 @@ public class LibertyGradleUtil {
                 LOGGER.error(String.format("Could not read project name from file %s", settingsPath), e);
             }
         }
-        return null;
+        return parentFolder.getName();
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -63,7 +63,8 @@ public class LibertyMavenUtil {
                 }
             }
         }
-        return null;
+        VirtualFile parentFolder = file.getParent();
+        return parentFolder.getName();
     }
 
     /**


### PR DESCRIPTION
Fixes #182 and #228 
Use name of directory containing the build file if settings.gradle is not found (Gradle) or if artifactId is not found (Maven)