### PR TITLE
Use gradle wrapper canonical path instead of './gradlew'

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -209,7 +209,13 @@ public class LibertyGradleUtil {
                     "execute it. Consider giving executable permission for the Gradle wrapper file or changing the build " +
                     "preferences for Gradle inside IntelliJ Gradle preferences.", translatedMessage);
         }
-        return gradlew;
+        String path;
+        try {
+            path = file.getCanonicalPath();
+        } catch (IOException e) {
+            throw new LibertyException("Could not get canonical path for gradle wrapper file");
+        }
+        return path;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Jenő Tobak <tobakjeno@gmail.com>

fixes [#256](https://github.com/OpenLiberty/liberty-tools-intellij/issues/257)