### PR TITLE
Fix for diagnostics not appearing until another LS capability is triggered

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.11.0'
+    id 'org.jetbrains.intellij' version '1.12.0'
 }
 
 group 'io.openliberty.tools'

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,8 +40,14 @@ public class LibertyConfigLanguageServer extends ProcessStreamConnectionProvider
             return;
         }
         if (libertyServerPath.exists()) {
-            setCommands(Arrays.asList(javaHome + File.separator + "bin" + File.separator + "java", "-jar",
-                    libertyServerPath.getAbsolutePath(), "-DrunAsync=true"));
+            ArrayList<String> params = new ArrayList<>();
+            params.add(javaHome + File.separator + "bin" + File.separator + "java");
+
+            // Uncomment next line to attach debugger to LCLS at port 1064, debug params must come before -jar
+            // params.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1064");
+            params.add("-jar");
+            params.add(libertyServerPath.getAbsolutePath());
+            setCommands(params);
         } else {
             LOGGER.warn(String.format("Unable to start the Liberty language server, Liberty language server path: %s does not exist", libertyServerPath));
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServiceAccessor.java
@@ -40,6 +40,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * The entry-point to retrieve a Language Server for a given resource/project.
+ * Deals with instantiations and caching of underlying
+ * {@link LanguageServerWrapper}.
+ *
+ */
 public class LanguageServiceAccessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(LanguageServiceAccessor.class);
     private final Project project;
@@ -579,6 +585,8 @@ public class LanguageServiceAccessor {
     }
 
     /**
+     * Gets a list of language servers. Will start language servers if they are not already running on the corresponding document.
+     *
      * @param document
      * @param filter
      * @return

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/diagnostics/LSPLocalInspectionTool.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/diagnostics/LSPLocalInspectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020, 2023 Red Hat, Inc. and others
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -7,6 +7,7 @@
  *
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
+ * IBM Corp - update checkFile()
  ******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.diagnostics;
 
@@ -22,17 +23,16 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiUtilCore;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LSPIJUtils;
-import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageServerWrapper;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageServiceAccessor;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,27 +67,30 @@ public class LSPLocalInspectionTool extends LocalInspectionTool {
             if (editor != null) {
                 List<ProblemDescriptor> problemDescriptors = new ArrayList<>();
                 try {
-                    for(LanguageServerWrapper wrapper : LanguageServiceAccessor.getInstance(file.getProject()).getLSWrappers(virtualFile, capabilities -> true)) {
-                        RangeHighlighter[] highlighters = LSPDiagnosticsToMarkers.getMarkers(editor, wrapper.serverDefinition.id);
-                        if (highlighters != null) {
-                            for(RangeHighlighter highlighter : highlighters) {
-                                PsiElement element;
-                                if (highlighter.getEndOffset() - highlighter.getStartOffset() > 0) {
-                                    element = new LSPPSiElement(editor.getProject(), file, highlighter.getStartOffset(), highlighter.getEndOffset(), editor.getDocument().getText(new TextRange(highlighter.getStartOffset(), highlighter.getEndOffset())));
-                                } else {
-                                    element = PsiUtilCore.getElementAtOffset(file, highlighter.getStartOffset());
+                    LanguageServiceAccessor languageServiceAccessor = LanguageServiceAccessor.getInstance(editor.getProject());
+                    // Use languageServerAccessor.getLanguageServers() so that servers are properly started if they are not already running
+                    for (LanguageServer server : languageServiceAccessor.getLanguageServers(editor.getDocument(), capabilities -> true).get()) {
+                        languageServiceAccessor.resolveServerDefinition(server).map(definition -> definition.id).ifPresent(id -> {
+                            RangeHighlighter[] highlighters = LSPDiagnosticsToMarkers.getMarkers(editor, id);
+                            if (highlighters != null) {
+                                for (RangeHighlighter highlighter : highlighters) {
+                                    PsiElement element;
+                                    if (highlighter.getEndOffset() - highlighter.getStartOffset() > 0) {
+                                        element = new LSPPSiElement(editor.getProject(), file, highlighter.getStartOffset(), highlighter.getEndOffset(), editor.getDocument().getText(new TextRange(highlighter.getStartOffset(), highlighter.getEndOffset())));
+                                    } else {
+                                        element = PsiUtilCore.getElementAtOffset(file, highlighter.getStartOffset());
+                                    }
+                                    ProblemHighlightType highlightType = getHighlightType(((Diagnostic) highlighter.getErrorStripeTooltip()).getSeverity());
+                                    problemDescriptors.add(manager.createProblemDescriptor(element, ((Diagnostic) highlighter.getErrorStripeTooltip()).getMessage(), true, highlightType, isOnTheFly));
                                 }
-                                ProblemHighlightType highlightType = getHighlightType(((Diagnostic)highlighter.getErrorStripeTooltip()).getSeverity());
-                                problemDescriptors.add(manager.createProblemDescriptor(element, ((Diagnostic)highlighter.getErrorStripeTooltip()).getMessage(), true, highlightType, isOnTheFly));
                             }
-                        }
+                        });
                     }
-                } catch (IOException e) {
+                } catch (Exception e) {
                     LOGGER.warn(e.getLocalizedMessage(), e);
                 }
                 return problemDescriptors.toArray(new ProblemDescriptor[problemDescriptors.size()]);
             }
-
         }
         return super.checkFile(file, manager, isOnTheFly);
     }


### PR DESCRIPTION
Fixes #258 
- Call `getLanguageServers()` instead of `getLSWrappers()` in `LSPLocalInspectionTool.checkFile()` (inspection/diagnostic logic) to ensure language servers are properly initialized and the correct textDocument/didOpen requests are sent to language servers. 
- Updates org.jetbrains.intellij plugin to 1.12.0
- Add commented out logic to attach JVM debugger to LCLS