### PR TITLE
Issue 137

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -49,7 +49,6 @@ public class LibertyGeneralAction extends AnAction {
     public void setLibertyModule(LibertyModule libertyModule) {
         this.libertyModule = libertyModule;
         this.project = libertyModule.getProject();
-        this.projectName = libertyModule.getName();
         this.projectType = libertyModule.getProjectType();
         this.buildFile = libertyModule.getBuildFile();
     }
@@ -85,12 +84,28 @@ public class LibertyGeneralAction extends AnAction {
                 // Multiple projects. Pop up dialog for user to select.
                 else {
                     final String[] projectNames = toProjectNames(libertyModules);
+                    final String[] projectNamesTooltips = toProjectNamesTooltips(libertyModules);
+                    /*
                     final int ret = Messages.showChooseDialog(project,
                             LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
                             LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"),
                             LibertyPluginIcons.libertyIcon_40,
                             projectNames,
                             projectNames[0]);
+
+                     */
+
+                    LibertyProjectChooserDialog libertyChooserDiag = new LibertyProjectChooserDialog(
+                            project,
+                            LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
+                            LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"),
+                            LibertyPluginIcons.libertyIcon_40,
+                            projectNames,
+                            projectNamesTooltips,
+                            projectNames[0]);
+                    libertyChooserDiag.show();
+                    final int ret = libertyChooserDiag.getSelectedIndex();
+
                     if (ret >= 0 && ret < libertyModules.size()) {
                         setLibertyModule(libertyModules.get(ret));
                     }
@@ -138,6 +153,14 @@ public class LibertyGeneralAction extends AnAction {
         return projectNames;
     }
 
+    protected final String[] toProjectNamesTooltips(@NotNull List<LibertyModule> list) {
+        final int size = list.size();
+        final String[] projectNamesTooltips = new String[size];
+        for (int i = 0; i < size; ++i) {
+            projectNamesTooltips[i] = list.get(i).getBuildFile().getCanonicalPath();
+        }
+        return projectNamesTooltips;
+    }
     protected void setActionCmd(String actionCmd) {
         this.actionCmd = actionCmd;
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
@@ -28,6 +27,7 @@ import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
@@ -83,18 +83,17 @@ public class LibertyGeneralAction extends AnAction {
                 }
                 // Multiple projects. Pop up dialog for user to select.
                 else {
+                    // projectNames can contain entries that are of the same name if there are two
+                    // or more projects found using the same name but differentiated by existing in separate
+                    // project folders.
                     final String[] projectNames = toProjectNames(libertyModules);
+                    // tooltip strings will appear when user hovers over one of the projects in the dialog list
+                    // they will display the fully qualified path to the build file so that users can
+                    // differntiate in the case of same named application names in the chooser list
                     final String[] projectNamesTooltips = toProjectNamesTooltips(libertyModules);
-                    /*
-                    final int ret = Messages.showChooseDialog(project,
-                            LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
-                            LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.title"),
-                            LibertyPluginIcons.libertyIcon_40,
-                            projectNames,
-                            projectNames[0]);
 
-                     */
-
+                    // Create a Chooser Dialog for multiple projects. User can select which one they
+                    // are interested in from list
                     LibertyProjectChooserDialog libertyChooserDiag = new LibertyProjectChooserDialog(
                             project,
                             LocalizedResourceUtil.getMessage("liberty.project.file.selection.dialog.message", actionCmd),
@@ -147,8 +146,17 @@ public class LibertyGeneralAction extends AnAction {
     protected final String[] toProjectNames(@NotNull List<LibertyModule> list) {
         final int size = list.size();
         final String[] projectNames = new String[size];
+        String[] differentiator = null;
+
         for (int i = 0; i < size; ++i) {
-            projectNames[i] = list.get(i).getName();
+            // We need a differentiator for the Shift-Shift Dialog Chooser in the event two projects have the
+            // same name. get the build dir name where the build file resides to be that differentiator.
+            String parentFolderName = list.get(i).getBuildFile().getParent().getName();
+
+            // Use the parent folder name as a differntiator - add it to the string entry as
+            // part of the project name
+            // Entry in list will be of the form: "<app-name> : <buildfile parent folder>"
+            projectNames[i] = list.get(i).getName() + ": " + parentFolderName;
         }
         return projectNames;
     }
@@ -157,7 +165,7 @@ public class LibertyGeneralAction extends AnAction {
         final int size = list.size();
         final String[] projectNamesTooltips = new String[size];
         for (int i = 0; i < size; ++i) {
-            projectNamesTooltips[i] = list.get(i).getBuildFile().getCanonicalPath();
+            projectNamesTooltips[i] = String.valueOf(list.get(i).getBuildFile().toNioPath());
         }
         return projectNamesTooltips;
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectChooserDialog.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectChooserDialog.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.ui.ComboBox;
@@ -14,9 +23,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 
 public class LibertyProjectChooserDialog extends MessageDialog {
-    //private JPanel contentPane;
-    //private JButton buttonOK;
-    //private JButton buttonCancel;
     private ComboBox<String> myComboBox;
 
     public LibertyProjectChooserDialog(@Nullable Project project,
@@ -32,13 +38,6 @@ public class LibertyProjectChooserDialog extends MessageDialog {
         ComboboxToolTipRenderer renderer = new ComboboxToolTipRenderer();
         renderer.setTooltips(List.of(tooltips));
         myComboBox.setRenderer(renderer);
-    }
-
-    public int getSelectedIndex() {
-        if (getExitCode() == 0) {
-            return myComboBox.getSelectedIndex();
-        }
-        return -1;
     }
 
     @Override
@@ -60,14 +59,19 @@ public class LibertyProjectChooserDialog extends MessageDialog {
     @Override
     protected void doOKAction() {
         String inputString = myComboBox.getSelectedItem().toString().trim();
-        //if (myValidator == null || myValidator.checkInput(inputString) && myValidator.canClose(inputString)) {
-            super.doOKAction();
-        //}
+        super.doOKAction();
     }
 
     @Override
     public JComponent getPreferredFocusedComponent() {
         return myComboBox;
+    }
+
+    public int getSelectedIndex() {
+        if (getExitCode() == 0) {
+            return myComboBox.getSelectedIndex();
+        }
+        return -1;
     }
 }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectChooserDialog.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectChooserDialog.java
@@ -1,0 +1,93 @@
+package io.openliberty.tools.intellij.actions;
+
+import com.intellij.openapi.ui.ComboBox;
+
+import java.util.List;
+import javax.swing.*;
+import java.awt.*;
+
+import com.intellij.openapi.ui.messages.MessageDialog;
+import org.jetbrains.annotations.Nullable;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+
+public class LibertyProjectChooserDialog extends MessageDialog {
+    //private JPanel contentPane;
+    //private JButton buttonOK;
+    //private JButton buttonCancel;
+    private ComboBox<String> myComboBox;
+
+    public LibertyProjectChooserDialog(@Nullable Project project,
+                                       @NlsContexts.DialogMessage String message,
+                                       @NlsContexts.DialogTitle String title,
+                                       @Nullable Icon icon,
+                                       String[] values,
+                                       String[] tooltips,
+                                       @NlsSafe String initialValue) {
+        super(message, title, new String[]{Messages.getOkButton(), Messages.getCancelButton()}, 0, icon);
+        myComboBox.setModel(new DefaultComboBoxModel<>(values));
+        myComboBox.setSelectedItem(initialValue);
+        ComboboxToolTipRenderer renderer = new ComboboxToolTipRenderer();
+        renderer.setTooltips(List.of(tooltips));
+        myComboBox.setRenderer(renderer);
+    }
+
+    public int getSelectedIndex() {
+        if (getExitCode() == 0) {
+            return myComboBox.getSelectedIndex();
+        }
+        return -1;
+    }
+
+    @Override
+    protected JComponent createCenterPanel() {
+        return null;
+    }
+
+    @Override
+    protected JComponent createNorthPanel() {
+        JPanel panel = createIconPanel();
+        JPanel messagePanel = createMessagePanel();
+
+        myComboBox = new ComboBox<>(220);
+        messagePanel.add(myComboBox, BorderLayout.SOUTH);
+        panel.add(messagePanel, BorderLayout.CENTER);
+        return panel;
+    }
+
+    @Override
+    protected void doOKAction() {
+        String inputString = myComboBox.getSelectedItem().toString().trim();
+        //if (myValidator == null || myValidator.checkInput(inputString) && myValidator.canClose(inputString)) {
+            super.doOKAction();
+        //}
+    }
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return myComboBox;
+    }
+}
+
+class ComboboxToolTipRenderer extends DefaultListCellRenderer {
+    List<String> tooltips;
+
+    @Override
+    public Component getListCellRendererComponent(JList list, Object value,
+                                                  int index, boolean isSelected, boolean cellHasFocus) {
+
+        JComponent comp = (JComponent) super.getListCellRendererComponent(list,
+                value, index, isSelected, cellHasFocus);
+
+        if (-1 < index && null != value && null != tooltips) {
+            list.setToolTipText(tooltips.get(index));
+        }
+        return comp;
+    }
+
+    public void setTooltips(List<String> tooltips) {
+        this.tooltips = tooltips;
+    }
+}


### PR DESCRIPTION
in the case where there are multiple applications in the dashboard with the same name (think the start and finish apps in the guides) the Shift-Shift choice of liberty dashboard actions presents a dialog chooser that contains identical entries. This fix incorporates a tooltip hover action that displays the path to the build file for each app listed so the user may determine which one to choose. 

in the course of adding this i determined that the chooser dialog was always returning the initalValue set in the list when the same named app appeared more than once. this is because the underlying Dialog/Chooser implementation is matching the LibertyModule name it is looking for with the first name it finds in the list of choices when determining the index of the correct choice. i had to add an additional piece of data - the folder name that contains the build file from the buildPath string. This allows the Dialog matcher to match with the distinct app that the user chose from the list.