### PR TITLE
Add ManagedBeanConstructorQuickFix.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstructorQuickFix.java
@@ -1,0 +1,20 @@
+/* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.InsertAnnotationMissingQuickFix;
+
+public class ManagedBeanConstructorQuickFix extends InsertAnnotationMissingQuickFix {
+    public ManagedBeanConstructorQuickFix() {
+        super("jakarta.inject.Inject");
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -17,6 +17,8 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.AddPathParamQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketConstants;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.corrections.DiagnosticsHelper;
@@ -98,7 +100,7 @@ public class JakartaCodeActionHandler {
 //            RemoveInjectAnnotationQuickFix RemoveInjectAnnotationQuickFix = new RemoveInjectAnnotationQuickFix();
 //            RemoveProduceAnnotationQuickFix RemoveProduceAnnotationQuickFix = new RemoveProduceAnnotationQuickFix();
 //            RemoveInvalidInjectParamAnnotationQuickFix RemoveInvalidInjectParamAnnotationQuickFix = new RemoveInvalidInjectParamAnnotationQuickFix();
-//            AddPathParamQuickFix AddPathParamQuickFix = new AddPathParamQuickFix();
+            AddPathParamQuickFix AddPathParamQuickFix = new AddPathParamQuickFix();
 
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
                 try {
@@ -221,9 +223,9 @@ public class JakartaCodeActionHandler {
 //                        codeActions.addAll(RemovePreDestroyAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(WebSocketConstants.DIAGNOSTIC_CODE_PATH_PARAMS_ANNOT)) {
-//                        codeActions.addAll(AddPathParamQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(WebSocketConstants.DIAGNOSTIC_CODE_PATH_PARAMS_ANNOT)) {
+                        codeActions.addAll(AddPathParamQuickFix.getCodeActions(context, diagnostic));
+                    }
                 } catch (Exception e) {
                     LOGGER.warn("Exception scanning diagnostics", e); // TODO do we need this? Remove if possible
                 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Red Hat, Inc.
+ * Copyright (c) 2019, 2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -13,6 +13,8 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction;
 
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
@@ -79,7 +81,7 @@ public class JakartaCodeActionHandler {
 //            PersistenceEntityQuickFix PersistenceEntityQuickFix = new PersistenceEntityQuickFix();
 //            ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
 //            BeanValidationQuickFix BeanValidationQuickFix = new BeanValidationQuickFix();
-//            ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
+            ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
 //            ManagedBeanNoArgConstructorQuickFix ManagedBeanNoArgConstructorQuickFix = new ManagedBeanNoArgConstructorQuickFix();
 //            JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
 //            JsonbTransientAnnotationQuickFix JsonbTransientAnnotationQuickFix = new JsonbTransientAnnotationQuickFix();
@@ -177,10 +179,10 @@ public class JakartaCodeActionHandler {
 //                            .equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
 //                        codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
-//                        codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
+                        codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic));
 //                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    }
 //                    if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
 //                        codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *     IBM Corporation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
+
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.InsertAnnotationProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * QuickFix for inserting annotations.
+ * Reused from https://github.com/eclipse/lsp4mp/blob/6f2d700a88a3262e39cc2ba04beedb429e162246/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class InsertAnnotationMissingQuickFix {
+    private static final Logger LOGGER = Logger.getLogger(InsertAnnotationMissingQuickFix.class.getName());
+    private static final String ANNOTATION_KEY = "annotation";
+
+    private final String[] annotations;
+
+    private final boolean generateOnlyOneCodeAction;
+
+    /**
+     * Constructor for insert annotation quick fix.
+     *
+     * <p>
+     * The participant will generate a CodeAction per annotation.
+     * </p>
+     *
+     * @param annotations list of annotation to insert.
+     */
+    public InsertAnnotationMissingQuickFix(String... annotations) {
+        this(false, annotations);
+    }
+
+    /**
+     * Constructor for insert annotation quick fix.
+     *
+     * @param generateOnlyOneCodeAction true if the participant must generate a
+     *                                  CodeAction which insert the list of
+     *                                  annotation and false otherwise.
+     * @param annotations               list of annotation to insert.
+     */
+    public InsertAnnotationMissingQuickFix(boolean generateOnlyOneCodeAction, String... annotations) {
+        this.generateOnlyOneCodeAction = generateOnlyOneCodeAction;
+        this.annotations = annotations;
+    }
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
+        insertAnnotations(diagnostic, context, codeActions);
+        return codeActions;
+    }
+
+    protected PsiModifierListOwner getBinding(PsiElement node) {
+        PsiModifierListOwner binding = PsiTreeUtil.getParentOfType(node, PsiVariable.class);
+        if (binding != null) {
+            return binding;
+        }
+        binding = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+        if (binding != null) {
+            return binding;
+        }
+        return PsiTreeUtil.getParentOfType(node, PsiClass.class);
+    }
+
+    protected String[] getAnnotations() {
+        return this.annotations;
+    }
+
+    protected void insertAnnotations(Diagnostic diagnostic, JavaCodeActionContext context,
+                                     List<CodeAction> codeActions) {
+        if (generateOnlyOneCodeAction) {
+            insertAnnotation(diagnostic, context, codeActions, annotations);
+        } else {
+            for (String annotation : annotations) {
+                JavaCodeActionContext annotationContext = context.copy();
+                insertAnnotation(diagnostic, annotationContext, codeActions, annotation);
+            }
+        }
+    }
+
+    protected void insertAnnotation(Diagnostic diagnostic, JavaCodeActionContext context,
+            List<CodeAction> codeActions, String... annotations) {
+        String name = getLabel(annotations);
+        PsiElement node = context.getCoveringNode();
+        PsiModifierListOwner parentType = getBinding(node);
+
+        ChangeCorrectionProposal proposal = new InsertAnnotationProposal(name, context.getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, context.getSource().getCompilationUnit(),
+                annotations);
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+    }
+
+    private static String getLabel(String[] annotations) {
+        StringBuilder name = new StringBuilder("Insert ");
+        for (int i = 0; i < annotations.length; i++) {
+            String annotation = annotations[i];
+            String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+            if (i > 0) {
+                name.append(", ");
+            }
+            name.append("@");
+            name.append(annotationName);
+        }
+        return name.toString();
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/AddPathParamQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/AddPathParamQuickFix.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lidia Ataupillco Ramos - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.InsertAnnotationQuickFix;
+
+/**
+ * Quick fix for adding the @PathParam annotation when one or more
+ * parameters on a method annotated endpoint class decorated with
+ * any of the annotations @OnMessage, @OnOpen, @OnClose, @OnError
+ *
+ * @author Lidia Ataupillco Ramos
+ */
+public class AddPathParamQuickFix extends InsertAnnotationQuickFix {
+    public AddPathParamQuickFix() {
+        super("jakarta.websocket.server.PathParam", false, "value");
+    }
+}


### PR DESCRIPTION
This quick fix enables the addition of the @Inject annotation on a constructor as demonstrated in the test case: jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBeanConstructor.java

This code assumes IntelliJ will add the import statement as part of reformatting. I believe this dependency is also part of the MicroProfile quick fixes. 

Also assuming we do not update the copyright if there were no changes other than the package name. Feel free to comment.