### PR TITLE
Fixes #288 - fix ExternalAnnotator sync issues, disable LocalInspectionTool

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/diagnostics/LSPLocalInspectionTool.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/operations/diagnostics/LSPLocalInspectionTool.java
@@ -63,33 +63,33 @@ public class LSPLocalInspectionTool extends LocalInspectionTool implements Exter
     @Nullable
     @Override
     public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
-        VirtualFile virtualFile = file.getVirtualFile();
-        if (virtualFile != null) {
-            Editor editor = LSPIJUtils.editorForFile(virtualFile);
-            if (editor != null) {
-                // initializes language servers and connects them to the given document if they haven't already started, do not wait for them to start (avoiding blocking the main thread)
-                LanguageServiceAccessor.getInstance(editor.getProject()).getLanguageServers(editor.getDocument(),
-                        capabilities -> true);
-                List<ProblemDescriptor> problemDescriptors = new ArrayList<>();
-                // get the started language servers and check if there are any valid markers (diagnostics) to create problemDescriptors for
-                for (LanguageServerWrapper wrapper : LanguageServiceAccessor.getInstance(file.getProject()).getMatchingStartedWrappers(virtualFile, serverCapabilities -> true)) {
-                    RangeHighlighter[] highlighters = LSPDiagnosticsToMarkers.getMarkers(editor, wrapper.serverDefinition.id);
-                    if (highlighters != null) {
-                        for (RangeHighlighter highlighter : highlighters) {
-                            PsiElement element;
-                            if (highlighter.getEndOffset() - highlighter.getStartOffset() > 0) {
-                                element = new LSPPSiElement(editor.getProject(), file, highlighter.getStartOffset(), highlighter.getEndOffset(), editor.getDocument().getText(new TextRange(highlighter.getStartOffset(), highlighter.getEndOffset())));
-                            } else {
-                                element = PsiUtilCore.getElementAtOffset(file, highlighter.getStartOffset());
-                            }
-                            ProblemHighlightType highlightType = getHighlightType(((Diagnostic) highlighter.getErrorStripeTooltip()).getSeverity());
-                            problemDescriptors.add(manager.createProblemDescriptor(element, ((Diagnostic) highlighter.getErrorStripeTooltip()).getMessage(), true, highlightType, isOnTheFly));
-                        }
-                    }
-                }
-                return problemDescriptors.toArray(new ProblemDescriptor[problemDescriptors.size()]);
-            }
-        }
+        // VirtualFile virtualFile = file.getVirtualFile();
+        // if (virtualFile != null) {
+        //     Editor editor = LSPIJUtils.editorForFile(virtualFile);
+        //     if (editor != null) {
+        //         // initializes language servers and connects them to the given document if they haven't already started, do not wait for them to start (avoiding blocking the main thread)
+        //         LanguageServiceAccessor.getInstance(editor.getProject()).getLanguageServers(editor.getDocument(),
+        //                 capabilities -> true);
+        //         List<ProblemDescriptor> problemDescriptors = new ArrayList<>();
+        //         // get the started language servers and check if there are any valid markers (diagnostics) to create problemDescriptors for
+        //         for (LanguageServerWrapper wrapper : LanguageServiceAccessor.getInstance(file.getProject()).getMatchingStartedWrappers(virtualFile, serverCapabilities -> true)) {
+        //             RangeHighlighter[] highlighters = LSPDiagnosticsToMarkers.getMarkers(editor, wrapper.serverDefinition.id);
+        //             if (highlighters != null) {
+        //                 for (RangeHighlighter highlighter : highlighters) {
+        //                     PsiElement element;
+        //                     if (highlighter.getEndOffset() - highlighter.getStartOffset() > 0) {
+        //                         element = new LSPPSiElement(editor.getProject(), file, highlighter.getStartOffset(), highlighter.getEndOffset(), editor.getDocument().getText(new TextRange(highlighter.getStartOffset(), highlighter.getEndOffset())));
+        //                     } else {
+        //                         element = PsiUtilCore.getElementAtOffset(file, highlighter.getStartOffset());
+        //                     }
+        //                     ProblemHighlightType highlightType = getHighlightType(((Diagnostic) highlighter.getErrorStripeTooltip()).getSeverity());
+        //                     problemDescriptors.add(manager.createProblemDescriptor(element, ((Diagnostic) highlighter.getErrorStripeTooltip()).getMessage(), true, highlightType, isOnTheFly));
+        //                 }
+        //             }
+        //         }
+        //         return problemDescriptors.toArray(new ProblemDescriptor[problemDescriptors.size()]);
+        //     }
+        // }
         return super.checkFile(file, manager, isOnTheFly);
     }
 


### PR DESCRIPTION
Move all logic to run in the `apply` step, which seems to work in our favor for the timing of when it runs compared to our diagnostics getting accepted. Seems to fix the syncing issues.