### PR TITLE
Try/catch out of bounds when applying text edits.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LSPIJUtils.java
@@ -215,12 +215,18 @@ public class LSPIJUtils {
         for(TextEdit edit : edits) {
             if (edit.getRange() != null) {
                 String text = edit.getNewText();
+                // compute start and end char offsets of the new Edit text
                 int start = toOffset(edit.getRange().getStart(), document);
-                int end = toOffset(edit.getRange().getEnd(), document);
+                int end;
+                try {
+                    end = toOffset(edit.getRange().getEnd(), document); // get endoffset of new edit from current document, out of bounds if new text doc has more lines
+                } catch (IndexOutOfBoundsException e) { // likely trying to get end of document
+                    end = document.getTextLength();
+                }
                 if (StringUtils.isEmpty(text)) {
                     document.deleteString(start, end);
                 } else {
-                    text = text.replaceAll("\r", "");
+                    text = text.replaceAll("\r", ""); // removes carriage return
                     if (end >= 0) {
                         if (end - start <= 0) {
                             document.insertString(start, text);


### PR DESCRIPTION
The `toOffset` method would get out of bounds because the it was using the line numbers from the new text, but trying to calculate using the pre-change document.

Added a try/catch to use the end offset of the original document instead.

Fixes some of the quickfixes in #122 
- HealthAnnotationMissingQuickFix
- InsertAnnotationMissingQuickFix
- MicroProfileGenerateOpenAPIOperation
- ApplicationScopedAnnotationMissingQuickFix