### PR TITLE
Adding a quick fix for removing annotations from method parameters.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveInvalidInjectParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveInvalidInjectParamAnnotationQuickFix.java
@@ -1,5 +1,5 @@
  /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveInvalidInjectParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveInvalidInjectParamAnnotationQuickFix.java
@@ -1,0 +1,28 @@
+ /*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveParamAnnotationQuickFix;
+
+import java.util.Arrays;
+
+ /**
+ * QuickFix for deleting any of @Disposes, @Observes and @ObservesAsync annotation for parameters
+ */
+public class RemoveInvalidInjectParamAnnotationQuickFix extends RemoveParamAnnotationQuickFix {
+
+    public RemoveInvalidInjectParamAnnotationQuickFix() {
+    	super(Arrays.copyOf(ManagedBeanConstants.INVALID_INJECT_PARAMS_FQ,
+                ManagedBeanConstants.INVALID_INJECT_PARAMS_FQ.length));
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveInvalidInjectParamAnnotationQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.HttpServletQuickFix;
@@ -109,7 +110,7 @@ public class JakartaCodeActionHandler {
             RemoveAbstractModifierQuickFix RemoveAbstractModifierQuickFix = new RemoveAbstractModifierQuickFix();
 //            RemoveInjectAnnotationQuickFix RemoveInjectAnnotationQuickFix = new RemoveInjectAnnotationQuickFix();
 //            RemoveProduceAnnotationQuickFix RemoveProduceAnnotationQuickFix = new RemoveProduceAnnotationQuickFix();
-//            RemoveInvalidInjectParamAnnotationQuickFix RemoveInvalidInjectParamAnnotationQuickFix = new RemoveInvalidInjectParamAnnotationQuickFix();
+            RemoveInvalidInjectParamAnnotationQuickFix RemoveInvalidInjectParamAnnotationQuickFix = new RemoveInvalidInjectParamAnnotationQuickFix();
             AddPathParamQuickFix AddPathParamQuickFix = new AddPathParamQuickFix();
 
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
@@ -178,14 +179,14 @@ public class JakartaCodeActionHandler {
 //                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_PRODUCES_INJECT)) {
 //                        codeActions.addAll(ConflictProducesInjectQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_INJECT_PARAM)) {
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_INJECT_PARAM)) {
 //                        codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
-//                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_PRODUCES_PARAM)) {
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic));
+                    }
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_PRODUCES_PARAM)) {
 //                        codeActions.addAll(RemoveProduceAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic));
+                    }
 //                    if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
 //                            || diagnostic.getCode().getLeft()
 //                            .equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/RemoveAnnotationsProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/RemoveAnnotationsProposal.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiModifierListOwner;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeActionKind;
+
+import java.util.List;
+
+public class RemoveAnnotationsProposal extends ChangeCorrectionProposal {
+
+    private final PsiFile invocationNode;
+    private final PsiModifierListOwner binding;
+    private final List<PsiAnnotation> annotationsToRemove;
+
+    public RemoveAnnotationsProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+                                     PsiModifierListOwner binding, int relevance,
+                                     List<PsiAnnotation> annotationsToRemove) {
+        super(label, CodeActionKind.QuickFix, relevance);
+        this.invocationNode = invocationNode;
+        this.binding = binding;
+        this.annotationsToRemove = annotationsToRemove;
+    }
+
+    @Override
+    public Change getChange() {
+        annotationsToRemove.forEach(a -> {
+            a.delete();
+        });
+        final Document document = invocationNode.getViewProvider().getDocument();
+        return new Change(document, document);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -66,22 +66,19 @@ public class RemoveModifierConflictQuickFix {
     
 
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
-        PsiElement node = context.getCoveredNode();
-        PsiClass parentType = getBinding(node);
-
         List<CodeAction> codeActions = new ArrayList<>();
-        removeModifiers(diagnostic, context, parentType, codeActions);
-
+        removeModifiers(diagnostic, context, codeActions);
         return codeActions;
     }
     
-    protected void removeModifiers(Diagnostic diagnostic, JavaCodeActionContext context, PsiClass parentType,
+    protected void removeModifiers(Diagnostic diagnostic, JavaCodeActionContext context,
             List<CodeAction> codeActions) {
-        if (generateOnlyOneCodeAction) {
-            removeModifier(diagnostic, context, parentType, codeActions, modifiers);
+        if (generateOnlyOneCodeAction || modifiers.length == 1) {
+            removeModifier(diagnostic, context, codeActions, modifiers);
         } else {
+            // Clone the psi.FileViewProvider for each CodeAction.
             for (String modifier : modifiers) {
-                removeModifier(diagnostic, context, parentType, codeActions, modifier);
+                removeModifier(diagnostic, context.copy(), codeActions, modifier);
             }
         }
     }
@@ -90,9 +87,10 @@ public class RemoveModifierConflictQuickFix {
      * use setData() API with diagnostic to pass in ElementType in diagnostic collector class.
      *
      */
-    private void removeModifier(Diagnostic diagnostic, JavaCodeActionContext context, PsiClass parentType,
+    private void removeModifier(Diagnostic diagnostic, JavaCodeActionContext context,
             List<CodeAction> codeActions, String... modifier) {
         PsiElement node = context.getCoveredNode();
+        PsiClass parentType = getBinding(node);
         PsiModifierListOwner modifierListOwner = PsiTreeUtil.getParentOfType(node, PsiModifierListOwner.class);
 
         String type = "";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -1,0 +1,112 @@
+ /*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
+
+ import com.intellij.psi.*;
+ import com.intellij.psi.util.PsiTreeUtil;
+ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.RemoveAnnotationsProposal;
+ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+ import org.eclipse.lsp4j.CodeAction;
+ import org.eclipse.lsp4j.Diagnostic;
+
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.List;
+
+ /**
+  * QuickFix for removing parameter annotations
+  */
+public class RemoveParamAnnotationQuickFix {
+
+	private final String[] annotations;
+	
+    public RemoveParamAnnotationQuickFix(String ...annotations) {
+        this.annotations = annotations;
+    }
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+
+        final PsiElement node = context.getCoveredNode();
+        final PsiMethod method = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+
+        final List<CodeAction> codeActions = new ArrayList<>();
+        final PsiParameterList parameters = method.getParameterList();
+        int parametersCount = parameters.getParametersCount();
+        for (int i = 0; i < parametersCount; ++i) {
+            final PsiParameter parameter = parameters.getParameter(i);
+            final PsiAnnotation[] psiAnnotations = parameter.getAnnotations();
+            final List<String> annotationsToRemove = new ArrayList<>();
+            // Search for annotations to remove from the current method parameter.
+            if (psiAnnotations != null) {
+                Arrays.stream(psiAnnotations).forEach(a -> {
+                    if (Arrays.stream(annotations).anyMatch(m -> m.equals(a.getQualifiedName()))) {
+                        annotationsToRemove.add(a.getQualifiedName());
+                    }
+                });
+            }
+            if (!annotationsToRemove.isEmpty()) {
+                // Create label
+                final StringBuilder sb = new StringBuilder("Remove the ");
+                sb.append("'@").append(getShortName(annotationsToRemove.get(0))).append("'");
+                for (int j = 1; j < annotationsToRemove.size(); ++j) {
+                    sb.append(", '@").append(getShortName(annotationsToRemove.get(j))).append("'");
+                }
+                sb.append(" annotation");
+                if (annotationsToRemove.size() > 1) {
+                    sb.append('s');
+                }
+                sb.append(" from parameter '").append(parameter.getName()).append("'");
+                // Remove annotations
+                removeAnnotations(diagnostic, context.copy(), codeActions, i, sb.toString(), annotationsToRemove);
+            }
+        }
+        return codeActions;
+    }
+
+    protected void removeAnnotations(Diagnostic diagnostic, JavaCodeActionContext context,
+                                     List<CodeAction> codeActions, int parameterIndex,
+                                     String label, List<String> annotationsToRemove) {
+
+        final PsiElement node = context.getCoveredNode();
+        final PsiClass parentType = getBinding(node);
+        final PsiMethod method = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+
+        final PsiParameter parameter = method.getParameterList().getParameter(parameterIndex);
+        final PsiAnnotation[] psiAnnotations = parameter.getAnnotations();
+        final List<PsiAnnotation> psiAnnotationsToRemove = new ArrayList<>();
+        Arrays.stream(psiAnnotations).forEach(a -> {
+            if (annotationsToRemove.stream().anyMatch(m -> m.equals(a.getQualifiedName()))) {
+                psiAnnotationsToRemove.add(a);
+            }
+        });
+
+        RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(label, context.getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, psiAnnotationsToRemove);
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+    }
+
+    protected PsiClass getBinding(PsiElement node) {
+        return PsiTreeUtil.getParentOfType(node, PsiClass.class);
+    }
+
+    protected static String getShortName(String qualifiedName) {
+        final int i = qualifiedName.lastIndexOf('.');
+        if (i != -1) {
+            return qualifiedName.substring(i+1);
+        }
+        return qualifiedName;
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -1,5 +1,5 @@
  /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Resolves #314.

I've been using: https://github.com/eclipse/lsp4jakarta/blob/main/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java to test these changes. Looks like there's a scaling issue with Jakarta when there a lot of code actions being produced. Only seeing the quick fixes in IntelliJ when the test case is reduced to one or a few methods.