### PR TITLE
Add a quick fix for the @PostConstruct annotation

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -12,12 +12,10 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations;
 
-import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiPrimitiveType;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.psi.util.PsiUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyReturnTypeProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiPrimitiveType;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.util.PsiUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyReturnTypeProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quick fix for AnnotationDiagnosticsCollector that changes the return type of a method to void.
+ * Uses ModifyReturnTypeProposal.
+ *
+ * @author Yijia Jing
+ *
+ */
+public class PostConstructReturnTypeQuickFix {
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
+        PsiElement node = context.getCoveredNode();
+        PsiMethod parentType = getBinding(node);
+        String name = "Change return type to void";
+        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(name, context.getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, PsiPrimitiveType.VOID);
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        codeActions.add(codeAction);
+        return codeActions;
+    }
+
+    protected PsiMethod getBinding(PsiElement node) {
+        if (node instanceof PsiMethod) {
+            return (PsiMethod) node;
+        }
+        return PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -13,6 +13,7 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction;
 
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.PostConstructReturnTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanNoArgConstructorQuickFix;
@@ -102,7 +103,7 @@ public class JakartaCodeActionHandler {
 //            ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
 //            RemovePreDestroyAnnotationQuickFix RemovePreDestroyAnnotationQuickFix = new RemovePreDestroyAnnotationQuickFix();
 //            RemovePostConstructAnnotationQuickFix RemovePostConstructAnnotationQuickFix = new RemovePostConstructAnnotationQuickFix();
-//            PostConstructReturnTypeQuickFix PostConstructReturnTypeQuickFix = new PostConstructReturnTypeQuickFix();
+            PostConstructReturnTypeQuickFix PostConstructReturnTypeQuickFix = new PostConstructReturnTypeQuickFix();
             RemoveFinalModifierQuickFix RemoveFinalModifierQuickFix = new RemoveFinalModifierQuickFix();
             RemoveStaticModifierQuickFix RemoveStaticModifierQuickFix = new RemoveStaticModifierQuickFix();
 //            RemoveMethodParametersQuickFix RemoveMethodParametersQuickFix = new RemoveMethodParametersQuickFix();
@@ -131,9 +132,9 @@ public class JakartaCodeActionHandler {
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_MISSING_RESOURCE_TYPE_ATTRIBUTE)) {
                         codeActions.addAll(AddResourceMissingTypeQuickFix.getCodeActions(context, diagnostic));
                     }
-//                    if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_RETURN_TYPE)) {
-//                        codeActions.addAll(PostConstructReturnTypeQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_RETURN_TYPE)) {
+                        codeActions.addAll(PostConstructReturnTypeQuickFix.getCodeActions(context, diagnostic));
+                    }
 //                    if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTE)
 //                            || diagnostic.getCode().getLeft()
 //                            .equals(ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES)) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -132,7 +132,7 @@ public class JakartaCodeActionHandler {
                         codeActions.addAll(AddResourceMissingTypeQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_RETURN_TYPE)) {
-                        codeActions.addAll(PostConstructReturnTypeQuickFix.getCodeActions(context, diagnostic, monitor));
+                        codeActions.addAll(PostConstructReturnTypeQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTE)
                             || diagnostic.getCode().getLeft()

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyReturnTypeProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyReturnTypeProposal.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.*;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.PostConstructReturnTypeQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.JakartaCodeActionHandler;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeActionKind;
+
+/**
+ * Code action proposal for changing the return type of a method.
+ *
+ * @author Yijia Jing
+ * @see JakartaCodeActionHandler
+ * @see PostConstructReturnTypeQuickFix
+ *
+ */
+public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
+
+    private final PsiFile invocationNode;
+    private final PsiElement binding;
+    private final PsiType newReturnType;
+
+    /**
+     * Constructor for ModifyReturnTypeProposal that accepts the new return type of a method.
+     *
+     * @param newReturnType the new return type to change to
+     */
+    public ModifyReturnTypeProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+                                    PsiElement binding, int relevance, PsiType newReturnType) {
+        super(label, CodeActionKind.QuickFix, relevance);
+        this.invocationNode = invocationNode;
+        this.binding = binding;
+        this.newReturnType = newReturnType;
+    }
+
+    @SuppressWarnings("restriction")
+    @Override
+    public Change getChange() {
+        if (binding instanceof PsiMethod) {
+            PsiMethod method = ((PsiMethod) binding);
+            PsiTypeElement oldType = method.getReturnTypeElement();
+            PsiElementFactory factory = JavaPsiFacade.getInstance(binding.getProject()).getElementFactory();
+            PsiTypeElement newType = factory.createTypeElement(newReturnType);
+            if (oldType != null) {
+                oldType.replace(newType);
+            }
+        }
+        final Document changed = invocationNode.getViewProvider().getDocument();
+        return new Change(changed, changed);
+    }
+}


### PR DESCRIPTION
Note that this quick fix changes the return type of the method but it does not try to rewrite all the `return` statements.

Fixes #316