### PR TITLE
Quick fixes related to RemoveAnnotationConflictQuickFix

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
+
+import com.google.gson.JsonArray;
+import com.intellij.psi.PsiElement;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveAnnotationConflictQuickFix;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
+    public ScopeDeclarationQuickFix() {
+        // annotation list to be derived from the diagnostic passed to
+        // `getCodeActions()`
+        super();
+    }
+
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        PsiElement node = context.getCoveredNode();
+        PsiElement parentType = getBinding(node);
+
+        JsonArray diagnosticData = (JsonArray) diagnostic.getData();
+
+        List<String> annotations = IntStream.range(0, diagnosticData.size())
+                .mapToObj(idx -> diagnosticData.get(idx).getAsString()).collect(Collectors.toList());
+
+        annotations.remove(ManagedBeanConstants.PRODUCES);
+
+        if (parentType != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+            /**
+             * for each annotation, choose the current annotation to keep and remove the
+             * rest since we can have at most one scope annotation.
+             */
+            for (String annotation : annotations) {
+                List<String> resultingAnnotations = new ArrayList<>(annotations);
+                resultingAnnotations.remove(annotation);
+                // For each list we will create one code action in its own context
+                JavaCodeActionContext newContext = context.copy();
+                PsiElement owningNode = getBinding(newContext.getCoveredNode());
+
+                removeAnnotation(diagnostic, newContext, owningNode, codeActions,
+                        resultingAnnotations.toArray(new String[] {}));
+            }
+
+            return codeActions;
+        }
+        return null;
+
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
@@ -44,13 +44,20 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
         annotations.remove(ManagedBeanConstants.PRODUCES);
 
         if (parentType != null) {
+
+            // Convert the short annotation names to their fully qualified equivalents.
+            List<String> fqAnnotations = new ArrayList<>();
+            for (String annotation : annotations) {
+                fqAnnotations.addAll(getFQAnnotationNames(parentType.getProject(), annotation));
+            }
+
             List<CodeAction> codeActions = new ArrayList<>();
             /**
              * for each annotation, choose the current annotation to keep and remove the
              * rest since we can have at most one scope annotation.
              */
-            for (String annotation : annotations) {
-                List<String> resultingAnnotations = new ArrayList<>(annotations);
+            for (String annotation : fqAnnotations) {
+                List<String> resultingAnnotations = new ArrayList<>(fqAnnotations);
                 resultingAnnotations.remove(annotation);
                 // For each list we will create one code action in its own context
                 JavaCodeActionContext newContext = context.copy();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -16,11 +16,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationCo
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.PostConstructReturnTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationQuickFix;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanNoArgConstructorQuickFix;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanQuickFix;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveInvalidInjectParamAnnotationQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSConstants;
@@ -106,7 +102,7 @@ public class JakartaCodeActionHandler {
             ManagedBeanNoArgConstructorQuickFix ManagedBeanNoArgConstructorQuickFix = new ManagedBeanNoArgConstructorQuickFix();
 //            JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
             JsonbTransientAnnotationQuickFix JsonbTransientAnnotationQuickFix = new JsonbTransientAnnotationQuickFix();
-//            ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
+            ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
 //            RemovePreDestroyAnnotationQuickFix RemovePreDestroyAnnotationQuickFix = new RemovePreDestroyAnnotationQuickFix();
 //            RemovePostConstructAnnotationQuickFix RemovePostConstructAnnotationQuickFix = new RemovePostConstructAnnotationQuickFix();
             PostConstructReturnTypeQuickFix PostConstructReturnTypeQuickFix = new PostConstructReturnTypeQuickFix();
@@ -207,9 +203,9 @@ public class JakartaCodeActionHandler {
                     if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION_TRANSIENT_FIELD)) {
                         codeActions.addAll(JsonbTransientAnnotationQuickFix.getCodeActions(context, diagnostic));
                     }
-//                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_SCOPEDECL)) {
-//                        codeActions.addAll(ScopeDeclarationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_SCOPEDECL)) {
+                        codeActions.addAll(ScopeDeclarationQuickFix.getCodeActions(context, diagnostic));
+                    }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL)) {
 //                        codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                         codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(context, diagnostic));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -26,6 +26,8 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.A
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NoResourcePublicConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NonPublicResourceMethodQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb.JsonbConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb.JsonbTransientAnnotationQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceAnnotationQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.*;
@@ -103,7 +105,7 @@ public class JakartaCodeActionHandler {
             ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
             ManagedBeanNoArgConstructorQuickFix ManagedBeanNoArgConstructorQuickFix = new ManagedBeanNoArgConstructorQuickFix();
 //            JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
-//            JsonbTransientAnnotationQuickFix JsonbTransientAnnotationQuickFix = new JsonbTransientAnnotationQuickFix();
+            JsonbTransientAnnotationQuickFix JsonbTransientAnnotationQuickFix = new JsonbTransientAnnotationQuickFix();
 //            ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
 //            RemovePreDestroyAnnotationQuickFix RemovePreDestroyAnnotationQuickFix = new RemovePreDestroyAnnotationQuickFix();
 //            RemovePostConstructAnnotationQuickFix RemovePostConstructAnnotationQuickFix = new RemovePostConstructAnnotationQuickFix();
@@ -202,9 +204,9 @@ public class JakartaCodeActionHandler {
 //                    if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
 //                        codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION_TRANSIENT_FIELD)) {
-//                        codeActions.addAll(JsonbTransientAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION_TRANSIENT_FIELD)) {
+                        codeActions.addAll(JsonbTransientAnnotationQuickFix.getCodeActions(context, diagnostic));
+                    }
 //                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_SCOPEDECL)) {
 //                        codeActions.addAll(ScopeDeclarationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
@@ -14,10 +14,7 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal;
 
 import com.intellij.openapi.editor.Document;
-import com.intellij.psi.PsiAnnotation;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiVariable;
+import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -62,11 +59,12 @@ public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
 
     @Override
     public Change getChange() {
-        if (declaringNode instanceof PsiVariable) {
-            PsiVariable targetNode = ((PsiVariable) declaringNode);
+        if (declaringNode instanceof PsiModifierListOwner) {
+            PsiModifierListOwner targetNode = ((PsiModifierListOwner) declaringNode);
             PsiAnnotation[] targetAnnotations = targetNode.getAnnotations();
             for (var annotation : targetAnnotations) {
-                if (Arrays.stream(annotations).anyMatch(a -> a.equals(annotation.getQualifiedName()))) {
+                // Allow the names in targetAnnotations to be fully qualified or short (no package name).
+                if (Arrays.stream(annotations).anyMatch(a -> annotation.getQualifiedName().endsWith(a))) {
                     annotation.delete();
                 }
             }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Jianing Xu - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiVariable;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeActionKind;
+
+import java.util.Arrays;
+
+/**
+ *
+ * Code action proposal for deleting an existing annotation for
+ * MethodDeclaration/Field.
+ *
+ * Author: Jianing Xu
+ *
+ */
+public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
+    private final PsiFile fInvocationNode;
+    private final PsiElement fBinding;
+
+    private final String[] annotations;
+    private final PsiElement declaringNode;
+
+    /**
+     * Constructor for DeleteAnnotationProposal
+     *
+     * @param label          - annotation label
+     * @param targetCU       - the entire Java compilation unit
+     * @param invocationNode
+     * @param binding
+     * @param relevance
+     * @param declaringNode  - declaringNode covered node of diagnostic
+     * @param annotations
+     *
+     */
+    public DeleteAnnotationProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+                                    PsiElement binding, int relevance, PsiElement declaringNode, String... annotations) {
+        super(label, CodeActionKind.QuickFix, relevance);
+        this.fInvocationNode = invocationNode;
+        this.fBinding = binding;
+        this.declaringNode = declaringNode;
+        this.annotations = annotations;
+    }
+
+    @Override
+    public Change getChange() {
+        if (declaringNode instanceof PsiVariable) {
+            PsiVariable targetNode = ((PsiVariable) declaringNode);
+            PsiAnnotation[] targetAnnotations = targetNode.getAnnotations();
+            for (var annotation : targetAnnotations) {
+                if (Arrays.stream(annotations).anyMatch(a -> a.equals(annotation.getQualifiedName()))) {
+                    annotation.delete();
+                }
+            }
+        }
+        final Document document = fInvocationNode.getViewProvider().getDocument();
+        return new Change(document, document);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
@@ -64,7 +64,7 @@ public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
             PsiAnnotation[] targetAnnotations = targetNode.getAnnotations();
             for (var annotation : targetAnnotations) {
                 // Allow the names in targetAnnotations to be fully qualified or short (no package name).
-                if (Arrays.stream(annotations).anyMatch(a -> annotation.getQualifiedName().endsWith(a))) {
+                if (Arrays.stream(annotations).anyMatch(a -> annotation.getQualifiedName().equals(a))) {
                     annotation.delete();
                 }
             }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *     IBM Corporation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiVariable;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.DeleteAnnotationProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * QuickFix for removing annotations. Modified from
+ * https://github.com/eclipse/lsp4mp/blob/6f2d700a88a3262e39cc2ba04beedb429e162246/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class RemoveAnnotationConflictQuickFix {
+    private final String[] annotations;
+
+    protected final boolean generateOnlyOneCodeAction;
+
+    /**
+     * Constructor for remove annotation quick fix.
+     *
+     * <p>
+     * The participant will generate a CodeAction per annotation.
+     * </p>
+     *
+     * @param annotations list of annotation to insert.
+     */
+    public RemoveAnnotationConflictQuickFix(String... annotations) {
+        this(false, annotations);
+    }
+
+    /**
+     * Constructor for remove annotation quick fix.
+     *
+     * @param generateOnlyOneCodeAction true if the participant must generate a
+     *                                  CodeAction which insert the list of
+     *                                  annotation and false otherwise.
+     * @param annotations               list of annotation to insert.
+     */
+    public RemoveAnnotationConflictQuickFix(boolean generateOnlyOneCodeAction, String... annotations) {
+        this.generateOnlyOneCodeAction = generateOnlyOneCodeAction;
+        this.annotations = annotations;
+    }
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        PsiElement node = context.getCoveredNode();
+        PsiElement parentType = getBinding(node);
+        if (parentType != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+            removeAnnotations(diagnostic, context, parentType, codeActions);
+            return codeActions;
+        }
+        return null;
+
+    }
+
+    protected void removeAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, PsiElement parentType,
+                                     List<CodeAction> codeActions) {
+        if (generateOnlyOneCodeAction) {
+            removeAnnotation(diagnostic, context, parentType, codeActions, annotations);
+        } else {
+            for (String annotation : annotations) {
+                removeAnnotation(diagnostic, context, parentType, codeActions, annotation);
+            }
+        }
+    }
+
+    protected static void removeAnnotation(Diagnostic diagnostic, JavaCodeActionContext context, PsiElement parentType,
+                                           List<CodeAction> codeActions, String... annotations) {
+        // Remove the annotation and the proper import by using JDT Core Manipulation
+        // API
+        String name = getLabel(annotations);
+        PsiElement declaringNode = getBinding(context.getCoveredNode());
+        ChangeCorrectionProposal proposal = new DeleteAnnotationProposal(name, context.getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, declaringNode, annotations);
+        // Convert the proposal to LSP4J CodeAction
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+    }
+
+    protected static PsiElement getBinding(PsiElement node) {
+        PsiElement parent = PsiTreeUtil.getParentOfType(node, PsiVariable.class);
+        if (parent != null) {
+            return parent;
+        }
+        return PsiTreeUtil.getParentOfType(node, PsiClass.class);
+    }
+
+    protected String[] getAnnotations() {
+        return this.annotations;
+    }
+
+    private static String getLabel(String[] annotations) {
+        StringBuilder name = new StringBuilder("Remove ");
+        for (int i = 0; i < annotations.length; i++) {
+            String annotation = annotations[i];
+            String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+            if (i > 0) {
+                name.append(", ");
+            }
+            name.append("@");
+            name.append(annotationName);
+        }
+        return name.toString();
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -14,10 +14,12 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiModifierListOwner;
-import com.intellij.psi.PsiVariable;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.PsiShortNamesCache;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.DeleteAnnotationProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
@@ -26,7 +28,9 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * QuickFix for removing annotations. Modified from
@@ -116,6 +120,13 @@ public class RemoveAnnotationConflictQuickFix {
 
     protected String[] getAnnotations() {
         return this.annotations;
+    }
+
+    protected List<String> getFQAnnotationNames(Project p, String annotationName) {
+        // Look up short names on the classpath to find FQnames. Multiple classes differ in package names.
+        PsiShortNamesCache cache = PsiShortNamesCache.getInstance(p);
+        PsiClass[] classes = cache.getClassesByName(annotationName, GlobalSearchScope.allScope(p));
+        return Arrays.stream(classes).map(PsiClass::getQualifiedName).collect(Collectors.toList());
     }
 
     private static String getLabel(String[] annotations) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -16,6 +16,7 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.qui
 
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiVariable;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.DeleteAnnotationProposal;
@@ -104,7 +105,7 @@ public class RemoveAnnotationConflictQuickFix {
     }
 
     protected static PsiElement getBinding(PsiElement node) {
-        PsiElement parent = PsiTreeUtil.getParentOfType(node, PsiVariable.class);
+        PsiElement parent = PsiTreeUtil.getParentOfType(node, PsiModifierListOwner.class);
         if (parent != null) {
             return parent;
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -84,7 +84,9 @@ public class RemoveAnnotationConflictQuickFix {
             removeAnnotation(diagnostic, context, parentType, codeActions, annotations);
         } else {
             for (String annotation : annotations) {
-                removeAnnotation(diagnostic, context, parentType, codeActions, annotation);
+                JavaCodeActionContext newContext = context.copy(); // each code action needs its own context
+                PsiElement selectedNode = getBinding(newContext.getCoveredNode());
+                removeAnnotation(diagnostic, newContext, selectedNode, codeActions, annotation);
             }
         }
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Adit Rada - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
+
+import com.google.gson.JsonArray;
+import com.intellij.psi.PsiElement;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * This class is used to provide options to remove multiple annotations
+ * at the same time. For example, "Remove @A, @B", "Remove @C, @D, @E".
+ *
+ * @author Adit Rada
+ *
+ */
+public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflictQuickFix {
+
+    public RemoveMultipleAnnotations() {
+        // annotation list to be derived from the diagnostic passed to
+        // `getCodeActions()`
+        super();
+    }
+
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        PsiElement node = context.getCoveredNode();
+        PsiElement parentType = getBinding(node);
+
+        JsonArray diagnosticData = (JsonArray) diagnostic.getData();
+
+        List<String> annotations = IntStream.range(0, diagnosticData.size())
+                .mapToObj(idx -> diagnosticData.get(idx).getAsString()).collect(Collectors.toList());
+
+        if (parentType != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+
+            List<List<String>> annotationsListsToRemove = getMultipleRemoveAnnotations(annotations);
+            for (List<String> annotationList : annotationsListsToRemove) {
+                String[] annotationsToRemove = annotationList.toArray(new String[annotationList.size()]);
+                removeAnnotation(diagnostic, context, parentType, codeActions, annotationsToRemove);
+            }
+            return codeActions;
+        }
+        return null;
+    }
+
+    /**
+     * Each List in the returned List of Lists should be a set of annotations that
+     * will be removed at one go. For example, to provide the user with the option to remove
+     * "@A, @B" and "@C". The return should be [[A, B], [C]]
+     *
+     * @param All the annotations present on the member.
+     * @return A List of Lists, with each list containing the annotations that must be
+     * removed at the same time.
+     * @author Adit Rada
+     *
+     */
+    protected abstract List<List<String>> getMultipleRemoveAnnotations(List<String> annotations);
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
@@ -13,6 +13,7 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
 
 import com.google.gson.JsonArray;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import org.eclipse.lsp4j.CodeAction;
@@ -52,7 +53,7 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
         if (parentType != null) {
             List<CodeAction> codeActions = new ArrayList<>();
 
-            List<List<String>> annotationsListsToRemove = getMultipleRemoveAnnotations(annotations);
+            List<List<String>> annotationsListsToRemove = getMultipleRemoveAnnotations(parentType.getProject(), annotations);
             for (List<String> annotationList : annotationsListsToRemove) {
                 // For each list we will create one code action in its own context
                 JavaCodeActionContext newContext = context.copy();
@@ -70,11 +71,12 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
      * will be removed at one go. For example, to provide the user with the option to remove
      * "@A, @B" and "@C". The return should be [[A, B], [C]]
      *
+     * @param project  The project is the context in which the annotation short names will be resolved to FQnames
      * @param annotations All the annotations present on the member.
      * @return A List of Lists, with each list containing the annotations that must be
      * removed at the same time.
      * @author Adit Rada
      *
      */
-    protected abstract List<List<String>> getMultipleRemoveAnnotations(List<String> annotations);
+    protected abstract List<List<String>> getMultipleRemoveAnnotations(Project project, List<String> annotations);
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMultipleAnnotations.java
@@ -43,6 +43,7 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
         PsiElement node = context.getCoveredNode();
         PsiElement parentType = getBinding(node);
 
+        // Obtain the list of annotations from the diagnostic.
         JsonArray diagnosticData = (JsonArray) diagnostic.getData();
 
         List<String> annotations = IntStream.range(0, diagnosticData.size())
@@ -53,8 +54,11 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
 
             List<List<String>> annotationsListsToRemove = getMultipleRemoveAnnotations(annotations);
             for (List<String> annotationList : annotationsListsToRemove) {
+                // For each list we will create one code action in its own context
+                JavaCodeActionContext newContext = context.copy();
+                PsiElement owningNode = getBinding(newContext.getCoveredNode());
                 String[] annotationsToRemove = annotationList.toArray(new String[annotationList.size()]);
-                removeAnnotation(diagnostic, context, parentType, codeActions, annotationsToRemove);
+                removeAnnotation(diagnostic, newContext, owningNode, codeActions, annotationsToRemove);
             }
             return codeActions;
         }
@@ -66,7 +70,7 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
      * will be removed at one go. For example, to provide the user with the option to remove
      * "@A, @B" and "@C". The return should be [[A, B], [C]]
      *
-     * @param All the annotations present on the member.
+     * @param annotations All the annotations present on the member.
      * @return A List of Lists, with each list containing the annotations that must be
      * removed at the same time.
      * @author Adit Rada

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb;
 
+import com.intellij.openapi.project.Project;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveMultipleAnnotations;
 
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ import java.util.List;
  */
 public class JsonbTransientAnnotationQuickFix extends RemoveMultipleAnnotations {
     @Override
-    protected List<List<String>> getMultipleRemoveAnnotations(List<String> annotations) {
+    protected List<List<String>> getMultipleRemoveAnnotations(Project project, List<String> annotations) {
         List<List<String>> annotationsListsToRemove = new ArrayList<List<String>>();
 
         if (annotations.contains(JsonbConstants.JSONB_TRANSIENT)) {
@@ -42,7 +43,12 @@ public class JsonbTransientAnnotationQuickFix extends RemoveMultipleAnnotations 
         // Provide as another option: Remove all other JsonbAnnotations
         annotations.remove(JsonbConstants.JSONB_TRANSIENT);
         if (annotations.size() > 0) {
-            annotationsListsToRemove.add(annotations);
+            // Convert the short annotation names to their fully qualified equivalents.
+            List<String> fqAnnotations = new ArrayList<>();
+            for (String annotation : annotations) {
+                fqAnnotations.addAll(getFQAnnotationNames(project, annotation));
+            }
+            annotationsListsToRemove.add(fqAnnotations);
         }
 
         return annotationsListsToRemove;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Adit Rada - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveMultipleAnnotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Quick fix for removing @JsonbTransient annotations when more than
+ * one occur in a class.
+ * The getCodeActions method is overridden in order to make sure that
+ * we return our custom quick fixes. There will be two quick fixes given
+ * to the user: (1) either remove @JsonbTransient or (2) remove all other
+ * Jsonb annotations.
+ *
+ * @author Adit Rada
+ *
+ */
+public class JsonbTransientAnnotationQuickFix extends RemoveMultipleAnnotations {
+    @Override
+    protected List<List<String>> getMultipleRemoveAnnotations(List<String> annotations) {
+        List<List<String>> annotationsListsToRemove = new ArrayList<List<String>>();
+
+        if (annotations.contains(JsonbConstants.JSONB_TRANSIENT)) {
+            // Provide as one option: Remove JsonbTransient
+            annotationsListsToRemove.add(Arrays.asList("jakarta.json.bind.annotation.JsonbTransient"));
+        }
+
+        // Provide as another option: Remove all other JsonbAnnotations
+        annotations.remove(JsonbConstants.JSONB_TRANSIENT);
+        if (annotations.size() > 0) {
+            annotationsListsToRemove.add(annotations);
+        }
+
+        return annotationsListsToRemove;
+    }
+}


### PR DESCRIPTION
I had to decide between using the new RemoveAnnotationsProposal and porting over the existing DeleteAnnotationProposal and I decided that the loop to find the annotation model objects to pass to the former was just about as difficult as porting the latter. Let me know what you think. 

Not finished with #310 yet.