### PR TITLE
Adding 3 quick fixes related to ModifyModifiersProposal

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation;
+
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyModifiersProposal;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.RemoveAnnotationsProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.*;
+
+/**
+ * Quickfix for fixing {@link BeanValidationConstants#DIAGNOSTIC_CODE_STATIC} error by either action
+ * 1. Removing constraint annotation on static field or method
+ * 2. Removing static modifier from field or method
+ * 
+ * @author Leslie Dawson (lamminade)
+ *
+ */
+public class BeanValidationQuickFix {
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
+        removeConstraintAnnotations(diagnostic, context.copy(), codeActions);
+
+        if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)) {
+            removeStaticModifier(diagnostic, context.copy(), codeActions);
+        }
+        return codeActions;
+    }
+
+    private void removeConstraintAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, List<CodeAction> codeActions) {
+        final PsiElement node = context.getCoveredNode();
+        final PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+        final PsiModifierListOwner modifierListOwner = PsiTreeUtil.getParentOfType(node, PsiModifierListOwner.class);
+
+        final String annotationName = diagnostic.getData().toString().replace("\"", "");
+        final PsiAnnotation[] annotations = modifierListOwner.getAnnotations();
+        if (annotations != null && annotations.length > 0) {
+            final Optional<PsiAnnotation> annotationToRemove =
+                    Arrays.stream(annotations).filter(a -> annotationName.equals(a.getQualifiedName())).findFirst();
+            if (annotationToRemove.isPresent()) {
+                final String name = "Remove constraint annotation " + annotationName + " from this " + getType(modifierListOwner);
+                final RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(name, context.getSource().getCompilationUnit(),
+                        context.getASTRoot(), parentType, 0, Collections.singletonList(annotationToRemove.get()));
+                final CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+                if (codeAction != null) {
+                    codeActions.add(codeAction);
+                }
+            }
+        }
+    }
+
+    private void removeStaticModifier(Diagnostic diagnostic, JavaCodeActionContext context, List<CodeAction> codeActions) {
+        final PsiElement node = context.getCoveredNode();
+        final PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+        final PsiModifierListOwner modifierListOwner = PsiTreeUtil.getParentOfType(node, PsiModifierListOwner.class);
+
+        final String name = "Remove static modifier from this " + getType(modifierListOwner);
+        final ModifyModifiersProposal proposal = new ModifyModifiersProposal(name, context.getSource().getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(),
+                Collections.singletonList("static"));
+        final CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+    }
+
+    private String getType(PsiModifierListOwner modifierListOwner) {
+        if (modifierListOwner instanceof PsiField) {
+            return "field";
+        } else if (modifierListOwner instanceof PsiMethod) {
+            return "method";
+        }
+        return "element";
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -66,7 +66,7 @@ public class ManagedBeanNoArgConstructorQuickFix {
         parentType = getBinding(node);
         String name = "Add a no-arg protected constructor to this class";
         ChangeCorrectionProposal proposal = new AddConstructorProposal(name,
-                targetContext.getCompilationUnit(), targetContext.getASTRoot(), parentType, 0);
+                targetContext.getSource().getCompilationUnit(), targetContext.getASTRoot(), parentType, 0);
         CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
 
         if (codeAction != null) {
@@ -79,7 +79,7 @@ public class ManagedBeanNoArgConstructorQuickFix {
         parentType = getBinding(node);
         name = "Add a no-arg public constructor to this class";
         proposal = new AddConstructorProposal(name,
-                targetContext.getCompilationUnit(), targetContext.getASTRoot(), parentType, 0, "public");
+                targetContext.getSource().getCompilationUnit(), targetContext.getASTRoot(), parentType, 0, "public");
         codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
 
         if (codeAction != null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -13,6 +13,8 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction;
 
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanNoArgConstructorQuickFix;
@@ -98,7 +100,7 @@ public class JakartaCodeActionHandler {
 //            ManagedBeanQuickFix ManagedBeanQuickFix = new ManagedBeanQuickFix();
             PersistenceEntityQuickFix PersistenceEntityQuickFix = new PersistenceEntityQuickFix();
 //            ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
-//            BeanValidationQuickFix BeanValidationQuickFix = new BeanValidationQuickFix();
+            BeanValidationQuickFix BeanValidationQuickFix = new BeanValidationQuickFix();
             ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
             ManagedBeanNoArgConstructorQuickFix ManagedBeanNoArgConstructorQuickFix = new ManagedBeanNoArgConstructorQuickFix();
 //            JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
@@ -190,11 +192,10 @@ public class JakartaCodeActionHandler {
 //                        codeActions.addAll(RemoveProduceAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                         codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic));
                     }
-//                    if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
-//                            || diagnostic.getCode().getLeft()
-//                            .equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
-//                        codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
+                            || diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
+                        codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic));
+                    }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
                         codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic));
                         codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context, diagnostic));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -20,6 +20,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveInvalidInjectP
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NoResourcePublicConstructorQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NonPublicResourceMethodQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.HttpServletQuickFix;
@@ -93,7 +94,7 @@ public class JakartaCodeActionHandler {
 //            DeleteConflictMapKeyQuickFix DeleteConflictMapKeyQuickFix = new DeleteConflictMapKeyQuickFix();
             NonPublicResourceMethodQuickFix NonPublicResourceMethodQuickFix = new NonPublicResourceMethodQuickFix();
 //            ResourceMethodMultipleEntityParamsQuickFix ResourceMethodMultipleEntityParamsQuickFix = new ResourceMethodMultipleEntityParamsQuickFix();
-//            NoResourcePublicConstructorQuickFix NoResourcePublicConstructorQuickFix = new NoResourcePublicConstructorQuickFix();
+            NoResourcePublicConstructorQuickFix NoResourcePublicConstructorQuickFix = new NoResourcePublicConstructorQuickFix();
 //            ManagedBeanQuickFix ManagedBeanQuickFix = new ManagedBeanQuickFix();
             PersistenceEntityQuickFix PersistenceEntityQuickFix = new PersistenceEntityQuickFix();
 //            ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
@@ -156,10 +157,9 @@ public class JakartaCodeActionHandler {
 //                        codeActions.addAll(ResourceMethodMultipleEntityParamsQuickFix.getCodeActions(context,
 //                                diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NO_PUBLIC_CONSTRUCTORS)) {
-//                        codeActions.addAll(NoResourcePublicConstructorQuickFix.getCodeActions(context,
-//                                diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NO_PUBLIC_CONSTRUCTORS)) {
+                        codeActions.addAll(NoResourcePublicConstructorQuickFix.getCodeActions(context, diagnostic));
+                    }
 //                    if (diagnostic.getCode().getLeft()
 //                            .equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTES)) {
 //                        codeActions.addAll(PersistenceAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -19,6 +19,8 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanNoArgCons
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveInvalidInjectParamAnnotationQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingNameQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.annotations.AddResourceMissingTypeQuickFix;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSConstants;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NonPublicResourceMethodQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.HttpServletQuickFix;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ServletConstants;
@@ -89,7 +91,7 @@ public class JakartaCodeActionHandler {
 //            CompleteFilterAnnotationQuickFix CompleteFilterAnnotationQuickFix = new CompleteFilterAnnotationQuickFix();
 //            PersistenceAnnotationQuickFix PersistenceAnnotationQuickFix = new PersistenceAnnotationQuickFix();
 //            DeleteConflictMapKeyQuickFix DeleteConflictMapKeyQuickFix = new DeleteConflictMapKeyQuickFix();
-//            NonPublicResourceMethodQuickFix NonPublicResourceMethodQuickFix = new NonPublicResourceMethodQuickFix();
+            NonPublicResourceMethodQuickFix NonPublicResourceMethodQuickFix = new NonPublicResourceMethodQuickFix();
 //            ResourceMethodMultipleEntityParamsQuickFix ResourceMethodMultipleEntityParamsQuickFix = new ResourceMethodMultipleEntityParamsQuickFix();
 //            NoResourcePublicConstructorQuickFix NoResourcePublicConstructorQuickFix = new NoResourcePublicConstructorQuickFix();
 //            ManagedBeanQuickFix ManagedBeanQuickFix = new ManagedBeanQuickFix();
@@ -147,10 +149,9 @@ public class JakartaCodeActionHandler {
 //                        codeActions
 //                                .addAll(CompleteFilterAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
 //                    }
-//                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NON_PUBLIC)) {
-//                        codeActions
-//                                .addAll(NonPublicResourceMethodQuickFix.getCodeActions(context, diagnostic, monitor));
-//                    }
+                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NON_PUBLIC)) {
+                        codeActions.addAll(NonPublicResourceMethodQuickFix.getCodeActions(context, diagnostic));
+                    }
 //                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_MULTIPLE_ENTITY_PARAMS)) {
 //                        codeActions.addAll(ResourceMethodMultipleEntityParamsQuickFix.getCodeActions(context,
 //                                diagnostic, monitor));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/AddConstructorProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/AddConstructorProposal.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.CodeActionKind;
  */
 public class AddConstructorProposal extends ChangeCorrectionProposal {
 
+    private final PsiFile sourceCU;
     private final PsiFile invocationNode;
     private final PsiClass binding;
     private final String visibility;
@@ -36,9 +37,10 @@ public class AddConstructorProposal extends ChangeCorrectionProposal {
      * Constructor for AddMethodProposal
      *
      */
-    public AddConstructorProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public AddConstructorProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                   PsiClass binding, int relevance) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.sourceCU = sourceCU;
         this.invocationNode = invocationNode;
         this.binding = binding;
         this.visibility = "protected";
@@ -49,9 +51,10 @@ public class AddConstructorProposal extends ChangeCorrectionProposal {
      *
      * @param visibility    a valid visibility modifier for the constructor, defaults to protected
      */
-    public AddConstructorProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public AddConstructorProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                   PsiClass binding, int relevance, String visibility) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.sourceCU = sourceCU;
         this.invocationNode = invocationNode;
         this.binding = binding;
         this.visibility = visibility;
@@ -78,6 +81,6 @@ public class AddConstructorProposal extends ChangeCorrectionProposal {
         binding.addBefore(newConstructor, bestSpot);
         PositionUtils.formatDocument(binding); // add the necessary new lines, must use 'binding,' it's already in the document
         final Document document = invocationNode.getViewProvider().getDocument();
-        return new Change(document, document);
+        return new Change(sourceCU.getViewProvider().getDocument(), document);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyModifiersProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyModifiersProposal.java
@@ -35,6 +35,7 @@ import java.util.List;
  */
 public class ModifyModifiersProposal extends ChangeCorrectionProposal {
 
+    private final PsiFile sourceCU;
     private final PsiFile invocationNode;
     private final PsiModifierListOwner binding;
     private final PsiModifierList modifiers;
@@ -51,9 +52,10 @@ public class ModifyModifiersProposal extends ChangeCorrectionProposal {
      * @param modifiersToAdd        list of valid modifiers as strings to be added
      * @param modifiersToRemove     list of modifiers as strings to be removed
      */
-    public ModifyModifiersProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyModifiersProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                 PsiModifierListOwner binding, int relevance, PsiModifierList modifiers, List<String> modifiersToAdd, List<String> modifiersToRemove) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.sourceCU = sourceCU;
         this.invocationNode = invocationNode;
         this.binding = binding;
         this.modifiers = modifiers;
@@ -67,9 +69,9 @@ public class ModifyModifiersProposal extends ChangeCorrectionProposal {
      *
      * @param modifiersToAdd        list of valid modifiers as strings to be added
      */
-    public ModifyModifiersProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyModifiersProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                    PsiModifierListOwner binding, int relevance, PsiModifierList modifiers, List<String> modifiersToAdd) {
-        this(label, targetCU, invocationNode, binding, relevance, modifiers, modifiersToAdd, Collections.emptyList());
+        this(label, sourceCU, invocationNode, binding, relevance, modifiers, modifiersToAdd, Collections.emptyList());
     }
 
     @Override
@@ -100,6 +102,6 @@ public class ModifyModifiersProposal extends ChangeCorrectionProposal {
         });
         PositionUtils.formatDocument(binding); // add the necessary new lines, must use 'binding,' it's already in the document
         final Document document = invocationNode.getViewProvider().getDocument();
-        return new Change(document, document);
+        return new Change(sourceCU.getViewProvider().getDocument(), document);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyModifiersProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyModifiersProposal.java
@@ -20,6 +20,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiModifierListOwner;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PositionUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -97,6 +98,7 @@ public class ModifyModifiersProposal extends ChangeCorrectionProposal {
                 modifiers.setModifierProperty(modifier, true);
             }
         });
+        PositionUtils.formatDocument(binding); // add the necessary new lines, must use 'binding,' it's already in the document
         final Document document = invocationNode.getViewProvider().getDocument();
         return new Change(document, document);
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/RemoveAnnotationsProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/RemoveAnnotationsProposal.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiModifierListOwner;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PositionUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -25,14 +26,16 @@ import java.util.List;
 
 public class RemoveAnnotationsProposal extends ChangeCorrectionProposal {
 
+    private final PsiFile sourceCU;
     private final PsiFile invocationNode;
     private final PsiModifierListOwner binding;
     private final List<PsiAnnotation> annotationsToRemove;
 
-    public RemoveAnnotationsProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public RemoveAnnotationsProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                      PsiModifierListOwner binding, int relevance,
                                      List<PsiAnnotation> annotationsToRemove) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.sourceCU = sourceCU;
         this.invocationNode = invocationNode;
         this.binding = binding;
         this.annotationsToRemove = annotationsToRemove;
@@ -43,7 +46,8 @@ public class RemoveAnnotationsProposal extends ChangeCorrectionProposal {
         annotationsToRemove.forEach(a -> {
             a.delete();
         });
+        PositionUtils.formatDocument(binding); // fix up whitespace
         final Document document = invocationNode.getViewProvider().getDocument();
-        return new Change(document, document);
+        return new Change(sourceCU.getViewProvider().getDocument(), document);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -106,7 +106,7 @@ public class RemoveModifierConflictQuickFix {
 
         String name = "Remove the \'" + modifier[0] + "\' modifier from this ";
         name = name.concat(type);
-        ModifyModifiersProposal proposal = new ModifyModifiersProposal(name, context.getCompilationUnit(),
+        ModifyModifiersProposal proposal = new ModifyModifiersProposal(name, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(), Arrays.asList(modifier));
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -90,7 +90,7 @@ public class RemoveParamAnnotationQuickFix {
             }
         });
 
-        RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(label, context.getCompilationUnit(),
+        RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(label, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, psiAnnotationsToRemove);
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
         if (codeAction != null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation, Shaunak Tulshibagwale and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Shaunak Tulshibagwale
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.AddConstructorProposal;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyModifiersProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Quick fix for NoResourcePublicConstructorQuickFix that uses
+ * ModifyModifiersProposal.
+ * 
+ * @author Shaunak Tulshibagwale
+ *
+ */
+public class NoResourcePublicConstructorQuickFix {
+
+    private final static String TITLE_MESSAGE = "Make constructor public";
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+
+        PsiElement node = context.getCoveredNode();
+        PsiMethod parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+        
+        if (parentMethod != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+
+            JavaCodeActionContext targetContext = context.copy();
+            node = targetContext.getCoveredNode();
+            PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+            parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+
+            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, targetContext.getSource().getCompilationUnit(),
+                    targetContext.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
+
+            // Convert the proposal to LSP4J CodeAction
+            CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
+            codeAction.setTitle(TITLE_MESSAGE);
+            codeActions.add(codeAction);
+
+            final PsiParameterList list = parentMethod.getParameterList();
+            if (list != null && list.getParametersCount() > 0) {
+                targetContext = context.copy();
+                node = targetContext.getCoveredNode();
+                parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+
+                final String name = "Add a no-arg public constructor to this class";
+                proposal = new AddConstructorProposal(name,
+                        targetContext.getSource().getCompilationUnit(), targetContext.getASTRoot(), parentType, 0, "public");
+                codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
+                codeActions.add(codeAction);
+            }
+            return codeActions;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -44,7 +44,7 @@ public class NonPublicResourceMethodQuickFix {
         final PsiMethod parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
 
         if (parentMethod != null) {
-            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getCompilationUnit(),
+            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
 
             // Convert the proposal to LSP4J CodeAction

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation, Matthew Shocrylas and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Matthew Shocrylas - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyModifiersProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Quick fix for ResourceMethodDiagnosticsCollector that uses
+ * ModifyModifiersProposal.
+ * 
+ * @author Matthew Shocrylas
+ *
+ */
+public class NonPublicResourceMethodQuickFix {
+
+    private final static String TITLE_MESSAGE = "Make method public";
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic)  {
+
+        final PsiElement node = context.getCoveredNode();
+        final PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+        final PsiMethod parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+
+        if (parentMethod != null) {
+            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getCompilationUnit(),
+                    context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
+
+            // Convert the proposal to LSP4J CodeAction
+            CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+            codeAction.setTitle(TITLE_MESSAGE);
+            return Collections.singletonList(codeAction);
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -86,7 +86,7 @@ public class PersistenceEntityQuickFix {
         parentType = getBinding(node);
         String name = "Add a no-arg protected constructor to this class";
         ChangeCorrectionProposal proposal = new AddConstructorProposal(name,
-                targetContext.getCompilationUnit(), targetContext.getASTRoot(), parentType, 0);
+                targetContext.getSource().getCompilationUnit(), targetContext.getASTRoot(), parentType, 0);
         CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
 
         if (codeAction != null) {
@@ -99,7 +99,7 @@ public class PersistenceEntityQuickFix {
         parentType = getBinding(node);
         name = "Add a no-arg public constructor to this class";
         proposal = new AddConstructorProposal(name,
-                targetContext.getCompilationUnit(), targetContext.getASTRoot(), parentType, 0, "public");
+                targetContext.getSource().getCompilationUnit(), targetContext.getASTRoot(), parentType, 0, "public");
         codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
 
         if (codeAction != null) {


### PR DESCRIPTION
Resolves #312 

This PR also updates `AddConstructorProposal`, `ModifyModifiersProposal` and `RemoveAnnotationsProposal` as well existing quick fixes that use these `ChangeCorrectionProposal`s to provide the correct source document to the `Change` object. This addresses an issue with computing the range of text to replace. Will need to apply something similar to the rest of the quick fixes / change proposals.