### PR TITLE
239 Replace getCanonicalPath with getPath

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -68,7 +68,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             return;
         }
 
-        String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
+        String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
         if (libertyModule.isDebugMode() && debugPort != -1) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -34,7 +34,7 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
             notifyError(ex.getTranslatedMessage());
             return;
         }
-        String cdToProjectCmd = "cd \"" + buildFile.getParent().getCanonicalPath() + "\"";
+        String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
         LibertyActionUtil.executeCommand(widget, startCmd);
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -40,7 +40,7 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
     protected void executeLibertyAction() {
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();
-        File failsafeReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "failsafe-report.html").normalize().toAbsolutePath().toFile();
+        File failsafeReportFile = Paths.get(parentFile.getPath(), "target", "site", "failsafe-report.html").normalize().toAbsolutePath().toFile();
         VirtualFile failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
 
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -72,7 +72,7 @@ public class ViewTestReport extends LibertyGeneralAction {
 
         if (testReportFile == null || !testReportFile.exists()) {
             // if does not exist look in default location: "build", "reports", "tests", "test", "index.html"
-            testReportFile = Paths.get(parentFile.getCanonicalPath(), "build", "reports", "tests", "test", "index.html").normalize().toAbsolutePath().toFile();
+            testReportFile = Paths.get(parentFile.getPath(), "build", "reports", "tests", "test", "index.html").normalize().toAbsolutePath().toFile();
         }
 
         VirtualFile testReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(testReportFile);
@@ -94,7 +94,7 @@ public class ViewTestReport extends LibertyGeneralAction {
     }
 
     private String getTestReportDestination(VirtualFile file) throws IOException {
-        String buildFile = LibertyGradleUtil.fileToString(file.getCanonicalPath());
+        String buildFile = LibertyGradleUtil.fileToString(file.getPath());
         String testReportRegex = "(?<=reports.html.destination[\\s\\=|\\=]).*([\"|'])(.*)([\"|'])";
 
         Pattern pattern = Pattern.compile(testReportRegex);
@@ -112,7 +112,7 @@ public class ViewTestReport extends LibertyGeneralAction {
     private File findCustomTestReport(VirtualFile parentFile) throws IOException {
         // look for the most recently modified index.html files in the workspace
         ArrayList<File> customTestReports = new ArrayList<File>();
-        try (Stream<Path> walk = Files.walk(Paths.get(parentFile.getCanonicalPath()))
+        try (Stream<Path> walk = Files.walk(Paths.get(parentFile.getPath()))
                 .filter(Files::isRegularFile)) {
             List<String> result = walk.map(x -> x.toString())
                     // exclude files from {bin, classes, target} dirs

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -40,7 +40,7 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
     protected void executeLibertyAction() {
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();
-        File surefireReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "surefire-report.html").normalize().toAbsolutePath().toFile();
+        File surefireReportFile = Paths.get(parentFile.getPath(), "target", "site", "surefire-report.html").normalize().toAbsolutePath().toFile();
         VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
 
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
@@ -43,7 +43,7 @@ public class ServerEnvFileType extends LanguageFileType implements FileTypeIdent
 
     @Override
     public boolean isMyFileType(@NotNull VirtualFile file) {
-        Path path = Paths.get(file.getCanonicalPath());
+        Path path = Paths.get(file.getPath());
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + SERVER_ENV_GLOB_PATTERN);
         return matcher.matches(path);
     }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvSubstitutor.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvSubstitutor.java
@@ -39,7 +39,7 @@ public class ServerEnvSubstitutor extends LanguageSubstitutor {
     @Override
     public @Nullable Language getLanguage(@NotNull VirtualFile file, @NotNull Project project) {
         if (isLibertyServerEnvFile(file)) {
-            LOGGER.trace("Substituting Properties language for Liberty server.env file: " + file.getCanonicalPath());
+            LOGGER.trace("Substituting Properties language for Liberty server.env file: " + file.getPath());
             // treat Liberty server.env files as Properties files
             return PropertiesLanguage.INSTANCE;
         }
@@ -47,7 +47,7 @@ public class ServerEnvSubstitutor extends LanguageSubstitutor {
     }
 
     private boolean isLibertyServerEnvFile(VirtualFile file) {
-        Path path = Paths.get(file.getCanonicalPath());
+        Path path = Paths.get(file.getPath());
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + SERVER_ENV_GLOB_PATTERN);
         return matcher.matches(path);
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServersRegistry.java
@@ -240,7 +240,7 @@ public class LanguageServersRegistry {
                     LanguageServerDefinition lsDef = mapping.getValue();
                     if (!lsDef.languageFilePatternMappings.isEmpty() && lsDef.languageFilePatternMappings.containsKey(language)) {
                         // check if document matches file pattern
-                        Path path = Paths.get(file.getCanonicalPath());
+                        Path path = Paths.get(file.getPath());
                         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + lsDef.languageFilePatternMappings.get(language));
                         if (matcher.matches(path)) {
                             LOGGER.trace("Available language server: " + mapping.getValue().id + " for file: " + file);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServiceAccessor.java
@@ -377,7 +377,7 @@ public class LanguageServiceAccessor {
                         boolean patternMappingsEmpty = serverDefinition.languageFilePatternMappings.isEmpty();
                         if (!patternMappingsEmpty && serverDefinition.languageFilePatternMappings.containsKey(contentType)) {
                             // check if document matches file pattern
-                            Path filePath = Paths.get(file.getCanonicalPath());
+                            Path filePath = Paths.get(file.getPath());
                             final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + serverDefinition.languageFilePatternMappings.get(contentType));
                             if (matcher.matches(filePath)) {
                                 // only start language server if the language and file pattern matches the language server definition

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -38,7 +38,7 @@ public class LibertyGradleUtil {
      */
     public static String getProjectName(VirtualFile file) {
         VirtualFile parentFolder = file.getParent();
-        Path settingsPath = Paths.get(parentFolder.getCanonicalPath(), "settings.gradle");
+        Path settingsPath = Paths.get(parentFolder.getPath(), "settings.gradle");
         File settingsFile = settingsPath.toFile();
         if (settingsFile.exists()) {
             try {
@@ -91,7 +91,7 @@ public class LibertyGradleUtil {
      * @throws IOException
      */
     public static BuildFile validBuildGradle(PsiFile file) throws IOException {
-            String buildFile = fileToString(file.getVirtualFile().getCanonicalPath());
+            String buildFile = fileToString(file.getVirtualFile().getPath());
             if (buildFile.isEmpty()) { return (new BuildFile(false, false)); }
 
             // check if "apply plugin: 'liberty'" is specified in the build.gradle

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -48,7 +48,7 @@ public class LibertyMavenUtil {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
 
-        File inputFile = new File(file.getCanonicalPath());
+        File inputFile = new File(file.getPath());
         Document doc = builder.parse(inputFile);
 
         doc.getDocumentElement().normalize();
@@ -82,7 +82,7 @@ public class LibertyMavenUtil {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
 
-        File inputFile = new File(file.getVirtualFile().getCanonicalPath());
+        File inputFile = new File(file.getVirtualFile().getPath());
         Document doc = builder.parse(inputFile);
 
         doc.getDocumentElement().normalize();

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -64,7 +64,7 @@ public class LibertyProjectUtil {
     }
 
     public static void addCustomLibertyProject(LibertyModule libertyModule) {
-        final String path = libertyModule.getBuildFile().getCanonicalPath();
+        final String path = libertyModule.getBuildFile().getPath();
         if (path != null) {
             final LibertyProjectSettings state = LibertyProjectSettings.getInstance(libertyModule.getProject());
             state.getCustomLibertyProjects().add(path);
@@ -74,13 +74,13 @@ public class LibertyProjectUtil {
 
     public static void removeCustomLibertyProject(LibertyModule libertyModule) {
         final LibertyProjectSettings state = LibertyProjectSettings.getInstance(libertyModule.getProject());
-        state.getCustomLibertyProjects().remove(libertyModule.getBuildFile().getCanonicalPath());
+        state.getCustomLibertyProjects().remove(libertyModule.getBuildFile().getPath());
         LibertyModules.getInstance().removeLibertyModule(libertyModule);
     }
 
     public static boolean isCustomLibertyProject(Project project, PsiFile buildFile) {
         final LibertyProjectSettings state = LibertyProjectSettings.getInstance(project);
-        return state.getCustomLibertyProjects().contains(buildFile.getVirtualFile().getCanonicalPath());
+        return state.getCustomLibertyProjects().contains(buildFile.getVirtualFile().getPath());
     }
 
     /**
@@ -196,7 +196,7 @@ public class LibertyProjectUtil {
      * @return <code>true</code> if the project contains src/main/liberty/config/server.xml relative to the build file; <code>false</code> otherwise
      */
     private static boolean isLibertyProject(PsiFile buildFile) {
-        String rootDir = buildFile.getVirtualFile().getParent().getCanonicalPath();
+        String rootDir = buildFile.getVirtualFile().getParent().getPath();
         return new File(rootDir, "src/main/liberty/config/server.xml").exists();
     }
 


### PR DESCRIPTION
Fixes #239 

Using IntelliJ's VFS `getCanonicalPath()` method can result in `null` return values and lead to NPE's. The main difference between the VFS `getCanonicalPath()` and `getPath()` is that `getCanonicalPath()` will attempt to resolve any symbolic links present in the path. Testing out various scenarios where `getCanonicalPath()` was previously used, it is not necessary to resolve the symlinks, and therefore no need to call `getCanonicalPath()` over `getPath()`.

The IntelliJ quick doc on `getCanonicalPath()` states:
```
Resolves all symbolic links containing in a path to this file and returns a path to a link target (in platform-independent format).
Note: please use this method judiciously. In most cases VFS clients don't need to resolve links in paths and should work with those provided by a user.
Returns:
getPath() if there are no symbolic links in a file's path; getCanonicalFile().getPath() if the link was successfully resolved; null otherwise
```