### PR TITLE
Clean up the creation of code actions

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -38,7 +38,7 @@ public class PostConstructReturnTypeQuickFix {
         PsiElement node = context.getCoveredNode();
         PsiMethod parentType = getBinding(node);
         String name = "Change return type to void";
-        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(name, context.getCompilationUnit(),
+        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(name, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, PsiPrimitiveType.VOID);
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
         codeActions.add(codeAction);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -187,20 +187,23 @@ public class JakartaCodeActionHandler {
                         codeActions.addAll(ConflictProducesInjectQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_INJECT_PARAM)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_PRODUCES_PARAM)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveProduceAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
                             || diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
                         codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
                         codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic));
@@ -212,33 +215,39 @@ public class JakartaCodeActionHandler {
                         codeActions.addAll(ScopeDeclarationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR) ||
                             diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_GENERIC)) {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_STATIC)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context2, diagnostic));
                     }
 
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_PARAMS)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePostConstructAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_PREDESTROY_STATIC)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePreDestroyAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_PREDESTROY_PARAMS)) {
+                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePreDestroyAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context, diagnostic));
+                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context2, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(WebSocketConstants.DIAGNOSTIC_CODE_PATH_PARAMS_ANNOT)) {
                         codeActions.addAll(AddPathParamQuickFix.getCodeActions(context, diagnostic));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -187,23 +187,23 @@ public class JakartaCodeActionHandler {
                         codeActions.addAll(ConflictProducesInjectQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_INJECT_PARAM)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_PRODUCES_PARAM)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveProduceAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveInvalidInjectParamAnnotationQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
                             || diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
                         codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
                         codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic));
@@ -215,39 +215,39 @@ public class JakartaCodeActionHandler {
                         codeActions.addAll(ScopeDeclarationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR) ||
                             diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_GENERIC)) {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_STATIC)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
 
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_PARAMS)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePostConstructAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_PREDESTROY_STATIC)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePreDestroyAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_PREDESTROY_PARAMS)) {
-                        JavaCodeActionContext context2 = context.copy(); // each code action needs its own context.
+                        JavaCodeActionContext contextCopy = context.copy(); // each code action needs its own context.
                         codeActions.addAll(RemovePreDestroyAnnotationQuickFix.getCodeActions(context, diagnostic));
-                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(context2, diagnostic));
+                        codeActions.addAll(RemoveMethodParametersQuickFix.getCodeActions(contextCopy, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(WebSocketConstants.DIAGNOSTIC_CODE_PATH_PARAMS_ANNOT)) {
                         codeActions.addAll(AddPathParamQuickFix.getCodeActions(context, diagnostic));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/DeleteAnnotationProposal.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
  *
  */
 public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
+    private final PsiFile fSourceCU;
     private final PsiFile fInvocationNode;
     private final PsiElement fBinding;
 
@@ -40,7 +41,7 @@ public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
      * Constructor for DeleteAnnotationProposal
      *
      * @param label          - annotation label
-     * @param targetCU       - the entire Java compilation unit
+     * @param sourceCU       - the entire Java compilation unit
      * @param invocationNode
      * @param binding
      * @param relevance
@@ -48,9 +49,10 @@ public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
      * @param annotations
      *
      */
-    public DeleteAnnotationProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public DeleteAnnotationProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                     PsiElement binding, int relevance, PsiElement declaringNode, String... annotations) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.fSourceCU = sourceCU;
         this.fInvocationNode = invocationNode;
         this.fBinding = binding;
         this.declaringNode = declaringNode;
@@ -70,6 +72,6 @@ public class DeleteAnnotationProposal extends ChangeCorrectionProposal {
             }
         }
         final Document document = fInvocationNode.getViewProvider().getDocument();
-        return new Change(document, document);
+        return new Change(fSourceCU.getViewProvider().getDocument(), document);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyAnnotationProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyAnnotationProposal.java
@@ -31,31 +31,37 @@ import java.util.List;
  */
 public class ModifyAnnotationProposal extends NewAnnotationProposal {
 
+    // The original file or compilation unit
+    private final PsiFile sourceCU;
+
     // list of attributes to add to the annotations
     private final List<String> attributesToAdd;
 
     // list of attributes (if they exist) to remove from the annotations
     private final List<String> attributesToRemove;
 
-    public ModifyAnnotationProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyAnnotationProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                     PsiModifierListOwner binding, PsiAnnotation annotationNode,
                                     int relevance, String annotation, List<String> attributesToAdd,
                                     List<String> attributesToRemove) {
-        super(label, targetCU, invocationNode, binding, annotationNode, relevance, annotation);
+        super(label, null, invocationNode, binding, annotationNode, relevance, annotation);
+        this.sourceCU = sourceCU;
         this.attributesToAdd = attributesToAdd;
         this.attributesToRemove = attributesToRemove;
     }
-    public ModifyAnnotationProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyAnnotationProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                     PsiModifierListOwner binding, PsiAnnotation annotationNode,
                                     int relevance, String annotation, List<String> attributesToAdd) {
-        super(label, targetCU, invocationNode, binding, annotationNode, relevance, annotation);
+        super(label, null, invocationNode, binding, annotationNode, relevance, annotation);
+        this.sourceCU = sourceCU;
         this.attributesToAdd = attributesToAdd;
         this.attributesToRemove = new ArrayList<>();
     }
-    public ModifyAnnotationProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyAnnotationProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                     PsiModifierListOwner binding, PsiAnnotation annotationNode,
                                     int relevance, List<String> attributesToAdd, String... annotations) {
-        super(label, targetCU, invocationNode, binding, annotationNode, relevance, annotations);
+        super(label, null, invocationNode, binding, annotationNode, relevance, annotations);
+        this.sourceCU = sourceCU;
         this.attributesToAdd = attributesToAdd;
         this.attributesToRemove = new ArrayList<>();
     }
@@ -91,7 +97,7 @@ public class ModifyAnnotationProposal extends NewAnnotationProposal {
         }
 
         final Document changed = fInvocationNode.getViewProvider().getDocument();
-        return  new Change(changed, changed);
+        return  new Change(sourceCU.getViewProvider().getDocument(), changed);
     }
 
     private PsiAnnotationMemberValue newDefaultExpression(PsiAnnotation annotation) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyReturnTypeProposal.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/ModifyReturnTypeProposal.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.CodeActionKind;
  */
 public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
 
+    private final PsiFile sourceCU;
     private final PsiFile invocationNode;
     private final PsiElement binding;
     private final PsiType newReturnType;
@@ -39,9 +40,10 @@ public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
      *
      * @param newReturnType the new return type to change to
      */
-    public ModifyReturnTypeProposal(String label, PsiFile targetCU, PsiFile invocationNode,
+    public ModifyReturnTypeProposal(String label, PsiFile sourceCU, PsiFile invocationNode,
                                     PsiElement binding, int relevance, PsiType newReturnType) {
         super(label, CodeActionKind.QuickFix, relevance);
+        this.sourceCU = sourceCU;
         this.invocationNode = invocationNode;
         this.binding = binding;
         this.newReturnType = newReturnType;
@@ -60,6 +62,6 @@ public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
             }
         }
         final Document changed = invocationNode.getViewProvider().getDocument();
-        return new Change(changed, changed);
+        return new Change(sourceCU.getViewProvider().getDocument(), changed);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -90,7 +90,7 @@ public class InsertAnnotationQuickFix {
     private void addAttribute(Diagnostic diagnostic, JavaCodeActionContext context, PsiModifierListOwner binding,
                               PsiAnnotation annotation, List<CodeAction> codeActions, String name, String... attributes) {
         String label = getLabel(name, attributes);
-        ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(label, context.getCompilationUnit(),
+        ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(label, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), binding, annotation, 0, name, Arrays.asList(attributes));
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
 
@@ -105,11 +105,6 @@ public class InsertAnnotationQuickFix {
         if (element != null) {
             return element;
         }
-        // TODO: FOLLOWING ONE CHECK
-        // handle annotation insertions for a variable declaration
-//        if (node.getParent() instanceof VariableDeclarationFragment) {
-//            return ((PsiElement) node.getParent());
-//        }
         return PsiTreeUtil.getParentOfType(node, PsiClass.class);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -101,7 +101,7 @@ public class RemoveAnnotationConflictQuickFix {
         // API
         String name = getLabel(annotations);
         PsiElement declaringNode = getBinding(context.getCoveredNode());
-        ChangeCorrectionProposal proposal = new DeleteAnnotationProposal(name, context.getCompilationUnit(),
+        ChangeCorrectionProposal proposal = new DeleteAnnotationProposal(name, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, declaringNode, annotations);
         // Convert the proposal to LSP4J CodeAction
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
@@ -66,7 +66,7 @@ public class PersistenceAnnotationQuickFix extends InsertAnnotationMissingQuickF
         CodeAction codeAction = null;
 
         for (PsiAnnotation annotationNode : annotationNodes) {
-            ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getCompilationUnit(),
+            ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), binding, annotationNode, 0, attributes, annotations);
 
             // Convert the proposal to LSP4J CodeAction

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
@@ -15,7 +15,6 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet;
 
 import com.intellij.psi.PsiAnnotation;
-import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -92,7 +91,7 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
                 ArrayList<String> attributesToAdd = new ArrayList<>();
                 attributesToAdd.add(attribute);
                 String name = getLabel(annotation, attribute, "Add");
-                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getCompilationUnit(),
+                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getSource().getCompilationUnit(),
                         targetContext.getASTRoot(), parentType, annotationNode,  0, annotation, attributesToAdd);
                 // Convert the proposal to LSP4J CodeAction
                 CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
@@ -118,7 +117,7 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
                 ArrayList<String> attributesToRemove = new ArrayList<>();
                 attributesToRemove.add(attribute);
                 String name = getLabel(annotation, attribute, "Remove");
-                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getCompilationUnit(),
+                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getSource().getCompilationUnit(),
                         targetContext.getASTRoot(), parentType, annotationNode, 0, annotation, new ArrayList<String>(), attributesToRemove);
                 // Convert the proposal to LSP4J CodeAction
                 CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -92,7 +92,7 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
                 ArrayList<String> attributesToAdd = new ArrayList<>();
                 attributesToAdd.add(attribute);
                 String name = getLabel(annotation, attribute, "Add");
-                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getCompilationUnit(),
+                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getSource().getCompilationUnit(),
                         targetContext.getASTRoot(), parentType, annotationNode, 0, annotation, attributesToAdd);
                 // Convert the proposal to LSP4J CodeAction
                 CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);
@@ -120,7 +120,7 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
                 ArrayList<String> attributesToRemove = new ArrayList<>();
                 attributesToRemove.add(attribute);
                 String name = getLabel(annotation, attribute, "Remove");
-                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getCompilationUnit(),
+                ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, targetContext.getSource().getCompilationUnit(),
                         targetContext.getASTRoot(), parentType, annotationNode, 0, annotation, new ArrayList<String>(), attributesToRemove);
                 // Convert the proposal to LSP4J CodeAction
                 CodeAction codeAction = targetContext.convertToCodeAction(proposal, diagnostic);


### PR DESCRIPTION
Bring the source compilation unit into the code actions and use to create correct change objects. (Some of these were already done.) Create a sufficient number of copies of the code action context such that each call to getCodeActions() gets a fresh copy of the context. This is necessary to create correct text change proposals.

Fixes #310