### PR TITLE
Fix an error when starting with runIde.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.13.0'
+    id 'org.jetbrains.intellij' version '1.13.3'
 }
 
 group 'io.openliberty.tools'


### PR DESCRIPTION
The error is:
Execution failed for task ':runIde'.
> Unsupported JVM architecture was selected for running Gradle tasks: x86_64. Supported architectures: amd64, aarch64

This was fixed starting in 1.13.1 of the org.jetbrains.intellij plugin helper so I chose the latest: 1.13.3