### PR TITLE
Quickfixtest

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -257,10 +257,10 @@ public abstract class SingleModLibertyLSTestCommon {
         Path pathToServerXML = null;
         pathToServerXML = Paths.get(projectsPath, projectName,"src", "main", "liberty", "config", "server.xml");
 
-        // get focus on bootstrap.properties tab prior to copy
+        // get focus on server.xml tab prior to copy
         UIBotTestUtils.clickOnFileTab(remoteRobot, "server.xml");
 
-        // Save the current bootstrap.properties content.
+        // Save the current server.xml content.
         UIBotTestUtils.copyWindowContent(remoteRobot);
 
         try {

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -70,8 +70,8 @@ public abstract class SingleModLibertyLSTestCommon {
         String hoverExpectedOutcome = "This feature provides support for the MicroProfile Health specification.";
 
         //mover cursor to hover point
-        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.xml");
-        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot);
+        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.xml", UIBotTestUtils.PopupType.DOCUMENTATION);
+        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DOCUMENTATION);
 
         // Validate that the hover action raised the expected hint text
         TestUtils.validateHoverData(hoverExpectedOutcome, hoverFoundOutcome);
@@ -88,8 +88,8 @@ public abstract class SingleModLibertyLSTestCommon {
         String hoverExpectedOutcome = "Configuration properties for an HTTP endpoint.";
 
         //mover cursor to hover point
-        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.xml");
-        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot);
+        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.xml", UIBotTestUtils.PopupType.DOCUMENTATION);
+        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DOCUMENTATION);
 
         // Validate that the hover action raised the expected hint text
         TestUtils.validateHoverData(hoverExpectedOutcome, hoverFoundOutcome);
@@ -113,7 +113,7 @@ public abstract class SingleModLibertyLSTestCommon {
 
         // Insert a new element in server.xml.
         try {
-            UIBotTestUtils.insertStanzaInAppServerXML(remoteRobot, stanzaSnippet, 18, 40, UIBotTestUtils.InsertionType.FEATURE);
+            UIBotTestUtils.insertStanzaInAppServerXML(remoteRobot, stanzaSnippet, 18, 40, UIBotTestUtils.InsertionType.FEATURE, true);
             Path pathToServerXML = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "server.xml");
             TestUtils.validateStanzaInServerXML(pathToServerXML.toString(), insertedFeature);
         } finally {
@@ -140,7 +140,7 @@ public abstract class SingleModLibertyLSTestCommon {
 
         // Insert a new element in server.xml.
         try {
-            UIBotTestUtils.insertStanzaInAppServerXML(remoteRobot, stanzaSnippet, 20, 0, UIBotTestUtils.InsertionType.ELEMENT);
+            UIBotTestUtils.insertStanzaInAppServerXML(remoteRobot, stanzaSnippet, 20, 0, UIBotTestUtils.InsertionType.ELEMENT, true);
             Path pathToServerXML = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "server.xml");
             TestUtils.validateStanzaInServerXML(pathToServerXML.toString(), insertedConfig);
         } finally {
@@ -216,8 +216,8 @@ public abstract class SingleModLibertyLSTestCommon {
         String hoverExpectedOutcome = "This setting controls the granularity of messages that go to the console. The valid values are INFO, AUDIT, WARNING, ERROR, and OFF. The default is AUDIT. If using with the Eclipse developer tools this must be set to the default.";
 
         //mover cursor to hover point
-        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.env");
-        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot);
+        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "server.env", UIBotTestUtils.PopupType.DOCUMENTATION);
+        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DOCUMENTATION);
 
         // Validate that the hover action raised the expected hint text
         TestUtils.validateHoverData(hoverExpectedOutcome, hoverFoundOutcome);
@@ -235,11 +235,49 @@ public abstract class SingleModLibertyLSTestCommon {
         String hoverExpectedOutcome = "This setting controls the granularity of messages that go to the console. The valid values are INFO, AUDIT, WARNING, ERROR, and OFF. The default is AUDIT. If using with the Eclipse developer tools this must be set to the default.";
 
         //mover cursor to hover point
-        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "bootstrap.properties");
-        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot);
+        UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, testHoverTarget, "bootstrap.properties", UIBotTestUtils.PopupType.DOCUMENTATION);
+        String hoverFoundOutcome = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DOCUMENTATION);
 
         // Validate that the hover action raised the expected hint text
         TestUtils.validateHoverData(hoverExpectedOutcome, hoverFoundOutcome);
+    }
+
+    /**
+     * Tests liberty-ls support in server.xml for
+     * diagnostic and quickfix
+     */
+    @Test
+    @Video
+    public void testDiagnosticAndQuickFixInServerXML() {
+        String stanzaSnippet = "<mpMetrics authentication=wrong\" />";
+        String correctedStanza = "<mpMetrics authentication=\"true\" />";
+        String quickfixChooserString = "true";
+        String expectedHoverData = "cvc-datatype-valid.1.2.3: 'wrong' is not a valid value of union type 'booleanType'.";
+
+        Path pathToServerXML = null;
+        pathToServerXML = Paths.get(projectsPath, projectName,"src", "main", "liberty", "config", "server.xml");
+
+        // get focus on bootstrap.properties tab prior to copy
+        UIBotTestUtils.clickOnFileTab(remoteRobot, "server.xml");
+
+        // Save the current bootstrap.properties content.
+        UIBotTestUtils.copyWindowContent(remoteRobot);
+
+        try {
+            UIBotTestUtils.insertStanzaInAppServerXML(remoteRobot, stanzaSnippet,20, 0, UIBotTestUtils.InsertionType.ELEMENT, false);
+
+            //move cursor to hover point
+            UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, "wrong", "server.xml", UIBotTestUtils.PopupType.DIAGNOSTIC);
+            String foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);
+            TestUtils.validateHoverData(expectedHoverData, foundHoverData);
+            UIBotTestUtils.chooseQuickFix(remoteRobot, quickfixChooserString);
+            TestUtils.validateStanzaInServerXML(pathToServerXML.toString(), correctedStanza);
+
+        } finally {
+            // Replace server.xml content with the original content
+            UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
+        }
+
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -283,6 +283,12 @@ public class TestUtils {
         }
     }
 
+    /**
+     * Validates the expected server.xml stanza entry is found
+     *
+     * @param pathToServerXml The path to the server.xml file to be examined
+     * @param insertedStanza the full stanza that is to be found
+     */
     public static void validateStanzaInServerXML(String pathToServerXml, String insertedStanza) {
 
         try {
@@ -292,7 +298,13 @@ public class TestUtils {
         }
     }
 
-    public static void validateConfigStringInConfigFile(String pathToConfigFile, String expectedConfigString) {
+    /**
+     * Validates the expected configuration name vale pair entry is found in config file
+     *
+     * @param pathToConfigFile The path to the config file to be examined
+     * @param expectedConfigString the full setting string that is to be found
+     */
+        public static void validateConfigStringInConfigFile(String pathToConfigFile, String expectedConfigString) {
         try {
             Assertions.assertTrue(isTextInFile(pathToConfigFile, expectedConfigString));
         } catch (IOException e) {

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -63,7 +63,7 @@ public class UIBotTestUtils {
      * UI Popup window types.
      */
     public enum PopupType {
-        DOCUMENTATION, QUICKFIX, DIAGNOSTIC
+        DOCUMENTATION, DIAGNOSTIC
     }
 
     /**
@@ -892,7 +892,7 @@ public class UIBotTestUtils {
      */
     public static String getHoverStringData(RemoteRobot remoteRobot, PopupType popupType) {
         // get the text from the LS diagnostic hint popup
-        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
+        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
 
         ContainerFixture popup;
         switch (popupType.name()) {
@@ -904,7 +904,7 @@ public class UIBotTestUtils {
                 break;
             default:
                 // no known pane type specified, return
-                return null;
+                return "";
         }
 
         List<RemoteText> rts = popup.findAllText();
@@ -934,7 +934,7 @@ public class UIBotTestUtils {
         keyboard.hotKey(VK_ALT, VK_ENTER);
 
         // get the text from the quickfix popup
-        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
+        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         ContainerFixture popup = projectFrame.getQuickFixPane();
 
         popup.findText(contains(quickfixChooserString)).click();

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -60,6 +60,13 @@ public class UIBotTestUtils {
     }
 
     /**
+     * UI Popup window types.
+     */
+    public enum PopupType {
+        DOCUMENTATION, QUICKFIX, DIAGNOSTIC
+    }
+
+    /**
      * UI Frames.
      */
     public enum Frame {
@@ -616,12 +623,14 @@ public class UIBotTestUtils {
 
 
     /**
-     * Moves the mouse cursor to a specific string target in server.xml
+     * Moves the mouse cursor to a specific string target in a liberty config file
      *
      * @param remoteRobot The RemoteRobot instance.
-     * @param hoverTarget The string to hover over in server.xml
+     * @param hoverTarget The string to hover over in the config file
+     * @param hoverFile The string path to the config file
+     * @param popupType the type of popup window that is expected from the hover action
      */
-    public static void hoverInAppServerCfgFile(RemoteRobot remoteRobot, String hoverTarget, String hoverFile) {
+    public static void hoverInAppServerCfgFile(RemoteRobot remoteRobot, String hoverTarget, String hoverFile, PopupType popupType) {
 
         Keyboard keyboard = new Keyboard(remoteRobot);
 
@@ -649,7 +658,19 @@ public class UIBotTestUtils {
 
                 // first get the contents of the popup - put in a String
                 ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
-                ContainerFixture popup = projectFrame.getDocumentationHintEditorPane();
+                ContainerFixture popup;
+                switch (popupType.name()) {
+                    case "DOCUMENTATION":
+                        popup = projectFrame.getDocumentationHintEditorPane();
+                        break;
+                    case "DIAGNOSTIC":
+                        popup = projectFrame.getDiagnosticPane();
+                        break;
+                    default:
+                        // no known popup type provided, return
+                        return;
+                }
+
                 List<RemoteText> rts = popup.findAllText();
                 StringBuilder remoteString = new StringBuilder();
                 for (RemoteText rt : rts) {
@@ -746,8 +767,13 @@ public class UIBotTestUtils {
      * content prior to calling this method.
      *
      * @param remoteRobot The RemoteRobot instance.
+     * @param stanzaSnippet truncated feature name to be used to select full name from popup
+     * @param line line number (in editor) to place cursor for text insertion in server.xml
+     * @param col column number (in editor) to place cursor for text insertion in server.xml
+     * @param type the type of stanza being inserted - FEATURE or CONFIG
+     * @param completeWithPopup use the popup to complete the insertion (or the full text will be typed in)
      */
-    public static void insertStanzaInAppServerXML(RemoteRobot remoteRobot, String stanzaSnippet, int line, int col, InsertionType type) {
+    public static void insertStanzaInAppServerXML(RemoteRobot remoteRobot, String stanzaSnippet, int line, int col, InsertionType type, boolean completeWithPopup) {
 
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         clickOnFileTab(remoteRobot, "server.xml");
@@ -800,17 +826,19 @@ public class UIBotTestUtils {
                 keyboard.enterText(stanzaSnippet);
                 TestUtils.sleepAndIgnoreException(2);
 
-                // Select the appropriate completion suggestion in the pop-up window that is automatically
-                // opened as text is typed. Avoid hitting ctrl + space as it has the side effect of selecting
-                // and entry automatically if the completion suggestion windows has one entry only.
-                ComponentFixture completionPopupWindow = projectFrame.getLookupList();
-                RepeatUtilsKt.waitFor(Duration.ofSeconds(5),
-                        Duration.ofSeconds(1),
-                        "Waiting for text " + stanzaSnippet + " to appear in the completion suggestion pop-up window",
-                        "Text " + stanzaSnippet + " did not appear in the completion suggestion pop-up window",
-                        () -> completionPopupWindow.hasText(stanzaSnippet));
+                if (completeWithPopup) {
+                    // Select the appropriate completion suggestion in the pop-up window that is automatically
+                    // opened as text is typed. Avoid hitting ctrl + space as it has the side effect of selecting
+                    // and entry automatically if the completion suggestion windows has one entry only.
+                    ComponentFixture completionPopupWindow = projectFrame.getLookupList();
+                    RepeatUtilsKt.waitFor(Duration.ofSeconds(5),
+                            Duration.ofSeconds(1),
+                            "Waiting for text " + stanzaSnippet + " to appear in the completion suggestion pop-up window",
+                            "Text " + stanzaSnippet + " did not appear in the completion suggestion pop-up window",
+                            () -> completionPopupWindow.hasText(stanzaSnippet));
 
-                completionPopupWindow.findText(stanzaSnippet).doubleClick();
+                    completionPopupWindow.findText(stanzaSnippet).doubleClick();
+                }
 
                 // Save the file.
                 if (remoteRobot.isMac()) {
@@ -857,14 +885,28 @@ public class UIBotTestUtils {
     }
 
     /**
-     * Validates the expected hover string message was raised in popup.
+     * Gathers the hover string data from the popup
      *
      * @param remoteRobot the remote robot instance
+     * @param popupType the type of popup window expected
      */
-    public static String getHoverStringData(RemoteRobot remoteRobot) {
+    public static String getHoverStringData(RemoteRobot remoteRobot, PopupType popupType) {
         // get the text from the LS diagnostic hint popup
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
-        ContainerFixture popup = projectFrame.getDocumentationHintEditorPane();
+
+        ContainerFixture popup;
+        switch (popupType.name()) {
+            case "DOCUMENTATION":
+                popup = projectFrame.getDocumentationHintEditorPane();
+                break;
+            case "DIAGNOSTIC":
+                popup = projectFrame.getDiagnosticPane();
+                break;
+            default:
+                // no known pane type specified, return
+                return null;
+        }
+
         List<RemoteText> rts = popup.findAllText();
 
         // print out the string data found in the popup window - for debugging
@@ -876,6 +918,35 @@ public class UIBotTestUtils {
         }
 
         return popupString.toString();
+    }
+
+    /**
+     * Opens the quickfix menu popup and chooses the
+     * approriate fix according to the quickfix substring
+     *
+     * @param remoteRobot the remote robot instance
+     * @param quickfixChooserString the text to find in the quick fix menu
+     */
+    public static void chooseQuickFix(RemoteRobot remoteRobot, String quickfixChooserString) {
+
+        // first trigger the quickfix popup by using the keyboard
+        Keyboard keyboard = new Keyboard(remoteRobot);
+        keyboard.hotKey(VK_ALT, VK_ENTER);
+
+        // get the text from the quickfix popup
+        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
+        ContainerFixture popup = projectFrame.getQuickFixPane();
+
+        popup.findText(contains(quickfixChooserString)).click();
+
+        // Save the file.
+        if (remoteRobot.isMac()) {
+            keyboard.hotKey(VK_META, VK_S);
+        } else {
+            // linux + windows
+            keyboard.hotKey(VK_CONTROL, VK_S);
+        }
+
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -247,6 +247,24 @@ public class ProjectFrameFixture extends CommonContainerFixture {
     }
 
     /**
+     * Returns the ContainerFixture object associated with the DocumentationHintEditorPane pop-up window.
+     *
+     * @return The ContainerFixture object associated with the DocumentationHintEditorPane pop-up window.
+     */
+    public ContainerFixture getDiagnosticPane() {
+        return find(ContainerFixture.class, byXpath("//div[@class='HeavyWeightWindow']//div[@class='JEditorPane']"), Duration.ofSeconds(20));
+    }
+
+    /**
+     * Returns the ContainerFixture object associated with the DocumentationHintEditorPane pop-up window.
+     *
+     * @return The ContainerFixture object associated with the DocumentationHintEditorPane pop-up window.
+     */
+    public ContainerFixture getQuickFixPane() {
+        return find(ContainerFixture.class, byXpath("//div[@class='HeavyWeightWindow']//div[@class='JBViewport'][.//div[@class='MyList']]"), Duration.ofSeconds(20));
+    }
+
+    /**
      * Returns the ContainerFixture object associated with the JBTextArea class.
      *
      * @param xpathVars The Locator custom variables: waitTime(seconds)


### PR DESCRIPTION
adds a test that does the following:

- inserts a config stanza to server.xml containing an incorrect attribute value
- hovers on the flagged value and tests the resulting diagnostic popup contents
- opens the quickfix menu and chooses a correct value from list to correct the value in the stanza
- tests the correctness of the fixed stanza