### PR TITLE
Ensure there is a delay when starting dev mode in debug mode…

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -165,7 +165,7 @@ public class DebugModeHandler {
      */
     private String waitForSocketActivation(ProgressIndicator monitor, LibertyModule libertyModule, String host, int debugPort) throws Exception {
         byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
-        int retryLimit = 360; // wait up to 3 minutes for dev mode to start (polling rate 2 per second, 500ms)
+        int retryLimit = 60; // wait up to 3 minutes for dev mode to start (polling rate 20 per minute, 3s)
 
         // Retrieve the location of the server.env in the liberty installation at the default location (wpl/usr/servers/<serverName>).
         Path serverEnvPath = getServerEnvPath(libertyModule);
@@ -210,7 +210,7 @@ public class DebugModeHandler {
                     LOGGER.trace(String.format("ConnectException waiting for runtime to start on port %d", debugPort));
                 }
             }
-            TimeUnit.MILLISECONDS.sleep(500);
+            TimeUnit.SECONDS.sleep(3);
         }
         throw new Exception(LocalizedResourceUtil.getMessage("cannot.attach.debugger.host.port", host, String.format("%d",debugPort)));
     }


### PR DESCRIPTION
… waiting for debugger to connect and reading server.env

Modified the algorithm so it always waits a fixed amount of time waiting for dev mode to start and the Liberty runtime to start. Selected 60 seconds as the timeout. Previously the timeout varied depending on how quickly dev mode started. It varied from a few seconds up to 10 minutes. 

Note that we need to wait for mvn liberty:dev to start, d/l Liberty, unzip it, download and install features and start the Liberty runtime. *Does everyone think this is long enough?*

If the timeout expires a dialog is shown in the IDE.

Fixes #348