### PR TITLE
Disable microprofile quickfix for excluding property from validation

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
@@ -66,7 +66,7 @@ public class MicroProfileServer extends ProcessStreamConnectionProvider {
         Map<String, Object> extendedClientCapabilities = new HashMap<>();
         Map<String, Object> commands = new HashMap<>();
         Map<String, Object> commandsKind = new HashMap<>();
-        commandsKind.put("valueSet", Arrays.asList("microprofile.command.configuration.update", "microprofile.command.open.uri"));
+        commandsKind.put("valueSet", Arrays.asList(/*"microprofile.command.configuration.update",*/ "microprofile.command.open.uri"));
         commands.put("commandsKind", commandsKind);
         extendedClientCapabilities.put("commands", commands);
         extendedClientCapabilities.put("completion", new HashMap<>());


### PR DESCRIPTION
Mirroring https://github.com/redhat-developer/intellij-quarkus/pull/814 as this quickfix also does nothing for us