### PR TITLE
Add manual refresh tests

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
@@ -16,20 +16,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * Tests Liberty Tools actions using a Gradle project.
+ * Tests Liberty Tools actions using a single module MicroProfile Gradle project.
  */
-public class GradleSingleModProjectTest extends SingleModProjectTestCommon {
+public class GradleSingleModMPProjectTest extends SingleModMPProjectTestCommon {
 
     /**
      * Single module Microprofile project name.
      */
     private static final String SM_MP_PROJECT_NAME = "singleModGradleMP";
-
-    /**
-     * Single module REST project that lacks the configuration to be recognized by Liberty tools.
-     */
-    private final String SM_NLT_REST_PROJECT_NAME = "singleModGradleRESTNoLTXmlCfg";
-
+    
     /**
      * The path to the folder containing the test projects.
      */
@@ -114,20 +109,6 @@ public class GradleSingleModProjectTest extends SingleModProjectTestCommon {
     }
 
     /**
-     * Returns the name of the single module REST project that does not meet
-     * the requirements needed to automatically show in the Liberty tool window.
-     * This project's Liberty config file does not the expected name and the
-     * build file does not have any Liberty plugin related entries.
-     *
-     * @return The name of the single module REST project that does not meet the
-     * requirements needed to automatically show in the Liberty tool window.
-     */
-    @Override
-    public String getSmNLTRestProjectName() {
-        return SM_NLT_REST_PROJECT_NAME;
-    }
-
-    /**
      * Returns the expected HTTP response payload associated with the single module
      * MicroProfile project.
      *
@@ -194,7 +175,7 @@ public class GradleSingleModProjectTest extends SingleModProjectTestCommon {
      */
     @Override
     public void deleteTestReports() {
-        boolean testReportDeleted = TestUtils.deleteFile(TEST_REPORT_PATH.toFile());
+        boolean testReportDeleted = TestUtils.deleteFile(TEST_REPORT_PATH);
         Assertions.assertTrue(testReportDeleted, () -> "Test report file: " + TEST_REPORT_PATH + " was not be deleted.");
     }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModNLTRestProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModNLTRestProjectTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import com.automation.remarks.junit5.Video;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests that use a single module non Liberty Tools compliant REST Gradle project.
+ */
+public class GradleSingleModNLTRestProjectTest extends SingleModNLTRestProjectTestCommon {
+    /**
+     * The path to the folder containing helper test files.
+     */
+    public static String HELPER_FILES_PATH = Paths.get("src", "test", "resources", "files", "smNLTRestProject", "gradle").toAbsolutePath().toString();
+
+    /**
+     * The path to the folder containing the test projects.
+     */
+    private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "gradle").toAbsolutePath().toString();
+
+    /**
+     * Single module REST project that lacks the configuration to be recognized by Liberty tools.
+     */
+    private static final String SM_NLT_REST_PROJECT_NAME = "singleModGradleRESTNoLTXmlCfg";
+
+    /**
+     * Build file name.
+     */
+    private final String BUILD_FILE_NAME = "build.gradle";
+
+    /**
+     * Prepares the environment for test execution.
+     */
+    @BeforeAll
+    public static void setup() {
+        prepareEnv(PROJECTS_PATH, SM_NLT_REST_PROJECT_NAME);
+    }
+
+    /**
+     * Returns the directory path containing helper files.
+     *
+     * @return The directory path containing helper files.
+     */
+    public String getHelperFilesDirPath() {
+        return HELPER_FILES_PATH;
+    }
+
+    /**
+     * Returns the projects directory path.
+     *
+     * @return The projects directory path.
+     */
+    @Override
+    public String getProjectsDirPath() {
+        return PROJECTS_PATH;
+    }
+
+    /**
+     * Returns the name of the single module REST project that does not meet
+     * the requirements needed to automatically show in the Liberty tool window.
+     * This project's Liberty config file does not the expected name and the
+     * build file does not have any Liberty plugin related entries.
+     *
+     * @return The name of the single module REST project that does not meet the
+     * requirements needed to automatically show in the Liberty tool window.
+     */
+    @Override
+    public String getSmNLTRestProjectName() {
+        return SM_NLT_REST_PROJECT_NAME;
+    }
+
+    /**
+     * Returns the name of the build file used by the project.
+     *
+     * @return The name of the build file used by the project.
+     */
+    @Override
+    public String getBuildFileName() {
+        return BUILD_FILE_NAME;
+    }
+
+    /**
+     * Tests:
+     * - Refresh button on Liberty tool window toolbar.
+     * - Detecting a project with a valid Liberty M/G plugin configuration in build file only.
+     * The build file in this case uses the plugins DSL to apply the Liberty Tools binary dependency
+     * directly from the gradle plugin community (<a href="https://plugins.gradle.org/">...</a>).
+     */
+    @Test
+    @Video
+    @Disabled("Until this issue is resolved: https://github.com/OpenLiberty/liberty-tools-intellij/issues/299")
+    public void testsRefreshProjectWithLTBuildCfgOnly() {
+        // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+
+        // Replace the current build file with the file containing Liberty plugin config.
+        Path newCfg = Paths.get(getHelperFilesDirPath(), "pluginsDSLOnlyDepDef.build.gradle");
+        Path originalCfg = Paths.get(getProjectsDirPath(), getSmNLTRestProjectName(), getBuildFileName());
+        Path backupCfg = Paths.get(getProjectsDirPath(), getSmNLTRestProjectName(), getBuildFileName() + ".bak");
+        try {
+            Files.copy(originalCfg, backupCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            fail("Unable to backup " + originalCfg + " to " + backupCfg + ".", e);
+        }
+
+        try {
+            Files.copy(newCfg, originalCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            fail("Unable to copy " + newCfg + " to " + originalCfg + ".", e);
+        }
+
+        // User the refresh icon on the Liberty tool window.
+        UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+        try {
+            // Validate that the project is displayed in the Liberty tool window.
+            UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "10");
+        } finally {
+            // Replace the current build file with the backup file.
+            try {
+                Files.copy(backupCfg, originalCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+            } catch (Exception e) {
+                fail("Unable to copy " + backupCfg + " to " + originalCfg + ".", e);
+            }
+
+            // Delete the backup file.
+            if (!TestUtils.deleteFile(backupCfg)) {
+                fail("Unable to delete " + backupCfg);
+            }
+
+            // Refresh the Liberty tool window using the refresh icon on the toolbar.
+            UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+            // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+            UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+        }
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
@@ -23,19 +23,14 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 /**
- * Tests Liberty Tools actions using a Maven project.
+ * Tests Liberty Tools actions using a single module MicroProfile Maven project.
  */
-public class MavenSingleModProjectTest extends SingleModProjectTestCommon {
+public class MavenSingleModMPProjectTest extends SingleModMPProjectTestCommon {
 
     /**
      * Single module Microprofile project name.
      */
     private static final String SM_MP_PROJECT_NAME = "singleModMavenMP";
-
-    /**
-     * Single module REST project that lacks the configuration to be recognized by Liberty tools.
-     */
-    private final String SM_NLT_REST_PROJECT_NAME = "singleModMavenRESTNoLTXmlCfg";
 
     /**
      * The path to the folder containing the test projects.
@@ -125,21 +120,7 @@ public class MavenSingleModProjectTest extends SingleModProjectTestCommon {
     public String getSmMPProjectName() {
         return SM_MP_PROJECT_NAME;
     }
-
-    /**
-     * Returns the name of the single module REST project that does not meet
-     * the requirements needed to automatically show in the Liberty tool window.
-     * This project's Liberty config file does not the expected name and the
-     * build file does not have any Liberty plugin related entries.
-     *
-     * @return The name of the single module REST project that does not meet the
-     * requirements needed to automatically show in the Liberty tool window.
-     */
-    @Override
-    public String getSmNLTRestProjectName() {
-        return SM_NLT_REST_PROJECT_NAME;
-    }
-
+    
     /**
      * Returns the expected HTTP response payload associated with the single module
      * MicroProfile project.
@@ -207,10 +188,10 @@ public class MavenSingleModProjectTest extends SingleModProjectTestCommon {
      */
     @Override
     public void deleteTestReports() {
-        boolean itReportDeleted = TestUtils.deleteFile(pathToITReport.toFile());
+        boolean itReportDeleted = TestUtils.deleteFile(pathToITReport);
         Assertions.assertTrue(itReportDeleted, () -> "Test report file: " + pathToITReport + " was not be deleted.");
 
-        boolean utReportDeleted = TestUtils.deleteFile(pathToUTReport.toFile());
+        boolean utReportDeleted = TestUtils.deleteFile(pathToUTReport);
         Assertions.assertTrue(utReportDeleted, () -> "Test report file: " + pathToUTReport + " was not be deleted.");
     }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModNLTRestProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModNLTRestProjectTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import java.nio.file.Paths;
+
+/**
+ * Tests that use a single module non Liberty Tools compliant REST Maven project.
+ */
+public class MavenSingleModNLTRestProjectTest extends SingleModNLTRestProjectTestCommon {
+    /**
+     * The path to the folder containing helper test files.
+     */
+    public static String HELPER_FILES_PATH = Paths.get("src", "test", "resources", "files", "smNLTRestProject", "maven").toAbsolutePath().toString();
+
+    /**
+     * The path to the folder containing the test projects.
+     */
+    private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "maven").toAbsolutePath().toString();
+
+    /**
+     * Single module REST project that lacks the configuration to be recognized by Liberty tools.
+     */
+    private static final String SM_NLT_REST_PROJECT_NAME = "singleModMavenRESTNoLTXmlCfg";
+
+    /**
+     * Build file name.
+     */
+    private final String BUILD_FILE_NAME = "pom.xml";
+
+    /**
+     * Prepares the environment for test execution.
+     */
+    @BeforeAll
+    public static void setup() {
+        prepareEnv(PROJECTS_PATH, SM_NLT_REST_PROJECT_NAME);
+    }
+
+    /**
+     * Returns the directory path containing helper files.
+     *
+     * @return The directory path containing helper files.
+     */
+    public String getHelperFilesDirPath() {
+        return HELPER_FILES_PATH;
+    }
+
+    /**
+     * Returns the projects directory path.
+     *
+     * @return The projects directory path.
+     */
+    @Override
+    public String getProjectsDirPath() {
+        return PROJECTS_PATH;
+    }
+
+    /**
+     * Returns the name of the single module REST project that does not meet
+     * the requirements needed to automatically show in the Liberty tool window.
+     * This project's Liberty config file does not the expected name and the
+     * build file does not have any Liberty plugin related entries.
+     *
+     * @return The name of the single module REST project that does not meet the
+     * requirements needed to automatically show in the Liberty tool window.
+     */
+    @Override
+    public String getSmNLTRestProjectName() {
+        return SM_NLT_REST_PROJECT_NAME;
+    }
+
+    /**
+     * Returns the name of the build file used by the project.
+     *
+     * @return The name of the build file used by the project.
+     */
+    @Override
+    public String getBuildFileName() {
+        return BUILD_FILE_NAME;
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -19,12 +19,11 @@ import java.time.Duration;
 import java.util.Map;
 
 import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Common component for running both Maven and Gradle tests.
+ * Holds common tests that use a single module MicroProfile project.
  */
-public abstract class SingleModProjectTestCommon {
+public abstract class SingleModMPProjectTestCommon {
 
     /**
      * URL to display the UI Component hierarchy. This is used to obtain xPath related
@@ -176,84 +175,6 @@ public abstract class SingleModProjectTestCommon {
 
                 // Validate that the server stopped.
                 TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
-            }
-        }
-    }
-
-    /**
-     * Tests the Add/Remove project from the tool window actions run from the search everywhere panel .
-     */
-    @Test
-    @Video
-    public void testManualProjectAddRemoveActionUsingSearch() {
-        // Import the project that is not automatically detected by Liberty Tools.
-        UIBotTestUtils.importProject(remoteRobot, getProjectsDirPath(), getSmNLTRestProjectName());
-
-        // Open the dashboard and wait for the project to complete indexing.
-        UIBotTestUtils.openLibertyToolWindow(remoteRobot);
-
-        // Validate that the project tree is showing. Note that indexing may start at any time
-        // and automatically remove the existing content from the window (project/message/etc.).
-        TestUtils.sleepAndIgnoreException(10);
-        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "300");
-
-        try {
-            // Add the project to the Liberty tool window.
-            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Add project to the tool window");
-
-            // Select project from the 'Add Liberty project' dialog.
-            UIBotTestUtils.selectProjectFromAddLibertyProjectDialog(remoteRobot, getSmNLTRestProjectName());
-
-            try {
-                // Validate that the project is displayed in the Liberty tool window.
-                UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "10");
-            } finally {
-                // Remove the project from the Liberty tool window.
-                UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Remove project from the tool window");
-
-                // Select project from the 'Remote Liberty project' dialog.
-                UIBotTestUtils.selectProjectFromRemoveLibertyProjectDialog(remoteRobot, getSmNLTRestProjectName());
-
-                // Answer the 'Remove Liberty project' dialog in the affirmative.
-                UIBotTestUtils.respondToRemoveProjectQueryDialog(remoteRobot);
-
-                // Validate that the project was removed. An exception is expected.
-                try {
-                    for (int i = 0; i < 5; i++) {
-                        UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "2");
-                        try {
-                            Thread.sleep(2000);
-                        } catch (Exception ee) {
-                            // Nothing to do. Continue to the next iteration.
-                        }
-                    }
-
-                    fail("Project " + getSmNLTRestProjectName() + " is still present in the Liberty tool window despite it being removed.");
-                } catch (Exception e) {
-                    // The project was not found. Success.
-                }
-            }
-        } finally {
-            // Import the original project.
-            Exception error = null;
-            int maxRetries = 3;
-            for (int i = 0; i < maxRetries; i++) {
-                error = null;
-                try {
-                    UIBotTestUtils.importProject(remoteRobot, getProjectsDirPath(), getSmMPProjectName());
-                    UIBotTestUtils.openLibertyToolWindow(remoteRobot);
-                    UIBotTestUtils.expandLibertyToolWindowProjectTree(remoteRobot, getSmMPProjectName());
-                    break;
-                } catch (Exception e) {
-                    // There are instances in which the import actions are successful, but the
-                    // project view never comes up. Instead, the welcome view is shown. If that is the
-                    // case retry.
-                    error = e;
-                }
-            }
-
-            if (error != null) {
-                fail("Unable to open project " + getSmMPProjectName(), error);
             }
         }
     }
@@ -472,18 +393,6 @@ public abstract class SingleModProjectTestCommon {
      * @return The name of the single module MicroProfile project.
      */
     public abstract String getSmMPProjectName();
-
-
-    /**
-     * Returns the name of the single module REST project that does not meet
-     * the requirements needed to automatically show in the Liberty tool window.
-     * This project's Liberty config file does not have the expected default name,
-     * and the build file does not have any Liberty plugin related entries.
-     *
-     * @return The name of the single module REST project that does not meet the
-     * requirements needed to automatically show in the Liberty tool window.
-     */
-    public abstract String getSmNLTRestProjectName();
 
     /**
      * Returns the expected HTTP response payload associated with the single module

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import com.automation.remarks.junit5.Video;
+import com.intellij.remoterobot.RemoteRobot;
+import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+
+import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Holds common tests that use a single module non Liberty Tools compliant REST project.
+ */
+public abstract class SingleModNLTRestProjectTestCommon {
+
+    /**
+     * URL to display the UI Component hierarchy. This is used to obtain xPath related
+     * information to find UI components.
+     */
+    public static final String REMOTE_BOT_URL = "http://localhost:8082";
+
+    /**
+     * The remote robot object.
+     */
+    public static final RemoteRobot remoteRobot = new RemoteRobot(REMOTE_BOT_URL);
+
+    /**
+     * Processes actions before each test.
+     *
+     * @param info Test information.
+     */
+    @BeforeEach
+    public void beforeEach(TestInfo info) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Entry");
+    }
+
+    /**
+     * Processes actions after each test.
+     *
+     * @param info Test information.
+     */
+    @AfterEach
+    public void afterEach(TestInfo info) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+    }
+
+    /**
+     * Cleanup.
+     */
+    @AfterAll
+    public static void cleanup() {
+        UIBotTestUtils.closeLibertyToolWindow(remoteRobot);
+        UIBotTestUtils.closeProjectView(remoteRobot);
+        UIBotTestUtils.closeProjectFrame(remoteRobot);
+        UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
+    }
+
+    /**
+     * Tests manually Adding/Removing project from the tool window using the Liberty add/remove
+     * options available through search everywhere panel.
+     */
+    @Test
+    @Video
+    public void testManualProjectAddRemoveActionUsingSearch() {
+        // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+
+        // Add the project to the Liberty tool window.
+        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Add project to the tool window");
+
+        // Select project from the 'Add Liberty project' dialog.
+        UIBotTestUtils.selectProjectFromAddLibertyProjectDialog(remoteRobot, getSmNLTRestProjectName());
+
+        try {
+            // Validate that the project is displayed in the Liberty tool window.
+            UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "10");
+        } finally {
+            // Remove the project from the Liberty tool window.
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Remove project from the tool window");
+
+            // Select project from the 'Remote Liberty project' dialog.
+            UIBotTestUtils.selectProjectFromRemoveLibertyProjectDialog(remoteRobot, getSmNLTRestProjectName());
+
+            // Answer the 'Remove Liberty project' dialog in the affirmative.
+            UIBotTestUtils.respondToRemoveProjectQueryDialog(remoteRobot);
+
+            // Refresh the Liberty tool window using the refresh icon on the toolbar.
+            UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+            // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+            UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+        }
+    }
+
+    /**
+     * Tests:
+     * - Refresh button on Liberty tool window toolbar.
+     * - Detecting a project with a src/main/liberty/config/server.xml file only.
+     */
+    @Test
+    @Video
+    public void testsRefreshProjectWithServerXmlOnly() {
+        // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+
+        // Copy a valid server.xml file to this project's src/main/liberty/config directory.
+        Path validServerXml = Paths.get(getHelperFilesDirPath(), "server.xml");
+        Path destination = Paths.get(getProjectsDirPath(), getSmNLTRestProjectName(), "src", "main", "liberty", "config", "server.xml");
+
+        try {
+            Files.copy(validServerXml, destination, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            fail("Unable to copy " + validServerXml + " to " + destination + ".", e);
+        }
+
+        // Refresh the Liberty tool window using the refresh icon on the toolbar.
+        UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+        // Validate that the project is displayed in the Liberty tool window.
+        try {
+            UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "10");
+        } finally {
+            // Remove the previously added server.xml file.
+            if (!TestUtils.deleteFile(Paths.get(destination.toString()))) {
+                fail("Unable to delete " + destination);
+            }
+
+            // Refresh the Liberty tool window using the refresh icon on the toolbar.
+            UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+            // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+            UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+        }
+    }
+
+    /**
+     * Tests:
+     * - Refresh button on Liberty tool window toolbar.
+     * - Detecting a project with a valid Liberty M/G plugin configuration in build file only.
+     * The build file in this case uses a buildscript block to customize the version and the
+     * location of the Liberty Tools binary dependency.
+     */
+    @Test
+    @Video
+    public void testsRefreshProjectWithLTBuildCfgOnlyWithBldScriptBlock() {
+        // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+
+        // Replace the current build file with the file containing Liberty plugin config.
+        Path newCfg = Paths.get(getHelperFilesDirPath(), getBuildFileName());
+        Path originalCfg = Paths.get(getProjectsDirPath(), getSmNLTRestProjectName(), getBuildFileName());
+        Path backupCfg = Paths.get(getProjectsDirPath(), getSmNLTRestProjectName(), getBuildFileName() + ".bak");
+        try {
+            Files.copy(originalCfg, backupCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            fail("Unable to backup " + originalCfg + " to " + backupCfg + ".", e);
+        }
+
+        try {
+            Files.copy(newCfg, originalCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            fail("Unable to copy " + newCfg + " to " + originalCfg + ".", e);
+        }
+
+        // User the refresh icon on the Liberty tool window.
+        UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+        try {
+            // Validate that the project is displayed in the Liberty tool window.
+            UIBotTestUtils.findProjectInLibertyToolWindow(remoteRobot, getSmNLTRestProjectName(), "10");
+        } finally {
+            // Replace the current build file with the backup file.
+            try {
+                Files.copy(backupCfg, originalCfg, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+            } catch (Exception e) {
+                fail("Unable to copy " + backupCfg + " to " + originalCfg + ".", e);
+            }
+
+            // Delete the backup file.
+            if (!TestUtils.deleteFile(backupCfg)) {
+                fail("Unable to delete " + backupCfg);
+            }
+
+            // Refresh the Liberty tool window using the refresh icon on the toolbar.
+            UIBotTestUtils.refreshLibertyToolWindow(remoteRobot);
+
+            // Validate that the Liberty tool window project tree is not showing. No projects are expected.
+            UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "10");
+        }
+    }
+
+    /**
+     * Prepares the environment to run the tests.
+     *
+     * @param projectPath The path of the project.
+     * @param projectName The name of the project being used.
+     */
+    public static void prepareEnv(String projectPath, String projectName) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
+                "prepareEnv. Entry. ProjectPath: " + projectPath + ". ProjectName: " + projectName);
+        waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
+        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
+        UIBotTestUtils.openProjectView(remoteRobot);
+        UIBotTestUtils.openLibertyToolWindow(remoteRobot);
+
+        // Validate that the project tree is showing. Note that indexing may start at any time
+        // and automatically remove the existing content from the window (project/message/etc.).
+        TestUtils.sleepAndIgnoreException(10);
+        UIBotTestUtils.waitForLTWNoProjectDetectedMsg(remoteRobot, "300");
+
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
+                "prepareEnv. Exit. ProjectName: " + projectName);
+    }
+
+    /**
+     * Returns the directory path containing helper files.
+     *
+     * @return The directory path containing helper files.
+     */
+    public abstract String getHelperFilesDirPath();
+
+    /**
+     * Returns the projects directory path.
+     *
+     * @return The projects directory path.
+     */
+    public abstract String getProjectsDirPath();
+
+    /**
+     * Returns the name of the single module REST project that does not meet
+     * the requirements needed to automatically show in the Liberty tool window.
+     * This project's Liberty config file does not have the expected default name,
+     * and the build file does not have any Liberty plugin related entries.
+     *
+     * @return The name of the single module REST project that does not meet the
+     * requirements needed to automatically show in the Liberty tool window.
+     */
+    public abstract String getSmNLTRestProjectName();
+
+    /**
+     * Returns the name of the build file used by the project.
+     *
+     * @return The name of the build file used by the project.
+     */
+    public abstract String getBuildFileName();
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -407,11 +407,12 @@ public class TestUtils {
     /**
      * Deletes file identified by the input path. If the file is a directory, it must be empty.
      *
-     * @param file The file.
+     * @param path The path of the file to delete.
      * @return Returns true if the file identified by the input path was deleted. False, otherwise.
      */
-    public static boolean deleteFile(File file) {
+    public static boolean deleteFile(Path path) {
         boolean deleted = true;
+        File file = path.toFile();
 
         if (file.exists()) {
             if (!file.isDirectory()) {

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -640,8 +640,8 @@ public class UIBotTestUtils {
      *
      * @param remoteRobot The RemoteRobot instance.
      * @param hoverTarget The string to hover over in the config file
-     * @param hoverFile The string path to the config file
-     * @param popupType the type of popup window that is expected from the hover action
+     * @param hoverFile   The string path to the config file
+     * @param popupType   the type of popup window that is expected from the hover action
      */
     public static void hoverInAppServerCfgFile(RemoteRobot remoteRobot, String hoverTarget, String hoverFile, PopupType popupType) {
 
@@ -792,11 +792,11 @@ public class UIBotTestUtils {
      * Inserts content to server.xml. Callers are required to have done a UI copy of the server.xml
      * content prior to calling this method.
      *
-     * @param remoteRobot The RemoteRobot instance.
-     * @param stanzaSnippet truncated feature name to be used to select full name from popup
-     * @param line line number (in editor) to place cursor for text insertion in server.xml
-     * @param col column number (in editor) to place cursor for text insertion in server.xml
-     * @param type the type of stanza being inserted - FEATURE or CONFIG
+     * @param remoteRobot       The RemoteRobot instance.
+     * @param stanzaSnippet     truncated feature name to be used to select full name from popup
+     * @param line              line number (in editor) to place cursor for text insertion in server.xml
+     * @param col               column number (in editor) to place cursor for text insertion in server.xml
+     * @param type              the type of stanza being inserted - FEATURE or CONFIG
      * @param completeWithPopup use the popup to complete the insertion (or the full text will be typed in)
      */
     public static void insertStanzaInAppServerXML(RemoteRobot remoteRobot, String stanzaSnippet, int line, int col, InsertionType type, boolean completeWithPopup) {
@@ -914,7 +914,7 @@ public class UIBotTestUtils {
      * Gathers the hover string data from the popup
      *
      * @param remoteRobot the remote robot instance
-     * @param popupType the type of popup window expected
+     * @param popupType   the type of popup window expected
      */
     public static String getHoverStringData(RemoteRobot remoteRobot, PopupType popupType) {
         // get the text from the LS diagnostic hint popup
@@ -950,7 +950,7 @@ public class UIBotTestUtils {
      * Opens the quickfix menu popup and chooses the
      * approriate fix according to the quickfix substring
      *
-     * @param remoteRobot the remote robot instance
+     * @param remoteRobot           the remote robot instance
      * @param quickfixChooserString the text to find in the quick fix menu
      */
     public static void chooseQuickFix(RemoteRobot remoteRobot, String quickfixChooserString) {
@@ -1138,7 +1138,7 @@ public class UIBotTestUtils {
                 Thread.sleep(secondsToWait * 1000L);
             }
 
-            URL url = new URL(MavenSingleModProjectTest.REMOTE_BOT_URL);
+            URL url = new URL(MavenSingleModMPProjectTest.REMOTE_BOT_URL);
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
 
@@ -1618,6 +1618,23 @@ public class UIBotTestUtils {
                 TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, "Retrying server stop. Cause: " + e.getMessage());
             }
         }
+    }
+
+    /**
+     * Refreshed the Liberty tool window using the refresh icon.
+     *
+     * @param remoteRobot The RemoteRobot instance.
+     */
+    public static void refreshLibertyToolWindow(RemoteRobot remoteRobot) {
+        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
+
+        // Click on the Liberty toolbar to give it focus.
+        ComponentFixture libertyTWBar = projectFrame.getBaseLabel("Liberty", "10");
+        libertyTWBar.click();
+
+        String xPath = "//div[@class='LibertyExplorer']//div[@tooltiptext.key='action.io.openliberty.tools.intellij.actions.RefreshLibertyToolbar.text']";
+        ComponentFixture actionButton = projectFrame.getActionButton(xPath, "10");
+        actionButton.click();
     }
 
     /**

--- a/src/test/resources/files/smNLTRestProject/gradle/build.gradle
+++ b/src/test/resources/files/smNLTRestProject/gradle/build.gradle
@@ -1,0 +1,56 @@
+apply plugin: "liberty"
+apply plugin: "war"
+
+version '1.0-SNAPSHOT'
+group 'test'
+
+sourceCompatibility = 17
+targetCompatibility = 17
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// configure liberty-gradle-plugin
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        // Sonatype repo for getting the latest binary scanner jar snapshot
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
+    dependencies {
+        classpath "io.openliberty.tools:liberty-gradle-plugin:3.5.2"
+    }
+}
+
+dependencies {
+    // provided dependencies
+    providedCompile 'jakarta.platform:jakarta.jakartaee-api:9.1.0'
+    providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation 'org.jboss.resteasy:resteasy-client:6.0.0.Final'
+    testImplementation 'org.jboss.resteasy:resteasy-json-binding-provider:6.0.0.Final'
+    testImplementation 'org.glassfish:jakarta.json:2.0.1'
+}
+
+test {
+    useJUnitPlatform()
+
+    testLogging {
+        displayGranularity 1
+        showStandardStreams = true
+        showStackTraces = true
+        exceptionFormat = 'full'
+        events 'PASSED', 'FAILED', 'SKIPPED'
+    }
+}
+
+test.dependsOn 'libertyStart'
+clean.dependsOn 'libertyStop'

--- a/src/test/resources/files/smNLTRestProject/gradle/pluginsDSLOnlyDepDef.build.gradle
+++ b/src/test/resources/files/smNLTRestProject/gradle/pluginsDSLOnlyDepDef.build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'war'
+    id 'io.openliberty.tools.gradle.Liberty' version '3.5.2'
+}
+
+version '1.0-SNAPSHOT'
+group 'test'
+
+sourceCompatibility = 17
+targetCompatibility = 17
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // provided dependencies
+    providedCompile 'jakarta.platform:jakarta.jakartaee-api:9.1.0'
+    providedCompile 'org.eclipse.microprofile:microprofile:5.0'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation 'org.jboss.resteasy:resteasy-client:6.0.0.Final'
+    testImplementation 'org.jboss.resteasy:resteasy-json-binding-provider:6.0.0.Final'
+    testImplementation 'org.glassfish:jakarta.json:2.0.1'
+}
+
+test {
+    useJUnitPlatform()
+
+    testLogging {
+        displayGranularity 1
+        showStandardStreams = true
+        showStackTraces = true
+        exceptionFormat = 'full'
+        events 'PASSED', 'FAILED', 'SKIPPED'
+    }
+}
+
+test.dependsOn 'libertyStart'
+clean.dependsOn 'libertyStop'

--- a/src/test/resources/files/smNLTRestProject/gradle/server.xml
+++ b/src/test/resources/files/smNLTRestProject/gradle/server.xml
@@ -15,7 +15,7 @@
     </featureManager>
 
     <httpEndpoint host="*" httpPort="9091"
-                  httpsPort="9454" id="defaultHttpEndpoint"/>
+                  httpsPort="9054" id="defaultHttpEndpoint"/>
 
     <webApplication contextRoot="/" location="singleModGradleRESTNoLTXmlCfg.war"/>
 

--- a/src/test/resources/files/smNLTRestProject/maven/pom.xml
+++ b/src/test/resources/files/smNLTRestProject/maven/pom.xml
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+ Copyright (c) 2023 IBM Corporation.
+
+ This program and the accompanying materials are made available under the
+ terms of the Eclipse Public License v. 2.0 which is available at
+ http://www.eclipse.org/legal/epl-2.0.
+
+ SPDX-License-Identifier: EPL-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>singleModMavenRESTNoLTXmlCfg</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>5.0</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>6.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <!-- Plugin to run functional tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/files/smNLTRestProject/maven/server.xml
+++ b/src/test/resources/files/smNLTRestProject/maven/server.xml
@@ -14,8 +14,8 @@
         <feature>jsonb-2.0</feature>
     </featureManager>
 
-    <httpEndpoint host="*" httpPort="9091"
-                  httpsPort="9454" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="9081"
+                  httpsPort="9044" id="defaultHttpEndpoint"/>
 
     <webApplication contextRoot="/" location="singleModGradleRESTNoLTXmlCfg.war"/>
 


### PR DESCRIPTION
This PR tests:
- The refresh icon on the Liberty tool window toolbar.
- Manually adding to the Liberty tool window a Gradle/Maven app with valid serve.xml and no LGP/LMP config in build file.
- Manually adding to the Liberty tool window a Gradle/Maven app with a valid LMP/LGP config in build file and not a valid server.xml.
- Liberty tools being able to handle a build.gradle build file that defines the plugins DSL to apply the Liberty Tools binary dependency directly from the gradle plugin community.