### PR TITLE
Listen to in-memory document updates to make the cache more responsive to config changes.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
@@ -10,6 +10,8 @@
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.project;
 
 import com.intellij.openapi.compiler.CompilerPaths;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -19,6 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 
@@ -163,12 +167,13 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
 			return null;
 		}
 		try {
-			long currentLastModified = configFile.getModificationStamp();
+			final Document doc = FileDocumentManager.getInstance().getDocument(configFile);
+			long currentLastModified = doc.getModificationStamp();
 			if (currentLastModified != lastModified) {
 				reset();
-				try (InputStream input = configFile.getInputStream()) {
+				try (Reader input = new StringReader(doc.getText())) {
 					config = loadConfig(input);
-					lastModified = configFile.getModificationStamp();
+					lastModified = doc.getModificationStamp();
 				} catch (IOException e) {
 					reset();
 					LOGGER.error("Error while loading properties from '" + configFile + "'.", e);
@@ -206,13 +211,13 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
 	}
 
 	/**
-	 * Load the config model from the given input stream <code>input</code>.
+	 * Load the config model from the given reader <code>input</code>.
 	 * 
-	 * @param input the input stream
-	 * @return he config model from the given input stream <code>input</code>.
+	 * @param input the reader
+	 * @return he config model from the given reader <code>input</code>.
 	 * @throws IOException
 	 */
-	protected abstract T loadConfig(InputStream input) throws IOException;
+	protected abstract T loadConfig(Reader input) throws IOException;
 
 	/**
 	 * Load the property informations.

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PropertiesConfigSource.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PropertiesConfigSource.java
@@ -14,6 +14,7 @@ import org.eclipse.lsp4mp.commons.utils.PropertyValueExpander;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +57,7 @@ public class PropertiesConfigSource extends AbstractConfigSource<Properties> {
 	}
 
 	@Override
-	protected Properties loadConfig(InputStream input) throws IOException {
+	protected Properties loadConfig(Reader input) throws IOException {
 		propertyValueExpander = null;
 		Properties properties = new Properties();
 		properties.load(input);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PropertiesConfigSource.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PropertiesConfigSource.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.module.Module;
 import org.eclipse.lsp4mp.commons.utils.PropertyValueExpander;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Required to address #328.

This PR also fixes several NPEs that could occur if cache eviction overlaps with other operations on the PsiMicroProfileProject. The way PsiMicroProfileProject was written probably still isn't thread-safe, but this addresses the more obvious race conditions.