### PR TITLE
when hover does not provoke a popup, click on pane before trying again

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -700,6 +700,8 @@ public class UIBotTestUtils {
             } catch (WaitForConditionTimeoutException wftoe) {
                 error = wftoe;
                 TestUtils.sleepAndIgnoreException(2);
+                // click on center of editor pane - allow hover to work on next attempt
+                editorNew.click();
             }
         }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -661,7 +661,9 @@ public class UIBotTestUtils {
                 // Find the target text on the editor and move the move to it.
                 editorNew.findText(contains(hoverTarget)).moveMouse();
                 // clear and "lightbulb" icons?
-                keyboard.hotKey(VK_ESCAPE);
+                if (!hoverFile.equals("server.xml")) {
+                    keyboard.hotKey(VK_ESCAPE);
+                }
 
                 // jitter the cursor
                 Point p = editorNew.findText(contains(hoverTarget)).getPoint();
@@ -689,13 +691,6 @@ public class UIBotTestUtils {
                 for (RemoteText rt : rts) {
                     remoteString.append(rt.getText());
                 }
-
-                // Check for "Fetching Documentation" message indicating there is a delay in getting hint
-                // allow some time for the LS hint to appear in the popup
-                if (remoteString.toString().contains("Fetching Documentation")) {
-                    TestUtils.sleepAndIgnoreException(2);
-                }
-
                 break;
             } catch (WaitForConditionTimeoutException wftoe) {
                 error = wftoe;
@@ -852,7 +847,6 @@ public class UIBotTestUtils {
 
                 // For either a FEATURE or a CONFIG stanza, insert where the cursor is currently located.
                 keyboard.enterText(stanzaSnippet);
-                TestUtils.sleepAndIgnoreException(2);
 
                 if (completeWithPopup) {
                     // Select the appropriate completion suggestion in the pop-up window that is automatically
@@ -890,8 +884,6 @@ public class UIBotTestUtils {
         if (error != null) {
             throw new RuntimeException("Unable to insert entry in server.xml using text: " + stanzaSnippet, error);
         }
-
-        TestUtils.sleepAndIgnoreException(5);
     }
 
     /**


### PR DESCRIPTION
fixes #374 
fix intermittent failure on the diagnostic - quickfix testcase by clicking on the editor pane if an attempt fails