### PR TITLE
Remove use of internal API Module.getModuleFilePath().

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LSPIJUtils.java
@@ -13,12 +13,10 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VfsUtil;
-import com.intellij.openapi.vfs.VfsUtilCore;
-import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.*;
 import com.intellij.psi.PsiElement;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.lsp4j.CompletionParams;
@@ -138,8 +136,13 @@ public class LSPIJUtils {
     }
 
     public static URI toUri(Module project) {
-        File file = new File(project.getModuleFilePath()).getParentFile();
-        return file.toURI();
+        // Module.getModuleFilePath() is an internal only API
+        // File file = new File(project.getModuleFilePath()).getParentFile();
+        VirtualFile[] roots = ModuleRootManager.getInstance(project).getContentRoots();
+        if (roots.length > 0) {
+            return roots[0].toNioPath().toUri(); // choose one of the context roots
+        }
+        return URI.create("file:///"); // error return value //$NON-NLS-1$
     }
 
     public static void applyWorkspaceEdit(WorkspaceEdit edit) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
@@ -12,9 +12,9 @@ package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
@@ -43,7 +43,6 @@ import com.intellij.psi.util.PsiTreeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -255,10 +254,13 @@ public class PsiTypeUtils {
         String location = null;
         Module module = ProjectFileIndex.getInstance(project).getModuleForFile(directory);
         if (module != null) {
-            VirtualFile moduleRoot = LocalFileSystem.getInstance().findFileByIoFile(new File(module.getModuleFilePath()).getParentFile());
-            String path = VfsUtilCore.getRelativePath(directory, moduleRoot);
-            if (path != null) {
-                location = '/' + module.getName() + '/' + path;
+            VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
+            if (roots != null) {
+                VirtualFile moduleRoot = roots[0]; // choose any
+                String path = VfsUtilCore.getRelativePath(directory, moduleRoot);
+                if (path != null) {
+                    location = '/' + module.getName() + '/' + path;
+                }
             }
         }
         if (location == null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
@@ -255,7 +255,7 @@ public class PsiTypeUtils {
         Module module = ProjectFileIndex.getInstance(project).getModuleForFile(directory);
         if (module != null) {
             VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
-            if (roots != null) {
+            if (roots.length > 0) {
                 VirtualFile moduleRoot = roots[0]; // choose any
                 String path = VfsUtilCore.getRelativePath(directory, moduleRoot);
                 if (path != null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.lsp4mp.commons.DocumentFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URL;
@@ -191,7 +192,13 @@ public class PsiUtilsLSImpl implements IPsiUtils {
     }
 
     public static String getProjectURI(Module module) {
-        return module.getModuleFilePath();
+        // Module.getModuleFilePath() is an internal only API
+        // return module.getModuleFilePath();
+        VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
+        if (roots.length > 0) {
+            return roots[0].toNioPath().toString().replace(File.separatorChar, '/'); // choose one of the context roots
+        }
+        return "/"; // error return value //$NON-NLS-1$
     }
 
     @Override


### PR DESCRIPTION
The error return when a module has no source directories should not happen in our case so a harmless non-null value is returned.

Part of #61