### PR TITLE
Check the initialize future for null before using it.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
@@ -733,6 +733,14 @@ public class LanguageServerWrapper {
     }
 
     void registerCapability(RegistrationParams params) {
+        if (initializeFuture == null) { // language server is shutting down but registration messages are still arriving
+            if (LOGGER.isDebugEnabled()) {
+                StringBuffer buffer = new StringBuffer();
+                params.getRegistrations().forEach(reg -> { buffer.append(reg.getMethod()).append(","); });
+                LOGGER.info("registerCapability, initializeFuture==null, ignore capabilities " + buffer);
+            }
+            return;
+        }
         initializeFuture.thenRun(() -> {
             params.getRegistrations().forEach(reg -> {
                 if ("workspace/didChangeWorkspaceFolders".equals(reg.getMethod())) { //$NON-NLS-1$


### PR DESCRIPTION
The danger in a simple null check is that we will miss or ignore a register capabilities message that will be needed later. I tried several approaches to marshal the threads but they all led to failures elsewhere.

In lsp4e the initializeFuture is not even checked but in IntelliJ this results in the capabilities field not being ready to receive the data (it is null when we need to register something). 

The future is set to null early in the stop() method so I tried to set it later but stopping the language server is performed asynchronously so this did not help. I tried to synchronize with the thread that stops the language server by waiting for it to complete before setting the initialize future to null but this caused a different failure. The language server is stopped asynchronously for a reason. 

Since this happens when stopping one project and starting another I tried waiting for all the register capabilities messages to be received and handled before starting the next project but these messages were held and not processed until the stop was issued. 

Since this exception seems to arise only when we stop the language servers while closing a project it seems acceptable to drop the register capabilities messages and move on.

Fixes #390