### PR TITLE
expand parser on build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ video
 .gradle
 .idea
 .DS_Store
-bin/main/
+bin/

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModNLTRestProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModNLTRestProjectTest.java
@@ -100,7 +100,6 @@ public class GradleSingleModNLTRestProjectTest extends SingleModNLTRestProjectTe
      */
     @Test
     @Video
-    @Disabled("Until this issue is resolved: https://github.com/OpenLiberty/liberty-tools-intellij/issues/299")
     public void testsRefreshProjectWithLTBuildCfgOnly() {
         testsRefreshProjectWithLTBuildCfgOnly("pluginsDSLOnlyDepDef.build.gradle");
     }


### PR DESCRIPTION
Addresses #299 and #26

![image](https://github.com/OpenLiberty/liberty-tools-intellij/assets/8934136/04973d9d-cb8f-450c-8f83-efdc4851c665)

Includes:  
- Minor syntax changes
- Added main regex for identifying the Liberty Gradle plugin. Uses `build.gradle` syntax as heuristics
    - Included in the regex is search for optional version definition. 
    - Assumes if version is not defined, Gradle pulls the latest version