### PR TITLE
Ensure getCodeActions() does not return null and returns a list instead.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -47,7 +48,7 @@ public class ManagedBeanNoArgConstructorQuickFix {
 
             return codeActions;
         }
-        return null;
+        return Collections.emptyList();
     }
 
     protected PsiClass getBinding(PsiElement node) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.Diagnostic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,7 +79,7 @@ public class RemoveAnnotationConflictQuickFix {
             removeAnnotations(diagnostic, context, parentType, codeActions);
             return codeActions;
         }
-        return null;
+        return Collections.emptyList();
 
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -55,19 +55,18 @@ import java.util.List;
  */
 public class PersistenceEntityQuickFix {
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
         PsiElement node = context.getCoveredNode();
         PsiClass parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
 
             // add constructor
             if (diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_EMPTY_CONSTRUCTOR)) {
                 codeActions.addAll(addConstructor(diagnostic, context, parentType));
             }
 
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     protected PsiClass getBinding(PsiElement node) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
@@ -40,10 +40,10 @@ import java.util.List;
 public class FilterImplementationQuickFix {
 
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
         PsiElement node = context.getCoveredNode();
         PsiClass parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             // Create code action
             // interface
             ChangeCorrectionProposal proposal = new ImplementInterfaceProposal(
@@ -54,9 +54,8 @@ public class FilterImplementationQuickFix {
             if (codeAction != null) {
                 codeActions.add(codeAction);
             }
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     private PsiClass getBinding(PsiElement node) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
@@ -40,10 +40,10 @@ import java.util.List;
  */
 public class HttpServletQuickFix {
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
         PsiElement node = context.getCoveredNode();
         PsiClass parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             // Create code action
             // interface
             final String TITLE_MESSAGE = "Let ''{0}'' extend ''{1}''";
@@ -56,9 +56,8 @@ public class HttpServletQuickFix {
             if (codeAction != null) {
                 codeActions.add(codeAction);
             }
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     private PsiClass getBinding(PsiElement node) {


### PR DESCRIPTION
This mirrors a fix in lsp4jakarta. In very short methods I changed the return to Collections.emptylist() but in the slightly longer methods I moved the definition of the return value out of the `if`. This is more like what we do in lsp4jakarta JDT component.