### PR TITLE
Disconnect LS on FileClosed

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -48,28 +49,6 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectC
             // Force the start of all languages servers mapped with the given file
             LanguageServiceAccessor.getInstance(source.getProject())
                     .getLanguageServers(document, capabilities -> true);
-        }
-    }
-
-    @Override
-    public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-        URI uri = LSPIJUtils.toUri(file);
-        if (uri != null) {
-            try {                
-                // TODO: revisit this code, because it can restart language servers
-                // when a diagnostics is published after the file is closed and the project is closed
-                // See https://github.com/redhat-developer/intellij-quarkus/issues/840
-                // Remove the cached file wrapper if needed
-                LSPVirtualFileWrapper.dispose(file);
-                // Disconnect the given file from all language servers
-                LanguageServiceAccessor.getInstance(source.getProject())
-                        .getLSWrappers(file, capabilities -> true)
-                        .forEach(
-                                wrapper -> wrapper.disconnect(uri)
-                        );
-            } catch (Exception e) {
-                LOGGER.warn("Error while disconnecting the file '" + uri + "' from all language servers", e);
-            }
         }
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
@@ -125,8 +125,4 @@ public class LanguageClientImpl implements LanguageClient {
         return future;
     }
 
-    // public void dispose() {
-
-    // }
-
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
@@ -125,4 +125,8 @@ public class LanguageClientImpl implements LanguageClient {
         return future;
     }
 
+    // public void dispose() {
+
+    // }
+
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
@@ -75,7 +75,7 @@ public class PsiUtilsLSImpl implements IPsiUtils {
 
     @Override
     public Module getModule(VirtualFile file) {
-        if (file != null) {
+        if (file != null && !project.isDisposed()) {
             return ProjectFileIndex.getInstance(project).getModuleForFile(file, false);
         }
         return null;
@@ -174,7 +174,11 @@ public class PsiUtilsLSImpl implements IPsiUtils {
         try {
             VirtualFile file = findFile(uri);
             if (file != null) {
-                return PsiManager.getInstance(getModule(file).getProject()).findFile(file);
+                Module module = getModule(file);
+                if (module == null) {
+                    return null;
+                }
+                return PsiManager.getInstance(module.getProject()).findFile(file);
             }
         } catch (IOException e) {
             LOGGER.error(e.getLocalizedMessage(), e);


### PR DESCRIPTION
Address #400 

A specific section pulled from Angelo's https://github.com/redhat-developer/intellij-quarkus/pull/849

The issue with the original fileClosed is that it loops over language servers and tries call getServerCapabilities. When the LS wrapper is stopped and a file is closed, it creates a contradiction to restart the LS with getServerCapabilities and stop at the same time.
