### PR TITLE
Report an error if Java 17 (or higher) is not found for launching the language servers.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
@@ -14,6 +14,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.server.ProcessStreamConnectionProvider;
+import io.openliberty.tools.intellij.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,13 @@ public class LibertyConfigLanguageServer extends ProcessStreamConnectionProvider
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
             LOGGER.error("Unable to launch the Liberty language server. Could not resolve the java home system property");
+            return;
+        }
+        if (!checkJavaVersion(javaHome, Constants.REQUIRED_JAVA_VERSION)) {
+            LOGGER.error("Unable to launch the Liberty language server." +
+                    " Java " + Constants.REQUIRED_JAVA_VERSION + " or more recent is required to run 'Liberty Tools for IntelliJ'." +
+                    " Change the boot Java runtime of the IDE as documented here:" +
+                    " https://www.jetbrains.com/help/idea/switching-boot-jdk.html");
             return;
         }
         if (libertyServerPath.exists()) {

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
@@ -14,6 +14,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.server.ProcessStreamConnectionProvider;
+import io.openliberty.tools.intellij.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,13 @@ public class LibertyXmlServer extends ProcessStreamConnectionProvider {
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
             LOGGER.error("Unable to launch the LemMinX language server. Could not resolve the java home system property");
+            return;
+        }
+        if (!checkJavaVersion(javaHome, Constants.REQUIRED_JAVA_VERSION)) {
+            LOGGER.error("Unable to launch the LemMinX language server." +
+                    " Java " + Constants.REQUIRED_JAVA_VERSION + " or more recent is required to run 'Liberty Tools for IntelliJ'." +
+                    " Change the boot Java runtime of the IDE as documented here:" +
+                    " https://www.jetbrains.com/help/idea/switching-boot-jdk.html");
             return;
         }
         if (lemminxServerPath.exists() && libertyServerPath.exists()) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
@@ -15,6 +15,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.server.ProcessStreamConnectionProvider;
+import io.openliberty.tools.intellij.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,13 @@ public class JakartaLanguageServer extends ProcessStreamConnectionProvider {
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
             LOGGER.error("Unable to launch the Eclipse LSP4Jakarta language server. Could not resolve the java home system property");
+            return;
+        }
+        if (!checkJavaVersion(javaHome, Constants.REQUIRED_JAVA_VERSION)) {
+            LOGGER.error("Unable to launch the Eclipse LSP4Jakarta language server." +
+                    " Java " + Constants.REQUIRED_JAVA_VERSION + " or more recent is required to run 'Liberty Tools for IntelliJ'." +
+                    " Change the boot Java runtime of the IDE as documented here:" +
+                    " https://www.jetbrains.com/help/idea/switching-boot-jdk.html");
             return;
         }
         if (lsp4JakartaServerPath.exists()) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
@@ -15,6 +15,7 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import io.openliberty.tools.intellij.liberty.lsp.LibertyXmlServer;
 import io.openliberty.tools.intellij.lsp4mp.lsp4ij.server.ProcessStreamConnectionProvider;
+import io.openliberty.tools.intellij.util.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,14 @@ public class MicroProfileServer extends ProcessStreamConnectionProvider {
         File lsp4mpServerPath = new File(descriptor.getPluginPath().toFile(), "lib/server/org.eclipse.lsp4mp.ls-uber.jar");
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
-            LOGGER.error("Unable to launch Eclipse LSP4MP language server. Could not resolve the java home system property");
+            LOGGER.error("Unable to launch the Eclipse LSP4MP language server. Could not resolve the java home system property");
+            return;
+        }
+        if (!checkJavaVersion(javaHome, Constants.REQUIRED_JAVA_VERSION)) {
+            LOGGER.error("Unable to launch the Eclipse LSP4MP language server." +
+                    " Java " + Constants.REQUIRED_JAVA_VERSION + " or more recent is required to run 'Liberty Tools for IntelliJ'." +
+                    " Change the boot Java runtime of the IDE as documented here:" +
+                    " https://www.jetbrains.com/help/idea/switching-boot-jdk.html");
             return;
         }
         if (lsp4mpServerPath.exists()) {

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -12,6 +12,7 @@ package io.openliberty.tools.intellij.util;
 import java.util.*;
 
 public final class Constants {
+    public static final int REQUIRED_JAVA_VERSION = 17;
     public static final String LIBERTY_DEV_DASHBOARD_ID = "Liberty";
     public static final String LIBERTY_GRADLE_PROJECT = "Liberty Gradle Project";
     public static final String LIBERTY_MAVEN_PROJECT = "Liberty Maven Project";


### PR DESCRIPTION
Resolves #196.

Used the VS Code tools as a reference for this fix. See the `checkJavaVersion()` and `parseMajorVersion()` functions in: https://github.com/OpenLiberty/liberty-tools-vscode/blob/main/src/util/requirements.ts.