### PR TITLE
441 quick patch

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/DocumentContentSynchronizer.java
@@ -112,6 +112,9 @@ public class DocumentContentSynchronizer implements DocumentListener {
         if (ApplicationManager.getApplication().isUnitTestMode()) {
             sendDidChangeEvents();
         } else {
+            if(languageServerWrapper.getProject().isDisposed()) {
+                return;
+            }
             PsiDocumentManager.getInstance(languageServerWrapper.getProject()).performForCommittedDocument(event.getDocument(), this::sendDidChangeEvents);
         }
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/DocumentContentSynchronizer.java
@@ -133,6 +133,9 @@ public class DocumentContentSynchronizer implements DocumentListener {
         if (ApplicationManager.getApplication().isUnitTestMode()) {
             sendDidChangeEvents(events);
         } else {
+            if(languageServerWrapper.getProject().isDisposed()) {
+                return;
+            }
             PsiDocumentManager.getInstance(languageServerWrapper.getProject()).performForCommittedDocument(document, () -> sendDidChangeEvents(events));
         }
     }


### PR DESCRIPTION
Temp fix to make #441 less severe

Check to see if the project associated with the languageServerWrapper object is disposed before trying to get a PsiDocumentManager instance.