### PR TITLE
Initial integration of automated LSP4Jakarta tests. (attempt #2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,22 @@ repositories {
     maven {
         url = "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies"
     }
+    maven {
+        url = "https://www.jetbrains.com/intellij-repository/releases"
+    }
+    maven {
+        url = "https://packages.jetbrains.team/maven/p/kpm/public"
+    }
+    maven {
+        url = "https://cache-redirector.jetbrains.com/packages.jetbrains.team/maven/p/grazi/grazie-platform-public"
+    }
+    maven {
+        url = "https://download.jetbrains.com/teamcity-repository"
+    }
+    maven {
+        url = "https://cache-redirector.jetbrains.com/download-pgp-verifier"
+    }
+
     mavenLocal() // TODO remove once Liberty LS is publicly available
 }
 
@@ -66,8 +82,15 @@ dependencies {
     testImplementation 'com.intellij.remoterobot:remote-robot:' + remoteRobotVersion
     testImplementation 'com.intellij.remoterobot:remote-fixtures:' + remoteRobotVersion
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:231.9011.34') {
+        transitive = false
+    }
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
+
+    // JUnit 4
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
 
     // Test: Logging Network Calls.
     testImplementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
@@ -131,6 +154,8 @@ runIdeForUiTests {
 
 test {
     useJUnitPlatform()
+    systemProperty "java.awt.headless", "true"
+    systemProperty 'idea.log.leaked.projects.in.tests', 'false'
 
     testLogging {
         showStandardStreams = true

--- a/build.gradle
+++ b/build.gradle
@@ -154,8 +154,6 @@ runIdeForUiTests {
 
 test {
     useJUnitPlatform()
-    systemProperty "java.awt.headless", "true"
-    systemProperty 'idea.log.leaked.projects.in.tests', 'false'
 
     testLogging {
         showStandardStreams = true

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/GeneratedAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/GeneratedAnnotationTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.annotations;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class GeneratedAnnotationTest extends BaseJakartaTest {
+
+    @Test
+    public void GeneratedAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/annotations/GeneratedAnnotation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected annotations
+        Diagnostic d1 = JakartaForJavaAssert.d(7, 4, 63,
+                "The annotation @Generated must define the attribute 'date' following the ISO 8601 standard.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "InvalidDateFormat");
+        
+        Diagnostic d2 = JakartaForJavaAssert.d(13, 4, 70,
+                "The annotation @Generated must define the attribute 'date' following the ISO 8601 standard.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "InvalidDateFormat");
+        
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.annotations;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class PostConstructAnnotationTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void GeneratedAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected Diagnostics
+
+        Diagnostic d1 = d(15, 19, 31, "A method with the @PostConstruct annotation must be void.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructReturnType");
+
+        Diagnostic d2 = d(20, 16, 28, "A method with the @PostConstruct annotation must not have any parameters.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructParams");
+
+        Diagnostic d3 = d(25, 16, 28, "A method with the @PostConstruct annotation must not throw checked exceptions.",
+                DiagnosticSeverity.Warning, "jakarta-annotations", "PostConstructException");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+        TextEdit te1 = te(19, 4, 20, 4, "");
+        TextEdit te2 = te(20, 29, 20, 40, "");
+        CodeAction ca1 = ca(uri, "Remove @PostConstruct", d2, te1);
+        CodeAction ca2 = ca(uri, "Remove all parameters", d2, te2);
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
+        TextEdit te3 = te(15, 11, 15, 18, "void");
+        CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
+        assertJavaCodeAction(codeActionParams2, utils, ca3);
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.annotations;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class PreDestroyAnnotationTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void GeneratedAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/annotations/PreDestroyAnnotation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected annotations
+        
+        Diagnostic d1 = d(20, 16, 28, "A method with the @PreDestroy annotation must not have any parameters.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PreDestroyParams");
+        
+        Diagnostic d2 = d(26, 20, 31, "A method with the @PreDestroy annotation must not be static.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PreDestroyStatic");
+        d2.setData(9);
+        
+        Diagnostic d3 = d(31, 13, 25, "A method with the @PreDestroy annotation must not throw checked exceptions.",
+                DiagnosticSeverity.Warning, "jakarta-annotations", "PreDestroyException");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d2, d1, d3);
+        
+        
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+        TextEdit te = te(19, 1, 20, 1,"");
+        TextEdit te1 = te(20, 29, 20, 40,"");
+        CodeAction ca = ca(uri, "Remove @PreDestroy", d1, te);
+        CodeAction ca1= ca(uri, "Remove all parameters", d1, te1);
+        assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+        
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+        TextEdit te2 = te(25, 1, 26, 1,"");
+        TextEdit te3 = te(26, 7, 26, 14,"");
+        CodeAction ca2 = ca(uri, "Remove @PreDestroy", d2, te2);
+        CodeAction ca3= ca(uri, "Remove the 'static' modifier from this method", d2, te3);
+        assertJavaCodeAction(codeActionParams1, utils, ca2, ca3);
+
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.annotations;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class ResourceAnnotationTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void ResourceAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/annotations/ResourceAnnotation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected annotations
+        Diagnostic d1 = d(22, 0, 22, "The @Resource annotation must define the attribute 'type'.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "MissingResourceTypeAttribute");
+
+        Diagnostic d2 = d(39, 0, 30, "The @Resource annotation must define the attribute 'name'.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "MissingResourceNameAttribute");
+
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+        
+        
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+        TextEdit te = te(22, 0, 22, 22, "@Resource(name = \"aa\", type = \"\")");
+        CodeAction ca= ca(uri, "Add type to jakarta.annotation.Resource", d1, te);
+        assertJavaCodeAction(codeActionParams, utils, ca);
+        
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+        TextEdit te1 = te(39, 0, 39, 30, "@Resource(type = \"\", name = \"\")");
+        CodeAction ca1= ca(uri, "Add name to jakarta.annotation.Resource", d2, te1);
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.beanvalidation;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class BeanValidationTest extends BaseJakartaTest {
+
+    @Test
+    public void validFieldConstraints() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/ValidConstraints.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // should be no errors 
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    @Ignore
+    public void fieldConstraintValidation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/FieldConstraintValidation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics
+        Diagnostic d1 = d(10, 16, 23,
+                "The @AssertTrue annotation can only be used on boolean and Boolean type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertTrue");
+        Diagnostic d2 = d(13, 19, 24,
+                "The @AssertFalse annotation can only be used on boolean and Boolean type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertFalse");
+        Diagnostic d3 = d(17, 19, 29,
+                "The @DecimalMax annotation can only be used on: \n"
+                + "- BigDecimal \n"
+                + "- BigInteger \n"
+                + "- CharSequence\n"
+                + "- byte, short, int, long (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "DecimalMax");
+        Diagnostic d4 = d(17, 19, 29,
+                "The @DecimalMin annotation can only be used on: \n"
+                + "- BigDecimal \n"
+                + "- BigInteger \n"
+                + "- CharSequence\n"
+                + "- byte, short, int, long (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "DecimalMin");
+        Diagnostic d5 = d(20, 20, 26,
+                "The @Digits annotation can only be used on: \n"
+                + "- BigDecimal \n"
+                + "- BigInteger \n"
+                + "- CharSequence\n"
+                + "- byte, short, int, long (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Digits");
+        Diagnostic d6 = d(23, 20, 32,
+                "The @Email annotation can only be used on String and CharSequence type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Email");
+        Diagnostic d7 = d(26, 20, 34,
+                "The @FutureOrPresent annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "FutureOrPresent");
+        Diagnostic d8 = d(29, 19, 30,
+                "The @Future annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Future");
+        Diagnostic d9 = d(33, 20, 23,
+                "The @Min annotation can only be used on \n"
+                        + "- BigDecimal \n"
+                        + "- BigInteger\n"
+                        + "- byte, short, int, long (and their respective wrappers) \n"
+                        + " type fields.",
+                        DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Min");
+        Diagnostic d10 = d(33, 20, 23,
+                "The @Max annotation can only be used on \n"
+                + "- BigDecimal \n"
+                + "- BigInteger\n"
+                + "- byte, short, int, long (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Max");
+        Diagnostic d11 = d(36, 20, 27,
+                "The @Negative annotation can only be used on \n"
+                + "- BigDecimal \n"
+                + "- BigInteger\n"
+                + "- byte, short, int, long, float, double (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Negative");
+        Diagnostic d12 = d(39, 19, 25,
+                "The @NegativeOrZero annotation can only be used on \n"
+                + "- BigDecimal \n"
+                + "- BigInteger\n"
+                + "- byte, short, int, long, float, double (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "NegativeOrZero");
+        Diagnostic d13 = d(42, 20, 32,
+                "The @NotBlank annotation can only be used on String and CharSequence type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "NotBlank");
+        Diagnostic d14 = d(45, 21, 31,
+                "The @Pattern annotation can only be used on String and CharSequence type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Pattern");
+        Diagnostic d15 = d(48, 19, 33,
+                "The @Past annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Past");
+        Diagnostic d16 = d(51, 19, 33,
+                "The @PastOrPresent annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "PastOrPresent");
+        Diagnostic d17 = d(54, 21, 25,
+                "The @Positive annotation can only be used on \n"
+                + "- BigDecimal \n"
+                + "- BigInteger\n"
+                + "- byte, short, int, long, float, double (and their respective wrappers) \n"
+                + " type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Positive");
+        // not yet implemented
+//        Diagnostic d18 = d(11, 17, 24,
+//                "The @PositiveOrZero annotation can only be used on boolean and Boolean type fields.",
+//                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "PositiveOrZero");
+        Diagnostic d19 = d(60, 27, 36,
+                "Constraint annotations are not allowed on static fields",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertTrue");
+        Diagnostic d20 = d(63, 27, 36,
+                "Constraint annotations are not allowed on static fields",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "Past");
+        
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8,
+                d9, d10, d11, d12, d13, d14, d15, d16, d17, d19, d20);
+
+        // Test quickfix codeActions - type (1-17), static, static+type (should only display static)
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+        TextEdit te = te(9, 4, 10, 4, "");
+        CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);    
+
+        assertJavaCodeAction(codeActionParams, utils, ca);
+
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d19);
+        TextEdit te1 = te(59, 4, 60, 4, "");
+        TextEdit te2 = te(60, 11, 60, 18, "");
+        CodeAction ca1 = ca(uri, "Remove constraint annotation AssertTrue from element", d19, te1);
+        CodeAction ca2 = ca(uri, "Remove static modifier from element", d19, te2);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca1, ca2);
+        
+
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d20);
+        TextEdit te3 = te(62, 4, 63, 4, "");
+        TextEdit te4 = te(63, 11, 63, 18, "");
+        CodeAction ca3 = ca(uri, "Remove constraint annotation Past from element", d20, te3);
+        CodeAction ca4 = ca(uri, "Remove static modifier from element", d20, te4);
+
+        assertJavaCodeAction(codeActionParams3, utils, ca3, ca4);
+    }
+    
+    @Test
+    @Ignore
+    public void methodConstraintValidation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/MethodConstraintValidation.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics
+        Diagnostic d1 = d(20, 26, 38,
+                "Constraint annotations are not allowed on static methods",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertTrue");
+        Diagnostic d2 = d(25, 18, 28,
+                "The @AssertTrue annotation can only be used on boolean and Boolean type methods.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertTrue");
+        Diagnostic d3 = d(30, 23, 33,
+                "Constraint annotations are not allowed on static methods",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertFalse");
+        
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+
+        // Test quickfix codeActions
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+        TextEdit te = te(19, 4, 20, 4, "");
+        TextEdit te2 = te(20, 10, 20, 17, "");
+        CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);
+        CodeAction ca2 = ca(uri, "Remove static modifier from element", d1, te2);
+
+        assertJavaCodeAction(codeActionParams, utils, ca, ca2);
+
+        codeActionParams = createCodeActionParams(uri, d2);
+        te = te(24, 4, 25, 4, "");
+        ca = ca(uri, "Remove constraint annotation AssertTrue from element", d2, te);    
+
+        assertJavaCodeAction(codeActionParams, utils, ca);
+        
+        codeActionParams = createCodeActionParams(uri, d3);
+        te = te(19, 4, 20, 4, "");
+        te2 = te(20, 10, 20, 17, "");
+        ca = ca(uri, "Remove constraint annotation AssertFalse from element", d3, te);
+        ca2 = ca(uri, "Remove static modifier from element", d3, te2);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.cdi;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class ManagedBeanConstructorTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void managedBeanAnnotations() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBeanConstructor.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostic
+        Diagnostic d = d(21, 8, 30,
+                "The @Inject annotation must define a managed bean constructor that takes parameters, or the managed bean must resolve to having a no-arg constructor instead.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanConstructor");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        // test expected quick-fix
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
+        TextEdit te1 = te(15, 44, 21, 1,
+                "\nimport jakarta.inject.Inject;\n\n@Dependent\npublic class ManagedBeanConstructor {\n	private int a;\n	\n	@Inject\n	");
+        TextEdit te2 = te(19, 1, 19, 1,
+        		"protected ManagedBeanConstructor() {\n\t}\n\n\t");
+        TextEdit te3 = te(19, 1, 19, 1,
+                "public ManagedBeanConstructor() {\n\t}\n\n\t");
+        CodeAction ca1 = ca(uri, "Insert @Inject", d, te1);
+        CodeAction ca2 = ca(uri, "Add a no-arg protected constructor to this class", d, te2);
+        CodeAction ca3 = ca(uri, "Add a no-arg public constructor to this class", d, te3);
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2, ca3);
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -1,0 +1,475 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.cdi;
+
+import com.google.gson.Gson;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class ManagedBeanTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void managedBeanAnnotations() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostic
+        Diagnostic d1 = d(6, 12, 13,
+                "The @Dependent annotation must be the only scope defined by a managed bean with a non-static public field.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
+        
+        Diagnostic d2 = d(5, 13, 24,
+                "Managed bean class of generic type must have scope @Dependent",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        // Assert for the diagnostic d1
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        TextEdit te1 = te(4, 0, 5, 0, "@Dependent\n");
+        CodeAction ca1 = ca(uri, "Replace current scope with @Dependent", d1, te1);
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+        
+        // Assert for the diagnostic d2
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        TextEdit te2 = te(4, 0, 5, 0, "@Dependent\n");
+        CodeAction ca2 = ca(uri, "Replace current scope with @Dependent", d2, te2);
+        assertJavaCodeAction(codeActionParams2, utils, ca2);
+    }
+    
+    @Test
+    @Ignore
+    public void scopeDeclaration() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostic
+        Diagnostic d1 = d(12, 16, 17,
+                "Scope type annotations must be specified by a producer field at most once.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+        d1.setData(new Gson().toJsonTree(Arrays.asList("Dependent", "ApplicationScoped", "Produces")));
+
+        Diagnostic d2 = d(15, 25, 41, "Scope type annotations must be specified by a producer method at most once.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+        d2.setData(new Gson().toJsonTree(Arrays.asList("ApplicationScoped", "RequestScoped", "Produces")));
+        
+        Diagnostic d3 = d(10, 13, 29, "Scope type annotations must be specified by a managed bean class at most once.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+        d3.setData(new Gson().toJsonTree(Arrays.asList("ApplicationScoped", "RequestScoped")));
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+
+        // Assert for the diagnostic d1
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        TextEdit te1 = te(11, 33, 12, 4, "");
+        TextEdit te2 = te(11, 14, 11, 33, "");
+        CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te2);
+        CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te1);
+        
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        
+        // Assert for the diagnostic d2
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        TextEdit te3 = te(14, 33, 15, 4, "");
+        TextEdit te4 = te(14, 14, 14, 33, "");
+        CodeAction ca3 = ca(uri, "Remove @RequestScoped", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove @ApplicationScoped", d2, te4);
+        
+        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        
+        // Assert for the diagnostic d3
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+        TextEdit te5 = te(9, 19, 10, 0, "");
+        TextEdit te6 = te(9, 0, 9, 19, "");
+        CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
+        CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
+        
+        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+    }
+
+    @Test
+    @Ignore
+    public void producesAndInject() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndInjectTogether.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(16, 18, 23, "The @Produces and @Inject annotations must not be used on the same field or property.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrInject");
+
+        Diagnostic d2 = d(11, 19, 27, "The @Produces and @Inject annotations must not be used on the same field or property.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrInject");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+
+        TextEdit te1 = te(14, 4, 15, 4, "");
+        TextEdit te2 = te(15, 4, 16, 4, "");
+        CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
+        CodeAction ca2 = ca(uri, "Remove @Inject", d1, te2);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+
+        TextEdit te3 = te(9, 4, 10, 4, "");
+        TextEdit te4 = te(10, 4, 11, 4, "");
+        CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove @Inject", d2, te4);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+    }
+
+    @Test
+    @Ignore
+    public void injectAndDisposesObservesObservesAsync() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(10, 18, 31,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d2 = d(16, 18, 31,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Observes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d3 = d(22, 18, 36,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d4 = d(28, 18, 39,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @Observes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d5 = d(34, 18, 44,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d6 = d(40, 18, 44,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        Diagnostic d7 = d(46, 18, 52,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+        
+        Diagnostic d8 = d(51, 18, 53,
+                "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
+        
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+
+        TextEdit te1 = te(9, 4, 10, 4, "");
+        TextEdit te2 = te(10, 32, 10, 42, "");
+        CodeAction ca1 = ca(uri, "Remove @Inject", d1, te1);
+        CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+
+        TextEdit te3 = te(15, 4, 16, 4, "");
+        TextEdit te4 = te(16, 32, 16, 42, "");
+        CodeAction ca3 = ca(uri, "Remove @Inject", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+
+        TextEdit te5 = te(21, 4, 22, 4, "");
+        TextEdit te6 = te(22, 37, 22, 52, "");
+        CodeAction ca5 = ca(uri, "Remove @Inject", d3, te5);
+        CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
+
+        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        
+        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+
+        TextEdit te7 = te(27, 4, 28, 4, "");
+        TextEdit te8 = te(28, 40, 28, 50, "");
+        TextEdit te9 = te(28, 64, 28, 74, "");
+        CodeAction ca7 = ca(uri, "Remove @Inject", d4, te7);
+        CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
+        CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
+
+        assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
+        
+        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+
+        TextEdit te10 = te(33, 4, 34, 4, "");
+        TextEdit te11 = te(34, 45, 34, 55, "");
+        TextEdit te12 = te(34, 69, 34, 84, "");
+        CodeAction ca10 = ca(uri, "Remove @Inject", d5, te10);
+        CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
+        CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
+
+        assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
+        
+        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
+
+        TextEdit te13 = te(39, 4, 40, 4, "");
+        TextEdit te14 = te(40, 45, 40, 55, "");
+        TextEdit te15 = te(40, 69, 40, 84, "");
+        CodeAction ca13 = ca(uri, "Remove @Inject", d6, te13);
+        CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
+        CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+
+        assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
+        
+        JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+
+        TextEdit te16 = te(45, 4, 46, 4, "");
+        TextEdit te17 = te(46, 53, 46, 63, "");
+        TextEdit te18 = te(46, 77, 46, 87, "");
+        TextEdit te19 = te(46, 101, 46, 116, "");
+        CodeAction ca16 = ca(uri, "Remove @Inject", d7, te16);
+        CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
+        CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
+        CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+
+        assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
+        
+        JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+
+        TextEdit te20 = te(50, 4, 51, 4, "");
+        TextEdit te21 = te(51, 54, 51, 89, "");
+        CodeAction ca20 = ca(uri, "Remove @Inject", d8, te20);
+        CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+
+        assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
+
+    }
+
+    @Test
+    @Ignore
+    public void producesAndDisposesObservesObservesAsync() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(12, 18, 31,
+                "A producer method cannot have parameter(s) annotated with @Disposes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d2 = d(18, 18, 31,
+                "A producer method cannot have parameter(s) annotated with @Observes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d3 = d(24, 18, 36,
+                "A producer method cannot have parameter(s) annotated with @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d4 = d(30, 18, 39,
+                "A producer method cannot have parameter(s) annotated with @Disposes, @Observes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d5 = d(36, 18, 44,
+                "A producer method cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d6 = d(42, 18, 44,
+                "A producer method cannot have parameter(s) annotated with @Disposes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+
+        Diagnostic d7 = d(48, 18, 52,
+                "A producer method cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+        
+        Diagnostic d8 = d(54, 18, 53,
+                "A producer method cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
+        
+        Diagnostic d9 = d(30, 18, 39,
+                "A disposer method cannot have parameter(s) annotated with @Observes",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
+        
+        Diagnostic d10 = d(42, 18, 44,
+                "A disposer method cannot have parameter(s) annotated with @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
+        
+        Diagnostic d11 = d(48, 18, 52,
+                "A disposer method cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
+        
+        Diagnostic d12 = d(54, 18, 53,
+                "A disposer method cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
+        
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12);
+
+        
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+
+        TextEdit te1 = te(11, 4, 12, 4, "");
+        TextEdit te2 = te(12, 32, 12, 42, "");
+        CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
+        CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+
+        TextEdit te3 = te(17, 4, 18, 4, "");
+        TextEdit te4 = te(18, 32, 18, 42, "");
+        CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+
+        TextEdit te5 = te(23, 4, 24, 4, "");
+        TextEdit te6 = te(24, 37, 24, 52, "");
+        CodeAction ca5 = ca(uri, "Remove @Produces", d3, te5);
+        CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
+
+        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        
+        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+
+        TextEdit te7 = te(29, 4, 30, 4, "");
+        TextEdit te8 = te(30, 40, 30, 50, "");
+        TextEdit te9 = te(30, 64, 30, 74, "");
+        CodeAction ca7 = ca(uri, "Remove @Produces", d4, te7);
+        CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
+        CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
+
+        assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
+        
+        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+
+        TextEdit te10 = te(35, 4, 36, 4, "");
+        TextEdit te11 = te(36, 45, 36, 55, "");
+        TextEdit te12 = te(36, 69, 36, 84, "");
+        CodeAction ca10 = ca(uri, "Remove @Produces", d5, te10);
+        CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
+        CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
+
+        assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
+        
+        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
+
+        TextEdit te13 = te(41, 4, 42, 4, "");
+        TextEdit te14 = te(42, 45, 42, 55, "");
+        TextEdit te15 = te(42, 69, 42, 84, "");
+        CodeAction ca13 = ca(uri, "Remove @Produces", d6, te13);
+        CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
+        CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+
+        assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
+        
+        JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+
+        TextEdit te16 = te(47, 4, 48, 4, "");
+        TextEdit te17 = te(48, 53, 48, 63, "");
+        TextEdit te18 = te(48, 77, 48, 87, "");
+        TextEdit te19 = te(48, 101, 48, 116, "");
+        CodeAction ca16 = ca(uri, "Remove @Produces", d7, te16);
+        CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
+        CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
+        CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+
+        assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
+        
+        JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+
+        TextEdit te20 = te(53, 4, 54, 4, "");
+        TextEdit te21 = te(54, 54, 54, 89, "");
+        CodeAction ca20 = ca(uri, "Remove @Produces", d8, te20);
+        CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+
+        assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
+        
+    }
+    
+    @Test
+    public void multipleDisposes() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/MultipleDisposes.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+        
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+        Diagnostic d = d(9, 18, 23,
+                "The annotation @Disposes must not be defined on more than one parameter of a method.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "RemoveExtraDisposes");
+        
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * With certain methods modified or deleted to fit the purposes of LSP4Jakarta
  *
  */
-public class BaseJakartaTest extends MavenImportingTestCase {
+public abstract class BaseJakartaTest extends MavenImportingTestCase {
 
     protected TestFixtureBuilder<IdeaProjectTestFixture> myProjectBuilder;
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+* Copyright (c) 2019, 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.core;
+
+import com.intellij.maven.testFramework.MavenImportingTestCase;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.LanguageLevelProjectExtension;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.builders.JavaModuleFixtureBuilder;
+import com.intellij.testFramework.builders.ModuleFixtureBuilder;
+import com.intellij.testFramework.fixtures.*;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Modified from:
+ * https://github.com/eclipse/lsp4mp/blob/bc926f75df2ca103d78c67b997c87adb7ab480b1/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
+ * With certain methods modified or deleted to fit the purposes of LSP4Jakarta
+ *
+ */
+public class BaseJakartaTest extends MavenImportingTestCase {
+
+    protected TestFixtureBuilder<IdeaProjectTestFixture> myProjectBuilder;
+
+    @Override
+    protected void setUpFixtures() throws Exception {
+        super.setUpFixtures();
+        //myTestFixture = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(getName()).getFixture();
+        //myTestFixture.setUp();
+        myProjectBuilder = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(getName());
+        final JavaTestFixtureFactory factory = JavaTestFixtureFactory.getFixtureFactory();
+        ModuleFixtureBuilder moduleBuilder = myProjectBuilder.addModule(JavaModuleFixtureBuilder.class);
+        myTestFixture = factory.createCodeInsightFixture(myProjectBuilder.getFixture());
+        myTestFixture.setUp();
+        LanguageLevelProjectExtension.getInstance(myTestFixture.getProject()).setLanguageLevel(LanguageLevel.JDK_1_6);
+    }
+
+    protected Module createJavaModule(final String name) throws Exception {
+        ModuleFixture moduleFixture = myProjectBuilder.addModule(JavaModuleFixtureBuilder.class).getFixture();
+        moduleFixture.setUp();
+        Module module = myProjectBuilder.addModule(JavaModuleFixtureBuilder.class).getFixture().getModule();
+        return module;
+    }
+
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    /**
+     * Create a new module into the test project from existing project folder.
+     *
+     * @param projectDirs the project folders
+     * @return the created modules
+     */
+    protected List<Module> createMavenModules(List<File> projectDirs) throws Exception {
+        Project project = myTestFixture.getProject();
+        List<VirtualFile> pomFiles = new ArrayList<>();
+        for(File projectDir : projectDirs) {
+            File moduleDir = new File(project.getBasePath(), projectDir.getName() + counter.getAndIncrement());
+            FileUtils.copyDirectory(projectDir, moduleDir);
+            VirtualFile pomFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(moduleDir).findFileByRelativePath("pom.xml");
+            pomFiles.add(pomFile);
+
+        }
+        importProjects(pomFiles.toArray(VirtualFile[]::new));
+        Module[] modules = ModuleManager.getInstance(myTestFixture.getProject()).getModules();
+        for(Module module : modules) {
+            setupJdkForModule(module.getName());
+        }
+        // QuarkusProjectService.getInstance(myTestFixture.getProject()).processModules();
+        return Arrays.asList(modules).stream().skip(1).collect(Collectors.toList());
+    }
+
+    protected Module createMavenModule(File projectDir) throws Exception {
+        List<Module> modules = createMavenModules(Collections.singletonList(projectDir));
+        return modules.get(modules.size() - 1);
+    }
+
+    /**
+     * Create a new module into the test project from existing in memory POM.
+     *
+     * @param name the new module name
+     * @param xml the project POM
+     * @return the created module
+     */
+    protected Module createMavenModule(String name, String xml) throws Exception {
+        Module module = myTestFixture.getModule();
+        File moduleDir = new File(module.getModuleFilePath()).getParentFile();
+        VirtualFile pomFile = createPomFile(LocalFileSystem.getInstance().findFileByIoFile(moduleDir), xml);
+        importProject(pomFile);
+        Module[] modules = ModuleManager.getInstance(myTestFixture.getProject()).getModules();
+        if (modules.length > 0) {
+            module = modules[modules.length - 1];
+            setupJdkForModule(module.getName());
+        }
+        return module;
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/JakartaForJavaAssert.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/JakartaForJavaAssert.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+* Copyright (c) 2020, 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.core;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PropertiesManagerForJakarta;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Assert;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Modified from:
+ * https://github.com/eclipse/lsp4mp/blob/bc926f75df2ca103d78c67b997c87adb7ab480b1/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileForJavaAssert.java
+ * With certain methods modified or deleted to fit the purposes of LSP4Jakarta
+ */
+public class JakartaForJavaAssert {
+
+    // ------------------- Assert for CodeAction
+
+    public static JakartaJavaCodeActionParams createCodeActionParams(String uri, Diagnostic d) {
+        TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri);
+        Range range = d.getRange();
+        CodeActionContext context = new CodeActionContext();
+        context.setDiagnostics(Arrays.asList(d));
+        JakartaJavaCodeActionParams codeActionParams = new JakartaJavaCodeActionParams(textDocument, range, context);
+        codeActionParams.setResourceOperationSupported(true);
+        return codeActionParams;
+    }
+
+    public static void assertJavaCodeAction(JakartaJavaCodeActionParams params, IPsiUtils utils, CodeAction... expected) {
+        List<? extends CodeAction> actual = PropertiesManagerForJakarta.getInstance().getCodeAction(params, utils);
+        assertCodeActions(actual != null && actual.size() > 0 ? actual : Collections.emptyList(), expected);
+    }
+
+    public static void assertCodeActions(List<? extends CodeAction> actual, CodeAction... expected) {
+        actual.stream().forEach(ca -> {
+            // we don't want to compare title, etc
+            ca.setCommand(null);
+            ca.setKind(null);
+            if (ca.getDiagnostics() != null) {
+                ca.getDiagnostics().forEach(d -> {
+                    d.setSeverity(null);
+                    d.setMessage("");
+                    d.setSource(null);
+                });
+            }
+        });
+
+        Assert.assertEquals(expected.length, actual.size());
+        
+        // remove extra '\r'
+        for (CodeAction ca : actual) {
+            ca.setTitle(replaceNewLineCharacters(ca.getTitle()));
+            List<Either<TextDocumentEdit, ResourceOperation>> tdes = ca.getEdit().getDocumentChanges();
+            for (Either<TextDocumentEdit, ResourceOperation> tde : tdes) {
+                List<TextEdit> tes = tde.getLeft().getEdits();
+                for (TextEdit te : tes) {
+                    te.setNewText(replaceNewLineCharacters(te.getNewText()));
+                }
+            }
+        }        
+        
+        for (int i = 0; i < expected.length; i++) {
+            Assert.assertEquals("Assert title [" + i + "]", expected[i].getTitle(),
+                    ((CodeAction) actual.get(i)).getTitle());
+            Assert.assertEquals("Assert edit [" + i + "]", expected[i].getEdit(),
+                    ((CodeAction) actual.get(i)).getEdit());
+        }
+    }
+
+    public static CodeAction ca(String uri, String title, Diagnostic d, TextEdit... te) {
+        CodeAction codeAction = new CodeAction();
+        codeAction.setTitle(title);
+        codeAction.setDiagnostics(Arrays.asList(d));
+
+        VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(uri, 0);
+
+        TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.asList(te));
+        WorkspaceEdit workspaceEdit = new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
+        workspaceEdit.setChanges(Collections.emptyMap());
+        codeAction.setEdit(workspaceEdit);
+        return codeAction;
+    }
+
+    public static TextEdit te(int startLine, int startCharacter, int endLine, int endCharacter, String newText) {
+        TextEdit textEdit = new TextEdit();
+        textEdit.setNewText(newText);
+        textEdit.setRange(r(startLine, startCharacter, endLine, endCharacter));
+        return textEdit;
+    }
+
+    // Assert for diagnostics
+
+    public static Diagnostic d(int line, int startCharacter, int endCharacter, String message,
+            DiagnosticSeverity severity, final String source, String code, Object data) {
+        Diagnostic d = new Diagnostic(r(line, startCharacter, line, endCharacter), message, severity, source,
+                code != null ? code : null);
+        d.setData(data);
+        return d;
+    }
+    
+    public static Diagnostic d(int line, int startCharacter, int endCharacter, String message,
+            DiagnosticSeverity severity, final String source, String code) {
+        return d(line, startCharacter, line, endCharacter, message, severity, source, code);
+    }
+
+    public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, String message,
+            DiagnosticSeverity severity, final String source, String code) {
+        // Diagnostic on 1 line
+        return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, severity, source,
+                code != null ? code : null);
+    }
+
+    public static Range r(int line, int startCharacter, int endCharacter) {
+        return r(line, startCharacter, line, endCharacter);
+    }
+
+    public static Range r(int startLine, int startCharacter, int endLine, int endCharacter) {
+        return new Range(p(startLine, startCharacter), p(endLine, endCharacter));
+    }
+
+    public static Position p(int line, int character) {
+        return new Position(line, character);
+    }
+
+    public static void assertJavaDiagnostics(JakartaDiagnosticsParams params, IPsiUtils utils, Diagnostic... expected) {
+        List<PublishDiagnosticsParams> actual = PropertiesManagerForJakarta.getInstance().diagnostics(params, utils);
+        assertDiagnostics(
+                actual != null && actual.size() > 0 ? actual.get(0).getDiagnostics() : Collections.emptyList(),
+                expected);
+    }
+
+    public static void assertDiagnostics(List<Diagnostic> actual, Diagnostic... expected) {
+        assertDiagnostics(actual, Arrays.asList(expected), false);
+    }
+
+    public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
+        /**
+         * ordering of diagnostics should not matter when testing for equality, so we
+         * sort diagnostics by their range.
+         */
+        Comparator<Position> posOrder = (a, b) -> a.getLine() == b.getLine() ? b.getCharacter() - a.getCharacter()
+                : b.getLine() - a.getLine();
+
+        Comparator<Range> rangePosOrder = (a, b) -> posOrder.compare(a.getStart(), b.getStart()) == 0
+                ? posOrder.compare(a.getEnd(), b.getEnd())
+                : posOrder.compare(a.getStart(), b.getStart());
+
+        Comparator<Diagnostic> diagnosticRangeOrder = (a, b) -> rangePosOrder.compare(a.getRange(), b.getRange());
+
+        actual.sort(diagnosticRangeOrder);
+        expected.sort(diagnosticRangeOrder);
+
+        // probably don't have to do this, as the code is using same way to build
+        // 'expected Diagnostic' object
+        // remove extra '\r'
+        for (Diagnostic dia : actual) {
+            dia.setMessage(replaceNewLineCharacters(dia.getMessage()));
+        }
+
+        List<Diagnostic> received = actual;
+        final boolean filterMessage;
+        if (expected != null && !expected.isEmpty()
+                && (expected.get(0).getMessage() == null || expected.get(0).getMessage().isEmpty())) {
+            filterMessage = true;
+        } else {
+            filterMessage = false;
+        }
+        if (filter) {
+            received = actual.stream().map(d -> {
+                Diagnostic simpler = new Diagnostic(d.getRange(), "");
+                simpler.setCode(d.getCode());
+                if (filterMessage) {
+                    simpler.setMessage(d.getMessage());
+                }
+                return simpler;
+            }).collect(Collectors.toList());
+        }
+        Assert.assertEquals("Unexpected diagnostics:\n" + actual, expected, received);
+    }
+
+    public static String fixURI(URI uri) {
+        String uriString = uri.toString();
+        return uriString.replaceFirst("file:/([^/])", "file:///$1");
+    }
+
+    // util. APIs
+
+    /**
+     * Returns new string without '\r' for new lines. (Windows generates an extra
+     * '\r' for each new line, it makes test messages fail to compare.)
+     * 
+     * @param source test message string
+     * @return new string without '\r' for new lines
+     */
+    public static String replaceNewLineCharacters(String source) {
+        return source.replaceAll("\r\n", "\n");
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.di;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class DependencyInjectionTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void DependencyInjectionDiagnostics() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/di/GreetingServlet.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        /* create expected diagnostics
+         * 
+         */
+        Diagnostic d1 = JakartaForJavaAssert.d(17, 27, 35, "The @Inject annotation must not define a final field.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrFinal");
+        d1.setData("field");
+
+        Diagnostic d2 = JakartaForJavaAssert.d(33, 25, 39, "The @Inject annotation must not define an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrAbstract");
+        d2.setData("method");
+        
+        Diagnostic d3 = JakartaForJavaAssert.d(26, 22, 33, "The @Inject annotation must not define a final method.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrFinal");
+        d3.setData("method");
+ 
+        Diagnostic d4 = JakartaForJavaAssert.d(43, 23, 36, "The @Inject annotation must not define a generic method.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectForGeneric");
+        d4.setData("method");
+        
+        Diagnostic d5 = JakartaForJavaAssert.d(37, 23, 35, "The @Inject annotation must not define a static method.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrStatic");
+        d5.setData("method");
+        
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
+        
+        
+        /* create expected quickFixes
+         * 
+         */
+        
+        // for d1
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        TextEdit te = JakartaForJavaAssert.te(16, 4, 17, 4,
+                "");
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
+        TextEdit te1 = JakartaForJavaAssert.te(17, 11, 17, 17,
+                "");
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this field", d1, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+        
+        // for d2
+        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+        te = JakartaForJavaAssert.te(32, 4, 33, 4,
+                "");
+        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d2, te);
+        te1 = JakartaForJavaAssert.te(33, 10, 33, 19,
+                "");
+        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", d2, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+        
+        // for d3
+        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+        te = JakartaForJavaAssert.te(25, 4, 26, 4,
+                "");
+        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te);
+        te1 = JakartaForJavaAssert.te(26, 10, 26, 16,
+                "");
+        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", d3, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+        
+        // for d4
+        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d4);
+        te = JakartaForJavaAssert.te(42, 4, 43, 4,
+                "");
+        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d4, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        
+        // for d5
+        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d5);
+        te = JakartaForJavaAssert.te(36, 4, 37, 4,
+                "");
+        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d5, te);
+        te1 = JakartaForJavaAssert.te(37, 10, 37, 17,
+                "");
+        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", d5, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Ananya Rao
+*******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.di;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class MultipleConstructorInjectTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void multipleInject() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/di/MultipleConstructorWithInject.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+
+        // test expected diagnostic
+        Diagnostic d1 = JakartaForJavaAssert.d(22, 11, 40,
+                "The @Inject annotation must not define more than one constructor.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInject");
+        
+        Diagnostic d2 = JakartaForJavaAssert.d(26, 11, 40,
+                "The @Inject annotation must not define more than one constructor.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInject");
+        
+        Diagnostic d3 = JakartaForJavaAssert.d(31, 14, 43,
+                "The @Inject annotation must not define more than one constructor.",
+                DiagnosticSeverity.Error, "jakarta-di", "RemoveInject");
+        
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1,d2,d3);
+       
+        // test expected quick-fix
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        TextEdit te = JakartaForJavaAssert.te(21, 4, 22, 4,"");
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+        TextEdit te2 = JakartaForJavaAssert.te(30, 4, 31, 4,"");
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te2);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
+        
+        
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceClassConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceClassConstructorTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation, Matthew Shocrylas and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Matthew Shocrylas - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.jaxrs;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class ResourceClassConstructorTest extends BaseJakartaTest {
+
+    @Test
+    public void MultipleConstructorsWithEqualParams() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsEqualLen.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostics
+        Diagnostic d1 = JakartaForJavaAssert.d(7, 8, 45,
+                "Multiple constructors have the same number of parameters, it may be ambiguous which constructor is used.",
+                DiagnosticSeverity.Warning, "jakarta-jax_rs", "AmbiguousConstructors");
+
+        Diagnostic d2 = JakartaForJavaAssert.d(11, 8, 45,
+                "Multiple constructors have the same number of parameters, it may be ambiguous which constructor is used.",
+                DiagnosticSeverity.Warning, "jakarta-jax_rs", "AmbiguousConstructors");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+    }
+
+    @Test
+    public void MultipleConstructorsWithDifferentLength() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsDiffLen.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostics
+        Diagnostic d = JakartaForJavaAssert.d(7, 8, 44,
+                "This constructor is unused, as root resource classes will only use the constructor with the most parameters.",
+                DiagnosticSeverity.Warning, "jakarta-jax_rs", "UnusedConstructor");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    @Test
+    public void NoPublicConstructor() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorClass.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostics
+        Diagnostic d1 = JakartaForJavaAssert.d(7, 12, 36,
+                "Root resource classes are instantiated by the JAX-RS runtime and MUST have a public constructor",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "NoPublicConstructors");
+
+        Diagnostic d2 = JakartaForJavaAssert.d(11, 14, 38,
+                "Root resource classes are instantiated by the JAX-RS runtime and MUST have a public constructor",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "NoPublicConstructors");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+
+    
+    @Test
+    public void NoPublicConstructorProviderClass() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorProviderClass.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+        Diagnostic d1 = JakartaForJavaAssert.d(19, 12, 44,
+                "Provider classes are instantiated by the JAX-RS runtime and MUST have a public constructor",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "NoPublicConstructors");
+
+        Diagnostic d2 = JakartaForJavaAssert.d(23, 14, 46,
+                "Provider classes are instantiated by the JAX-RS runtime and MUST have a public constructor",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "NoPublicConstructors");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2023 IBM Corporation, Matthew Shocrylas, Bera Sogut and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Matthew Shocrylas - initial API and implementation, Bera Sogut
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.jaxrs;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class ResourceMethodTest extends BaseJakartaTest {
+    
+    @Test
+    @Ignore
+    public void NonPublicMethod() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NotPublicResourceMethod.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+        
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+        
+        Diagnostic d = JakartaForJavaAssert.d(20, 17, 30, "Only public methods can be exposed as resource methods",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "NonPublicResourceMethod");
+        
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+        
+        // Test for quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+        TextEdit te = JakartaForJavaAssert.te(20, 4, 20, 11, "public"); // range may need to change
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Make method public", d, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+    }
+
+    @Test
+    @Ignore
+    public void multipleEntityParamsMethod() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+
+        Diagnostic d = JakartaForJavaAssert.d(21, 13, 46, "Resource methods cannot have more than one entity parameter",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "ResourceMethodMultipleEntityParams");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+
+        // Test for quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+
+        TextEdit te1 = JakartaForJavaAssert.te(21, 112, 21, 130, "");
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam1", d, te1);
+
+        TextEdit te2 = JakartaForJavaAssert.te(21, 47, 21, 68, "");
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d, te2);
+
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation, Adit Rada, Yijia Jing - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.jsonb;
+
+import com.google.gson.Gson;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+
+@RunWith(JUnit4.class)
+public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void deleteExtraJsonbCreatorAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = JakartaForJavaAssert.d(18, 11, 39,
+                "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
+        
+        Diagnostic d2 = JakartaForJavaAssert.d(21, 48, 61,
+                "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        // test code actions
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        TextEdit te1 = JakartaForJavaAssert.te(17, 4, 18, 4, "");
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d1, te1);
+        
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+        TextEdit te2 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d2, te2);
+
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
+    }
+    
+    @Test
+    @Ignore
+    public void JsonbTransientNotMutuallyExclusive() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+        // Diagnostic for the field "id"
+        Diagnostic d1 = JakartaForJavaAssert.d(21, 16, 18,
+                "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
+        d1.setData(new Gson().toJsonTree(Arrays.asList("JsonbTransient")));
+
+        // Diagnostic for the field "name"
+        Diagnostic d2 = JakartaForJavaAssert.d(25, 19, 23,
+                "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
+        d2.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty",  "JsonbTransient")));
+
+        // Diagnostic for the field "favoriteLanguage"
+        Diagnostic d3 = JakartaForJavaAssert.d(30, 19, 35,
+                "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
+        d3.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty", "JsonbAnnotation",  "JsonbTransient")));
+        
+        // Diagnostic for the field "favoriteEditor"
+        Diagnostic d4 = JakartaForJavaAssert.d(39, 19, 33,
+                "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
+        d4.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty")));
+        
+        // Diagnostic for the getter "getId"
+        Diagnostic d5 = JakartaForJavaAssert.d(42, 16, 21,
+                "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
+        d5.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty")));
+       
+        // Diagnostic for the setter "setId"
+        Diagnostic d6 = JakartaForJavaAssert.d(49, 17, 22,
+                "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
+        d6.setData(new Gson().toJsonTree(Arrays.asList("JsonbAnnotation")));
+        
+        // Diagnostic for the getter "getFavoriteEditor"
+        Diagnostic d7 = JakartaForJavaAssert.d(67, 19, 36,
+                "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
+        d7.setData(new Gson().toJsonTree(Arrays.asList("JsonbTransient")));
+       
+        // Diagnostic for the setter "setFavoriteEditor"
+        Diagnostic d8 = JakartaForJavaAssert.d(74, 17, 34,
+                "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
+        d8.setData(new Gson().toJsonTree(Arrays.asList("JsonbAnnotation", "JsonbTransient")));
+  
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
+
+
+        // Test code actions
+        // Quick fix for the field "id"
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        TextEdit te1 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d1, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
+        
+        // Quick fix for the field "name"
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+        TextEdit te3 = JakartaForJavaAssert.te(24, 4, 25, 4, "");
+        TextEdit te4 = JakartaForJavaAssert.te(23, 4, 24, 4, "");
+        CodeAction ca3 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d2, te3);
+        CodeAction ca4 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d2, te4);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+       
+        // Quick fix for the field "favoriteLanguage"
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+        TextEdit te5 = JakartaForJavaAssert.te(29, 4, 30, 4, "");
+        TextEdit te6 = JakartaForJavaAssert.te(27, 4, 29, 4, "");
+        CodeAction ca5 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d3, te5);
+        CodeAction ca6 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty, @JsonbAnnotation", d3, te6);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        
+        // Quick fix for the accessor "getId"
+        JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, d5);
+        TextEdit te7 = JakartaForJavaAssert.te(41, 4, 42, 4, "");
+        CodeAction ca7 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d5, te7);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, ca7);
+
+        // Quick fix for the accessor "setId"
+        JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, d6);
+        TextEdit te8 = JakartaForJavaAssert.te(48, 4, 49, 4, "");
+        CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.jsonp;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+
+@RunWith(JUnit4.class)
+public class JakartaJsonpTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void invalidPointerTarget() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jsonp/CreatePointerInvalidTarget.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+        
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        
+        Diagnostic d1 = JakartaForJavaAssert.d(20, 60, 64,
+                "Json.createPointer target must be a sequence of '/' prefixed tokens or an empty String", 
+                DiagnosticSeverity.Error, "jakarta-jsonp", "InvalidCreatePointerArg");
+        
+        Diagnostic d2 = JakartaForJavaAssert.d(21, 62, 70,
+                "Json.createPointer target must be a sequence of '/' prefixed tokens or an empty String", 
+                DiagnosticSeverity.Error, "jakarta-jsonp", "InvalidCreatePointerArg");
+        
+        Diagnostic d3 = JakartaForJavaAssert.d(22, 60, 80,
+                "Json.createPointer target must be a sequence of '/' prefixed tokens or an empty String", 
+                DiagnosticSeverity.Error, "jakarta-jsonp", "InvalidCreatePointerArg");
+        
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.persistence;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class JakartaPersistenceTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void deleteMapKeyOrMapKeyClass() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(16, 32, 42,
+                "@MapKeyClass and @MapKey annotations cannot be used on the same field or property",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveMapKeyorMapKeyClass");
+
+        Diagnostic d2 = d(11, 25, 32,
+                "@MapKeyClass and @MapKey annotations cannot be used on the same field or property",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveMapKeyorMapKeyClass");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+
+        TextEdit te1 = te(15, 4, 16, 4, "");
+        TextEdit te2 = te(14, 4, 15, 4, "");
+        CodeAction ca1 = ca(uri, "Remove @MapKeyClass", d1, te1);
+        CodeAction ca2 = ca(uri, "Remove @MapKey", d1, te2);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+
+        TextEdit te3 = te(9, 13, 10, 27, "");
+        TextEdit te4 = te(9, 4, 10, 4, "");
+        CodeAction ca3 = ca(uri, "Remove @MapKeyClass", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove @MapKey", d2, te4);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+    }
+
+    
+    @Test
+    @Ignore
+    public void completeMapKeyJoinColumnAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/MultipleMapKeyAnnotations.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+        
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test diagnostics are present
+        Diagnostic d1 = d(12, 25, 30,
+                "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
+        Diagnostic d2 = d(12, 25, 30,
+                "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
+
+        Diagnostic d3 = d(16, 25, 30,
+                "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
+        Diagnostic d4 = d(16, 25, 30,
+                "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
+
+        Diagnostic d5 = d(20, 25, 30,
+                "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
+        
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5); 
+        
+        // test quick fixes
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        TextEdit te1 = te(10, 4, 11, 23,  "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")");
+        CodeAction ca1 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d1, te1);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d3);
+        TextEdit te2 = te(14, 4, 15, 52,  "@MapKeyJoinColumn(referencedColumnName = \"rcn2\", name = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"\")");
+        CodeAction ca2 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d3, te2);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca2);
+        
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d5);
+        TextEdit te3 = te(18, 4, 19, 23,  "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"rcn1\")");
+        CodeAction ca3 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d5, te3);
+
+        assertJavaCodeAction(codeActionParams3, utils, ca3);
+    }
+
+    @Test
+    @Ignore
+    public void addEmptyConstructor() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/EntityMissingConstructor.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test diagnostics are present
+        Diagnostic d = d(5, 13, 37,
+                "A class using the @Entity annotation must contain a public or protected constructor with no arguments.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "MissingEmptyConstructor");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        // test quick fixes
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
+        TextEdit te1 = te(7, 4, 7, 4,  "protected EntityMissingConstructor() {\n\t}\n\n\t");
+        CodeAction ca1 = ca(uri, "Add a no-arg protected constructor to this class", d, te1);
+        TextEdit te2 = te(7, 4, 7, 4,  "public EntityMissingConstructor() {\n\t}\n\n\t");
+        CodeAction ca2 = ca(uri, "Add a no-arg public constructor to this class", d, te2);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+    }
+
+    @Test
+    @Ignore
+    public void removeFinalModifiers() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/FinalModifiers.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test diagnostics are present
+        Diagnostic d1 = d(10, 21, 28,
+                "A class using the @Entity annotation cannot contain any methods that are declared final",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalMethods");
+        d1.setData("method");
+
+        Diagnostic d2 = d(7, 14, 15,
+                "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
+        d2.setData("field");
+
+        Diagnostic d3 = d(8, 17, 18,
+                "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
+        d3.setData("field");
+
+        Diagnostic d4 = d(8, 30, 31,
+                "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
+                DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
+        d4.setData("field");
+
+        Diagnostic d5 = d(5, 19, 33,
+                "A class using the @Entity annotation must not be final.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "InvalidClass");
+        d5.setData("type");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
+
+        // test quick fixes
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        TextEdit te1 = te(10, 10, 10, 16, "");
+        CodeAction ca1 = ca(uri,  "Remove the 'final' modifier from this method", d1, te1);
+
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        TextEdit te2 = te(7, 4, 7, 10, "");
+        CodeAction ca2 = ca(uri,  "Remove the 'final' modifier from this field", d2, te2);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca2);
+
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+        TextEdit te3 = te(8, 4, 8, 10, "");
+        CodeAction ca3 = ca(uri,  "Remove the 'final' modifier from this field", d3, te3);
+
+        assertJavaCodeAction(codeActionParams3, utils, ca3);
+
+        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+        TextEdit te4 = te(8, 4, 8, 10, "");
+        CodeAction ca4 = ca(uri,  "Remove the 'final' modifier from this field", d4, te4);
+
+        assertJavaCodeAction(codeActionParams4, utils, ca4);
+
+        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+        TextEdit te5 = te(5, 6, 5, 12, "");
+        CodeAction ca5 = ca(uri, "Remove the 'final' modifier from this class", d5, te5);
+
+        assertJavaCodeAction(codeActionParams5, utils, ca5);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright (c) 2021, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.servlet;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class JakartaServletTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore // getAllSuperTypes() returns nothing for tests. See #232
+    public void ExtendWebServlet() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/servlet/DontExtendHttpServlet.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected
+        Diagnostic d = JakartaForJavaAssert.d(5, 13, 34, "Annotated classes with @WebServlet must extend the HttpServlet class.",
+                DiagnosticSeverity.Warning, "jakarta-servlet", "ExtendHttpServlet");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        // test associated quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+        TextEdit te = JakartaForJavaAssert.te(5, 34, 5, 34, " extends HttpServlet");
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontExtendHttpServlet' extend 'HttpServlet'", d, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+    }
+
+    @Test
+    @Ignore // getAllSuperTypes() returns nothing for tests. See #232
+    public void CompleteWebServletAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/servlet/InvalidWebServlet.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = JakartaForJavaAssert.d(9, 0, 13,
+                "The annotation @WebServlet must define the attribute urlPatterns or the attribute value.",
+                DiagnosticSeverity.Error, "jakarta-servlet", "CompleteHttpServletAttributes");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+        TextEdit te1 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(value = \"\")\n");
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Add the `value` attribute to @WebServlet", d, te1);
+
+        TextEdit te2 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(urlPatterns = \"\")\n");
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Add the `urlPatterns` attribute to @WebServlet", d, te2);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+    }
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+* Copyright (c) 2022, 2023 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.websocket;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+public class JakartaWebSocketTest extends BaseJakartaTest {
+
+    @Test
+    @Ignore
+    public void addPathParamsAnnotation() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/AnnotationTest.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // OnOpen PathParams Annotation check
+        Diagnostic d1 = JakartaForJavaAssert.d(18, 47, 64,
+                "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "AddPathParamsAnnotation"
+        );
+        
+        // OnClose PathParams Annotation check
+        Diagnostic d2 = JakartaForJavaAssert.d(24, 49, 67,
+                "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "AddPathParamsAnnotation"
+        );
+        
+        Diagnostic d3 = JakartaForJavaAssert.d(24, 76, 94,
+                "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "AddPathParamsAnnotation"
+        );
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+        
+        // Expected code actions
+        JakartaJavaCodeActionParams codeActionsParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        String newText = "\nimport jakarta.websocket.server.PathParam;\nimport jakarta.websocket.server.ServerEndpoint;\nimport jakarta.websocket.Session;\n\n" 
+                        + "/**\n * Expected Diagnostics are related to validating that the parameters have the \n * valid annotation @PathParam (code: AddPathParamsAnnotation)\n * See issue #247 (onOpen) and #248 (onClose)\n */\n" 
+                        + "@ServerEndpoint(value = \"/infos\")\npublic class AnnotationTest {\n    // @PathParam missing annotation for \"String missingAnnotation\"\n    @OnOpen\n    public void OnOpen(Session session, @PathParam(value = \"\") ";
+        TextEdit te = JakartaForJavaAssert.te(5, 32, 18, 40, newText);
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Insert @jakarta.websocket.server.PathParam", d1, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionsParams, utils, ca);
+    }
+
+    @Test
+    public void changeInvalidParamType() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/InvalidParamType.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // OnOpen Invalid Param Types
+        Diagnostic d1 = JakartaForJavaAssert.d(19, 47, 59,
+        "Invalid parameter type. When using @jakarta.websocket.OnOpen, parameter must be of type: \n- jakarta.websocket.EndpointConfig\n- jakarta.websocket.Session\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnOpenChangeInvalidParam");
+
+        // OnClose Invalid Param Type
+        Diagnostic d2 = JakartaForJavaAssert.d(24, 73, 85,
+                "Invalid parameter type. When using @jakarta.websocket.OnClose, parameter must be of type: \n- jakarta.websocket.CloseReason\n- jakarta.websocket.Session\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnCloseChangeInvalidParam");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+
+    @Test
+    public void testPathParamInvalidURI() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websockets/PathParamURIWarningTest.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = JakartaForJavaAssert.d(22, 59, 77, "PathParam value does not match specified Endpoint URI",
+                DiagnosticSeverity.Warning, "jakarta-websocket", "ChangePathParamValue");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    @Test
+    public void testServerEndpointRelativeURI() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = JakartaForJavaAssert.d(6, 0, 27, "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    @Test
+    public void testServerEndpointNoSlashURI() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d1 = JakartaForJavaAssert.d(7, 0, 23, "Server endpoint paths must start with a leading '/'.", DiagnosticSeverity.Error,
+                "jakarta-websocket", "ChangeInvalidServerEndpoint");
+        Diagnostic d2 = JakartaForJavaAssert.d(7, 0, 23, "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+
+    @Test
+    public void testServerEndpointInvalidTemplateURI() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = JakartaForJavaAssert.d(6, 0, 46, "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    @Test
+    public void testServerEndpointDuplicateVariableURI() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = JakartaForJavaAssert.d(6, 0, 40, "Server endpoint paths must not use the same variable more than once in a path.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    @Test
+    public void testDuplicateOnMessage() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d1 = JakartaForJavaAssert.d(12, 4, 14,
+                "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
+        Diagnostic d2 = JakartaForJavaAssert.d(17, 4, 14,
+                "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/pom.xml
+++ b/src/test/resources/projects/maven/jakarta-sample/pom.xml
@@ -1,0 +1,114 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.openliberty</groupId>
+    <artifactId>jakarta-servlet</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <liberty.var.artifactId>${project.artifactId}</liberty.var.artifactId>
+    </properties>
+
+    <dependencies>
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.3</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <version>3.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+            <version>3.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>7.0.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+        <!-- Support for JDK 9 and above -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <!-- Enable liberty-maven plugin -->
+            <!-- tag::libertyMavenPlugin[] -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.7.1</version>
+                <configuration>
+                    <runtimeArtifact>
+                        <groupId>io.openliberty.beta</groupId>
+                        <artifactId>openliberty-jakartaee9</artifactId>
+                        <version>21.0.0.2-beta</version>
+                        <type>zip</type>
+                    </runtimeArtifact>
+                </configuration>
+            </plugin>
+            <!-- end::libertyMavenPlugin[] -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <!-- Plugin to run functional tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/GeneratedAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/GeneratedAnnotation.java
@@ -1,0 +1,31 @@
+package io.openliberty.sample.jakarta.annotations;
+
+import jakarta.annotation.Generated;
+
+@Generated(value = "demoServlet", date="")
+public class GeneratedAnnotation {
+
+    @Generated(value = "demoServlet", date="not_ISO_compliant")
+    private Integer studentId;
+
+    @Generated(value = "demoServlet", date="2001-07-04T12:08:56.235-0700")
+    private boolean isHappy;
+
+    @Generated(value = "demoServletijiojioj", date="NOTISOCOMPLIANT2")
+    private boolean isSad;
+
+    @Generated("com.sun.xml.rpc.AProcessor")
+    private String emailAddress;
+    
+    @Generated(value="com.sun.xml.rpc.AProcessor")
+    private String homeTown;
+    
+    public GeneratedAnnotation(Integer studentId, Boolean isHappy, boolean isSad, String graduationDate, Integer gpa,
+            String emailAddress) {
+        this.studentId = studentId;
+        this.isHappy = isHappy;
+        this.isSad = isSad;
+        this.emailAddress = emailAddress;
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -1,0 +1,32 @@
+package io.openliberty.sample.jakarta.annotations;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+
+@Resource(type = Object.class, name = "aa")
+public class PostConstructAnnotation {
+
+    private Integer studentId;
+
+    private boolean isHappy;
+
+    private boolean isSad;
+
+    @PostConstruct()
+    public Integer getStudentId() {
+        return this.studentId;
+    }
+
+    @PostConstruct
+    public void getHappiness(String type) {
+
+    }
+
+    @PostConstruct
+    public void throwTantrum() throws Exception {
+        System.out.println("I'm sad");
+    }
+
+    private String emailAddress;
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PreDestroyAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PreDestroyAnnotation.java
@@ -1,0 +1,43 @@
+package io.openliberty.sample.jakarta.annotations;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Resource;
+
+@Resource(type = Object.class, name = "aa") 
+public class PreDestroyAnnotation { 
+
+    private Integer studentId;
+	
+    private boolean isHappy;
+
+    private boolean isSad;
+	
+	@PreDestroy()
+	public Integer getStudentId() {
+		return this.studentId;
+	}
+	
+	@PreDestroy()
+	public boolean getHappiness(String type) {
+		if (type.equals("happy")) return this.isHappy;
+		return this.isSad;
+	}
+	
+	@PreDestroy()
+	public static void makeUnhappy() {
+		System.out.println("I'm sad");
+	}
+	
+	@PreDestroy()
+	public void throwTantrum() throws Exception {
+		System.out.println("I'm sad");
+	}
+
+
+    private String emailAddress;
+
+
+}
+
+
+

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/ResourceAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/ResourceAnnotation.java
@@ -1,0 +1,45 @@
+package io.openliberty.sample.jakarta.annotations;
+
+import jakarta.annotation.Resource;
+
+@Resource(type = Object.class, name = "aa")
+public class ResourceAnnotation {
+
+    private Integer studentId;
+
+
+	@Resource(shareable = true)
+    private boolean isHappy;
+
+	@Resource(name = "test")
+    private boolean isSad;
+
+
+    private String emailAddress;
+
+
+}
+
+@Resource(name = "aa")
+class PostDoctoralStudent {
+
+    private Integer studentId;
+
+
+	@Resource(shareable = true)
+    private boolean isHappy;
+
+	@Resource
+    private boolean isSad;
+
+
+    private String emailAddress;
+
+}
+
+@Resource(type = Object.class)
+class MasterStudent {
+
+    private Integer studentId;
+
+} 

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/FieldConstraintValidation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/FieldConstraintValidation.java
@@ -1,0 +1,65 @@
+package io.openliberty.sample.jakarta.beanvalidation;
+
+import java.util.Calendar;
+import java.util.List;
+
+import jakarta.validation.constraints.*;
+
+public class FieldConstraintValidation {
+
+    @AssertTrue
+    private int isHappy;                    // invalid types
+
+    @AssertFalse
+    private Double isSad;
+
+    @DecimalMax("30.0")
+    @DecimalMin("10.0")
+    private String bigDecimal;
+
+    @Digits(fraction = 0, integer = 0)
+    private boolean digits;
+
+    @Email
+    private Integer emailAddress;
+
+    @FutureOrPresent
+    private boolean graduationDate;
+
+    @Future
+    private double fergiesYear;
+
+    @Min(value = 50)
+    @Max(value = 100)
+    private boolean gpa;
+
+    @Negative
+    private boolean subZero;
+
+    @NegativeOrZero
+    private String notPos;
+
+    @NotBlank
+    private boolean saysomething;
+
+    @Pattern(regexp = "")
+    private Calendar thisIsUsed;
+
+    @Past
+    private double theGoodOldDays;
+
+    @PastOrPresent
+    private char[] aGoodFieldName;
+
+    @Positive
+    private String[] area;
+
+    @PositiveOrZero
+    private List<String> maybeZero;
+
+    @AssertTrue
+    private static boolean typeValid;       // static
+
+    @Past
+    private static boolean doubleBad;      // static and invalid type
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/MethodConstraintValidation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/MethodConstraintValidation.java
@@ -1,0 +1,35 @@
+package io.openliberty.sample.jakarta.beanvalidation;
+
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+
+public class MethodConstraintValidation {
+
+    // valid cases
+    @AssertFalse
+    private boolean falseMethod() {
+        return false;
+    }
+
+    @AssertTrue
+    public boolean trueMethod() {
+        return true;
+    }
+
+    // invalid cases
+    @AssertTrue
+    public static boolean anotherTruth() {  // static
+        return true;
+    }
+
+    @AssertTrue
+    public String notBoolean() {            // invalid type
+        return "aha!";
+    }
+
+    @AssertFalse
+    private static int notBoolTwo(int x) {  // invalid type, static
+        return x;
+    }
+   
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/ValidConstraints.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/beanvalidation/ValidConstraints.java
@@ -1,0 +1,95 @@
+package io.openliberty.sample.jakarta.beanvalidation;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.Calendar;
+import java.util.Map;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+
+public class ValidConstraints {
+    @AssertTrue
+    private boolean isHappy;
+
+    @AssertFalse
+    private boolean isSad;
+
+    @DecimalMax("30.0")
+    @DecimalMin("10.0")
+    private BigDecimal bigDecimal;
+    
+    @Digits(integer=5, fraction=1)
+    private BigInteger digies;
+    
+    @Email
+    private String emailAddress;
+    
+    @FutureOrPresent
+    private Calendar graduationDate;
+    
+    @Future
+    private Year fergiesYear;
+
+    @Min(value = 50)
+    @Max(value = 100)
+    private Integer gpa;
+    
+    @Negative
+    private int subZero;
+    
+    @NegativeOrZero
+    private double notPos;
+    
+    @NotBlank
+    private String saysomething;
+   
+//    not yet implemented - see issue #63
+//    @NotEmpty
+//    private String imgivinguponyou;
+    
+    @NotNull
+    private String thisIsUsed;
+    
+    @Null
+    private String NeverUsed;
+
+    @Past
+    private OffsetDateTime theGoodOldDays;
+    
+    @PastOrPresent
+    private YearMonth aGoodFieldName;
+    
+    @Positive
+    private int area;
+    
+    @PositiveOrZero
+    private int maybeZero;
+
+//    not yet implemented - see issue #63
+//    @Size
+//    private boolean wordMap;
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java
@@ -1,0 +1,55 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.inject.Inject;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+
+public class InjectAndDisposesObservesObservesAsync {
+    
+    @Inject
+    public String greetDisposes(@Disposes String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Inject
+    public String greetObserves(@Observes String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Inject
+    public String greetObservesAsync(@ObservesAsync String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Inject
+    public String greetDisposesObserves(@Disposes String name1, @Observes String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Inject
+    public String greetObservesObservesAsync(@Observes String name1, @ObservesAsync String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Inject
+    public String greetDisposesObservesAsync(@Disposes String name1, @ObservesAsync String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Inject
+    public String greetDisposesObservesObservesAsync(@Disposes String name1, @Observes String name2, @ObservesAsync String name3) {
+        return "Hi " + name1 + ", " + name2 + " and " + name3 + "!";
+    }
+    
+    @Inject
+    public String greetDisposesObservesObservesAsync2(@Disposes @Observes @ObservesAsync String name) {
+        return "Hi " + name + "!";
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.*;
+
+@RequestScoped
+public class ManagedBean<T> {
+	public int a;
+	
+	
+	public ManagedBean() {
+		this.a = 10;
+	}
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBeanConstructor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBeanConstructor.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
+package io.openliberty.sample.jakarta.cdi;
+                                           
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class ManagedBeanConstructor {
+	private int a;
+	
+	public ManagedBeanConstructor(int a) {
+		this.a = a;
+	}
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/MultipleDisposes.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/MultipleDisposes.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.enterprise.inject.Disposes;
+
+@ApplicationScoped
+public class MultipleDisposes {
+    
+    public String greet(@Disposes String name1, @Disposes String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java
@@ -1,0 +1,58 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+
+@ApplicationScoped
+public class ProducesAndDisposesObservesObservesAsync {
+    @Produces
+    public String greetDisposes(@Disposes String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Produces
+    public String greetObserves(@Observes String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Produces
+    public String greetObservesAsync(@ObservesAsync String name) {
+        return "Hi " + name + "!";
+    }
+    
+    
+    @Produces
+    public String greetDisposesObserves(@Disposes String name1, @Observes String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Produces
+    public String greetObservesObservesAsync(@Observes String name1, @ObservesAsync String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Produces
+    public String greetDisposesObservesAsync(@Disposes String name1, @ObservesAsync String name2) {
+        return "Hi " + name1 + " and " + name2 + "!";
+    }
+    
+    
+    @Produces
+    public String greetDisposesObservesObservesAsync(@Disposes String name1, @Observes String name2, @ObservesAsync String name3) {
+        return "Hi " + name1 + ", " + name2 + " and " + name3 + "!";
+    }
+    
+    
+    @Produces
+    public String greetDisposesObservesObservesAsync2(@Disposes @Observes @ObservesAsync String name) {
+        return "Hi " + name + "!";
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndInjectTogether.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndInjectTogether.java
@@ -1,0 +1,20 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped; 
+import jakarta.enterprise.inject.Produces; 
+import jakarta.inject.Inject;
+
+
+@ApplicationScoped
+public class ProducesAndInjectTogether {
+    @Produces
+    @Inject
+    private String greeting = "Hello";
+    
+    
+    @Produces
+    @Inject
+    public String greet(String name) {
+        return this.greeting + " " + name + "!";
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java
@@ -1,0 +1,19 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.inject.Produces;
+
+import jakarta.enterprise.context.*;
+
+@ApplicationScoped @RequestScoped
+public class ScopeDeclaration {
+    @Produces @ApplicationScoped @Dependent
+    private int n;
+    
+    @Produces @ApplicationScoped @RequestScoped
+    public List<Integer> getAllProductIds() {
+        return Collections.emptyList();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/Greeting.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/Greeting.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.di;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Singleton;
+
+@ApplicationScoped
+public class Greeting {
+
+    public String greet(String name) {
+        return "Hello, " + name;
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/GreetingNoDefaultConstructor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/GreetingNoDefaultConstructor.java
@@ -1,0 +1,14 @@
+package io.openliberty.sample.jakarta.di;
+
+public class GreetingNoDefaultConstructor {
+
+    private String greeting;
+
+    public GreetingNoDefaultConstructor(String greeting) {
+        this.greeting = greeting;
+    }
+
+    public String greet(String name) {
+        return greeting + " " + name;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/GreetingServlet.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/GreetingServlet.java
@@ -1,0 +1,49 @@
+package io.openliberty.sample.jakarta.di;
+
+import jakarta.inject.Inject;
+import jakarta.enterprise.inject.Produces;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class GreetingServlet {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    // d1: test code for @Inject fields cannot be final
+    @Inject
+    private final Greeting greeting = new Greeting();
+
+    @Produces
+    public GreetingNoDefaultConstructor getInstance() {
+        return new GreetingNoDefaultConstructor("Howdy");
+    }
+
+    // d2
+    @Inject
+    public final void injectFinal() {
+        // test code for @Inject methods cannot be final
+        return;
+    }
+
+    // d3: test code for @Inject methods cannot be abstract
+    @Inject
+    public abstract void injectAbstract();
+
+    // d4: test code for @Inject methods cannot be static
+    @Inject
+    public static void injectStatic() {
+        return;
+    }
+
+    // d5: test code for @Inject methods cannot be generic
+    @Inject
+    public <T> List<T> injectGeneric(T arg) {
+        // do nothing
+        return new ArrayList<T>();
+    };
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/MultipleConstructorWithInject.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/di/MultipleConstructorWithInject.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Ananya Rao
+*******************************************************************************/
+
+package io.openliberty.sample.jakarta.di;
+
+import jakarta.inject.Inject;
+
+public class MultipleConstructorWithInject{
+    private int productNum;
+    private String productDesc;
+	
+    @Inject
+    public MultipleConstructorWithInject(int productNum) {
+        this.productNum = productNum;
+	}
+    @Inject
+    public MultipleConstructorWithInject(String productDesc) {
+        this.productDesc = productDesc;
+	}
+
+    @Inject
+    protected MultipleConstructorWithInject(int productNum, String productDesc) {
+        this.productNum = productNum;
+        this.productDesc = productDesc;
+	}
+}
+

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Bera Sogut
+*******************************************************************************/
+
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.FormParam;
+
+public class MultipleEntityParamsResourceMethod {
+
+	@DELETE
+	public void resourceMethodWithTwoEntityParams(String entityParam1, @FormParam(value = "") String nonEntityParam, int entityParam2) {
+        
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorClass.java
@@ -1,0 +1,16 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.Path;
+
+@Path("/somewhere")
+public class NoPublicConstructorClass {
+
+    private NoPublicConstructorClass() {
+
+    }
+
+    protected NoPublicConstructorClass(int arg1) {
+
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorProviderClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorProviderClass.java
@@ -1,0 +1,39 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+
+
+@Consumes("application/x-www-form-urlencoded")
+@Provider
+public class NoPublicConstructorProviderClass implements MessageBodyReader<Object> {
+
+    private NoPublicConstructorProviderClass() {
+
+    }
+
+    protected NoPublicConstructorProviderClass(int arg1) {
+
+    }
+
+	@Override
+	public boolean isReadable(Class<?> arg0, Type arg1, Annotation[] arg2, MediaType arg3) {
+		return false;
+	}
+
+	@Override
+	public Object readFrom(Class<Object> arg0, Type arg1, Annotation[] arg2, MediaType arg3,
+			MultivaluedMap<String, String> arg4, InputStream arg5) throws IOException, WebApplicationException {
+		return null;
+	}
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NotPublicResourceMethod.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/NotPublicResourceMethod.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation, Matthew Shocrylas and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Matthew Shocrylas - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.HEAD;
+
+public class NotPublicResourceMethod {
+	
+    @HEAD
+    private void privateMethod() {
+        
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsDiffLen.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsDiffLen.java
@@ -1,0 +1,16 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.Path;
+
+@Path("/somewhere")
+public class RootResourceClassConstructorsDiffLen {
+
+	public RootResourceClassConstructorsDiffLen() {
+		
+	}
+	
+	public RootResourceClassConstructorsDiffLen(int arg1) {
+		
+	}
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsEqualLen.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsEqualLen.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.Path;
+
+@Path("/somewhere")
+public class RootResourceClassConstructorsEqualLen {
+	
+	public RootResourceClassConstructorsEqualLen(int arg1) {
+		
+	}
+	
+	public RootResourceClassConstructorsEqualLen(String arg1) {
+		
+	}
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.sample.jakarta.jsonb;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+
+public class ExtraJsonbCreatorAnnotations {
+    @JsonbCreator
+    public ExtraJsonbCreatorAnnotations() {}
+    
+    @JsonbCreator
+    private static ExtraJsonbCreatorAnnotations factoryMethod() {
+        return null;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java
@@ -1,0 +1,78 @@
+/******************************************************************************* 
+* Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Adit Rada, Yijia Jing - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.sample.jakarta.jsonb;
+
+import jakarta.json.bind.annotation.JsonbAnnotation;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTransient;
+
+public class JsonbTransientDiagnostic {
+    @JsonbTransient
+    private int id;
+
+    @JsonbProperty("name")
+    @JsonbTransient
+    private String name;    // Diagnostic: JsonbTransient is mutually exclusive with other JsonB annotations
+
+    @JsonbProperty("fav_lang")
+    @JsonbAnnotation
+    @JsonbTransient
+    private String favoriteLanguage;    // Diagnostic: JsonbTransient is mutually exclusive with other JsonB annotations
+    
+    // No diagnostic as field is not annotated with other Jsonb annotations,
+    // even though the accessors are annotated with @JsonbTransient
+    private String favoriteDatabase;
+    
+    // Diagnostic will appear as field accessors have @JsonbTransient,
+    // but field itself has annotation other than transient
+    @JsonbProperty("fav_editor")
+    private String favoriteEditor;
+    
+    @JsonbProperty("person-id")
+    private int getId() { 
+        // A diagnostic is expected on getId because as a getter, it is annotated with other 
+        // Jsonb annotations while its corresponding field id is annotated with JsonbTransient
+        return id;
+    }
+    
+    @JsonbAnnotation
+    private void setId(int id) {
+        // A diagnostic is expected on setId because as a setter, it is annotated with other 
+        // Jsonb annotations while its corresponding field id is annotated with JsonbTransient
+        this.id = id;
+    }
+    
+    @JsonbTransient
+    private String getFavoriteDatabase() {
+        return favoriteDatabase;
+    }
+    
+    @JsonbTransient
+    private void setFavoriteDatabase(String favoriteDatabase) {
+        this.favoriteDatabase = favoriteDatabase;
+    }
+    
+    // A diagnostic will appear as field has conflicting annotation
+    @JsonbTransient
+    private String getFavoriteEditor() {
+        return favoriteEditor;
+    }
+    
+    // A diagnostic will appear as @JsonbTransient is not mutually exclusive on this accessor
+    @JsonbAnnotation
+    @JsonbTransient
+    private void setFavoriteEditor(String favoriteEditor) {
+        this.favoriteEditor = favoriteEditor;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/CreatePointerInvalidTarget.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/CreatePointerInvalidTarget.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
+package io.openliberty.sample.jakarta.jsonp;
+
+import jakarta.json.Json;
+import jakarta.json.JsonPointer;
+
+public class CreatePointerInvalidTarget {
+
+    public static void makePointers() {
+        JsonPointer doubleSlashPointer = Json.createPointer("//");
+        JsonPointer noSlashPrefixPointer = Json.createPointer("name/1");
+        JsonPointer slashSuffixPointer = Json.createPointer("/skills/languages/");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/EntityMissingConstructor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/EntityMissingConstructor.java
@@ -1,0 +1,10 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityMissingConstructor {
+
+    private EntityMissingConstructor(int x) {}
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/FinalModifiers.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/FinalModifiers.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public final class FinalModifiers {
+
+    final int x = 1;
+    final String y = "hello", z = "world";
+    
+    public final int methody() {
+        final int ret = 100;
+        return 100 + ret;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java
@@ -1,0 +1,20 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyClass;
+
+public class MapKeyAndMapKeyClassTogether {
+    @MapKey()
+    @MapKeyClass(Map.class)
+    Map<Integer, String> testMap = new HashMap<>();
+    
+    
+    @MapKey()
+    @MapKeyClass(Map.class)
+    public Map<Integer, String> getTestMap(){
+    	return this.testMap;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MultipleMapKeyAnnotations.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MultipleMapKeyAnnotations.java
@@ -1,0 +1,22 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MapKeyJoinColumn;
+
+@Entity
+public class MultipleMapKeyAnnotations {
+    @MapKeyJoinColumn()
+    @MapKeyJoinColumn()
+    Map<Integer, String> test1;
+    
+    @MapKeyJoinColumn(name = "n1")
+    @MapKeyJoinColumn(referencedColumnName = "rcn2")
+    Map<Integer, String> test2;
+    
+    @MapKeyJoinColumn(name = "n1", referencedColumnName = "rcn1")
+    @MapKeyJoinColumn()
+    Map<Integer, String> test3;
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontExtendHttpServlet.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontExtendHttpServlet.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.servlet;
+
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet(name = "demoServlet", urlPatterns = { "/demo" })
+public class DontExtendHttpServlet {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/InvalidWebServlet.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/InvalidWebServlet.java
@@ -1,0 +1,17 @@
+package io.openliberty.sample.jakarta.servlet;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet()
+public class InvalidWebServlet extends HttpServlet {
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+		res.setContentType("text/html;charset=UTF-8");
+		res.getWriter().println("Hello Jakarta EE 9 + Open Liberty!");
+	}
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/AnnotationTest.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/AnnotationTest.java
@@ -1,0 +1,28 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import java.io.IOException;
+
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.server.ServerEndpoint;
+import jakarta.websocket.Session;
+
+/**
+ * Expected Diagnostics are related to validating that the parameters have the 
+ * valid annotation @PathParam (code: AddPathParamsAnnotation)
+ * See issue #247 (onOpen) and #248 (onClose)
+ */
+@ServerEndpoint(value = "/infos")
+public class AnnotationTest {
+    // @PathParam missing annotation for "String missingAnnotation"
+    @OnOpen
+    public void OnOpen(Session session, String missingAnnotation) throws IOException {
+        System.out.println("Websocket opened: " + session.getId().toString());
+    }
+    
+    // Used to check that the expected diagnostic handle more than one case
+    @OnClose
+    public void OnClose(Session session, Integer missingAnnotation1, String missingAnnotation2) {
+        System.out.println("Websocket opened: " + session.getId().toString());
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
@@ -1,0 +1,22 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import java.io.Reader;
+
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.PathParam;
+import jakarta.websocket.server.ServerEndpoint;
+
+// String and Reader will cause a duplicate diagnostic as they're both text message formats.
+@ServerEndpoint("/{var}")
+public class DuplicateOnMessage {
+    @OnMessage
+    public void textHandler1(@PathParam("var") String var, String text, Session session) {
+        session.getAsyncRemote().sendText(text);
+    }
+
+    @OnMessage
+    public void textHandler2(@PathParam("var") String var, Reader text, Session session) {
+        session.getAsyncRemote().sendText(var);
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/InvalidParamType.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/InvalidParamType.java
@@ -1,0 +1,28 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import java.io.IOException;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+
+/**
+ * Expected Diagnostics are related to validating that the parameters for the 
+ * WebSocket methods are of valid types for onOpen (diagnostic code: OnOpenChangeInvalidParam) 
+ * and onClose (diagnostic code: OnCloseChangeInvalidParam).
+ * See issues #247 (onOpen) and #248 (onClose)
+ */
+@ServerEndpoint(value = "/infos")
+public class InvalidParamType {
+    @OnOpen
+    public void OnOpen(Session session, Object invalidParam) throws IOException {
+        System.out.println("WebSocket closed for " + session.getId());
+    }
+    
+    @OnClose
+    public void OnClose(Session session, CloseReason closeReason, Object invalidParam) throws IOException {
+        System.out.println("WebSocket closed for " + session.getId());
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+// Diagnostics:
+// + Server endpoint paths must not use the same variable more than once in a path.
+@ServerEndpoint("/{varA}/{varB}/{varA}")
+public class ServerEndpointDuplicateVariableURI {}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+// Diagnostics:
+// + Server endpoint paths must be a URI-template (level-1) or a partial URI.
+@ServerEndpoint("/{very incorrect variable}/")
+public class ServerEndpointInvalidTemplateURI {}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
@@ -1,0 +1,9 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+// Diagnostics:
+// + Server endpoint paths must start with a leading '/'.
+// + Server endpoint paths must be a URI-template (level-1) or a partial URI.
+@ServerEndpoint("path")
+public class ServerEndpointNoSlash {}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+// Diagnostics:
+// + Server endpoint paths must not contain the sequences '/../', '/./' or '//'.
+@ServerEndpoint("/../path")
+public class ServerEndpointRelativePathTest {}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websockets/PathParamURIWarningTest.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websockets/PathParamURIWarningTest.java
@@ -1,0 +1,42 @@
+package io.openliberty.sample.jakarta.websockets;
+
+import java.io.IOException;
+import jakarta.websocket.server.PathParam;
+import jakarta.websocket.server.ServerEndpoint;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.Session;
+
+@ServerEndpoint(value = "/paramdemo/{test}/{abcd}")
+public class PathParamURIWarningTest {
+    private static Session session;
+
+    @OnOpen
+    public void OnOpen(Session session) throws IOException {
+        this.session = session;
+        System.out.println("Websocket opened: " + session.getId().toString());
+    }
+
+    @OnMessage
+    public void onMessage(String message, Session session, @PathParam("tast") String test) {
+        System.out.println("Program requested " + message + " using " + session.getId());
+        System.out.println(session.getPathParameters() + " - " + session.getRequestURI());
+        if (test == null) {
+            session.getAsyncRemote().sendText("Test String was Null!");
+        } else {
+            session.getAsyncRemote().sendText("Test String was \"" + message + "\"");
+        }
+    }
+
+    @OnError
+    public void onError(Session session, Throwable throwable) {
+        System.out.println("There was an error WebSocket error for " + session.getId() + " " + throwable.getMessage());
+    }
+
+    @OnClose
+    public void onClose(Session session) {
+        System.out.println("WebSocket closed for " + session.getId());
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/liberty/config/bootstrap.properties
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/liberty/config/bootstrap.properties
@@ -1,0 +1,2 @@
+default.http.port = 9080
+default.https.port = 9443

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/liberty/config/server.xml
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/liberty/config/server.xml
@@ -1,0 +1,10 @@
+<server description="Sample Liberty server">
+    <featureManager>
+        <feature>jakartaee-9.0</feature>
+    </featureManager>
+
+    <webApplication location="${artifactId}.war" contextRoot="/" />
+
+    <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+
+</server>


### PR DESCRIPTION
This PR re-introduces https://github.com/OpenLiberty/liberty-tools-intellij/pull/449 with the following changes:

- Removed system properties that were not required for running the tests.
- Made `BaseJakartaTest` into an abstract class to prevent the JUnit test runner from reporting an error for having no test methods.

See https://github.com/OpenLiberty/liberty-tools-intellij/issues/379 for details on the origin of these tests.