### PR TITLE
Enable remaining Jakarta diagnostic tests.

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -40,7 +40,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class PostConstructAnnotationTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void GeneratedAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -65,17 +65,18 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-        TextEdit te1 = te(19, 4, 20, 4, "");
-        TextEdit te2 = te(20, 29, 20, 40, "");
-        CodeAction ca1 = ca(uri, "Remove @PostConstruct", d2, te1);
-        CodeAction ca2 = ca(uri, "Remove all parameters", d2, te2);
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
-        
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
-        TextEdit te3 = te(15, 11, 15, 18, "void");
-        CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
-        assertJavaCodeAction(codeActionParams2, utils, ca3);
-    }
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+            TextEdit te1 = te(19, 4, 20, 4, "");
+            TextEdit te2 = te(20, 29, 20, 40, "");
+            CodeAction ca1 = ca(uri, "Remove @PostConstruct", d2, te1);
+            CodeAction ca2 = ca(uri, "Remove all parameters", d2, te2);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
 
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
+            TextEdit te3 = te(15, 11, 15, 18, "void");
+            CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
+            assertJavaCodeAction(codeActionParams2, utils, ca3);
+        }
+    }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
@@ -66,21 +66,21 @@ public class PreDestroyAnnotationTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d2, d1, d3);
         
-        
-        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
-        TextEdit te = te(19, 1, 20, 1,"");
-        TextEdit te1 = te(20, 29, 20, 40,"");
-        CodeAction ca = ca(uri, "Remove @PreDestroy", d1, te);
-        CodeAction ca1= ca(uri, "Remove all parameters", d1, te1);
-        assertJavaCodeAction(codeActionParams, utils, ca, ca1);
-        
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-        TextEdit te2 = te(25, 1, 26, 1,"");
-        TextEdit te3 = te(26, 7, 26, 14,"");
-        CodeAction ca2 = ca(uri, "Remove @PreDestroy", d2, te2);
-        CodeAction ca3= ca(uri, "Remove the 'static' modifier from this method", d2, te3);
-        assertJavaCodeAction(codeActionParams1, utils, ca2, ca3);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+            TextEdit te = te(19, 1, 20, 1, "");
+            TextEdit te1 = te(20, 29, 20, 40, "");
+            CodeAction ca = ca(uri, "Remove @PreDestroy", d1, te);
+            CodeAction ca1 = ca(uri, "Remove all parameters", d1, te1);
+            assertJavaCodeAction(codeActionParams, utils, ca, ca1);
 
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+            TextEdit te2 = te(25, 1, 26, 1, "");
+            TextEdit te3 = te(26, 7, 26, 14, "");
+            CodeAction ca2 = ca(uri, "Remove @PreDestroy", d2, te2);
+            CodeAction ca3 = ca(uri, "Remove the 'static' modifier from this method", d2, te3);
+            assertJavaCodeAction(codeActionParams1, utils, ca2, ca3);
+        }
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
@@ -40,7 +40,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class PreDestroyAnnotationTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void GeneratedAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -59,7 +58,7 @@ public class PreDestroyAnnotationTest extends BaseJakartaTest {
         
         Diagnostic d2 = d(26, 20, 31, "A method with the @PreDestroy annotation must not be static.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "PreDestroyStatic");
-        d2.setData(9);
+        d2.setData("makeUnhappy");
         
         Diagnostic d3 = d(31, 13, 25, "A method with the @PreDestroy annotation must not throw checked exceptions.",
                 DiagnosticSeverity.Warning, "jakarta-annotations", "PreDestroyException");

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -59,20 +59,18 @@ public class ResourceAnnotationTest extends BaseJakartaTest {
         Diagnostic d2 = d(39, 0, 30, "The @Resource annotation must define the attribute 'name'.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "MissingResourceNameAttribute");
 
-
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
-        
-        
-        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
-        TextEdit te = te(22, 0, 22, 22, "@Resource(name = \"aa\", type = \"\")");
-        CodeAction ca= ca(uri, "Add type to jakarta.annotation.Resource", d1, te);
-        assertJavaCodeAction(codeActionParams, utils, ca);
-        
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-        TextEdit te1 = te(39, 0, 39, 30, "@Resource(type = \"\", name = \"\")");
-        CodeAction ca1= ca(uri, "Add name to jakarta.annotation.Resource", d2, te1);
-        assertJavaCodeAction(codeActionParams1, utils, ca1);
 
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+            TextEdit te = te(22, 0, 22, 22, "@Resource(name = \"aa\", type = \"\")");
+            CodeAction ca = ca(uri, "Add type to jakarta.annotation.Resource", d1, te);
+            assertJavaCodeAction(codeActionParams, utils, ca);
+
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+            TextEdit te1 = te(39, 0, 39, 30, "@Resource(type = \"\", name = \"\")");
+            CodeAction ca1 = ca(uri, "Add name to jakarta.annotation.Resource", d2, te1);
+            assertJavaCodeAction(codeActionParams1, utils, ca1);
+        }
     }
-
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -40,7 +40,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class ResourceAnnotationTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void ResourceAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -169,29 +169,31 @@ public class BeanValidationTest extends BaseJakartaTest {
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8,
                 d9, d10, d11, d12, d13, d14, d15, d16, d17, d19, d20);
 
-        // Test quickfix codeActions - type (1-17), static, static+type (should only display static)
-        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
-        TextEdit te = te(9, 4, 10, 4, "");
-        CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);    
+        if (CHECK_CODE_ACTIONS) {
+            // Test quickfix codeActions - type (1-17), static, static+type (should only display static)
+            JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+            TextEdit te = te(9, 4, 10, 4, "");
+            CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);
 
-        assertJavaCodeAction(codeActionParams, utils, ca);
+            assertJavaCodeAction(codeActionParams, utils, ca);
 
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d19);
-        TextEdit te1 = te(59, 4, 60, 4, "");
-        TextEdit te2 = te(60, 11, 60, 18, "");
-        CodeAction ca1 = ca(uri, "Remove constraint annotation AssertTrue from element", d19, te1);
-        CodeAction ca2 = ca(uri, "Remove static modifier from element", d19, te2);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d19);
+            TextEdit te1 = te(59, 4, 60, 4, "");
+            TextEdit te2 = te(60, 11, 60, 18, "");
+            CodeAction ca1 = ca(uri, "Remove constraint annotation AssertTrue from element", d19, te1);
+            CodeAction ca2 = ca(uri, "Remove static modifier from element", d19, te2);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca1, ca2);
-        
+            assertJavaCodeAction(codeActionParams2, utils, ca1, ca2);
 
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d20);
-        TextEdit te3 = te(62, 4, 63, 4, "");
-        TextEdit te4 = te(63, 11, 63, 18, "");
-        CodeAction ca3 = ca(uri, "Remove constraint annotation Past from element", d20, te3);
-        CodeAction ca4 = ca(uri, "Remove static modifier from element", d20, te4);
 
-        assertJavaCodeAction(codeActionParams3, utils, ca3, ca4);
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d20);
+            TextEdit te3 = te(62, 4, 63, 4, "");
+            TextEdit te4 = te(63, 11, 63, 18, "");
+            CodeAction ca3 = ca(uri, "Remove constraint annotation Past from element", d20, te3);
+            CodeAction ca4 = ca(uri, "Remove static modifier from element", d20, te4);
+
+            assertJavaCodeAction(codeActionParams3, utils, ca3, ca4);
+        }
     }
     
     @Test
@@ -220,25 +222,27 @@ public class BeanValidationTest extends BaseJakartaTest {
         
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        // Test quickfix codeActions
-        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
-        TextEdit te = te(19, 4, 20, 4, "");
-        TextEdit te2 = te(20, 10, 20, 17, "");
-        CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);
-        CodeAction ca2 = ca(uri, "Remove static modifier from element", d1, te2);
+        if (CHECK_CODE_ACTIONS) {
+            // Test quickfix codeActions
+            JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
+            TextEdit te = te(19, 4, 20, 4, "");
+            TextEdit te2 = te(20, 10, 20, 17, "");
+            CodeAction ca = ca(uri, "Remove constraint annotation AssertTrue from element", d1, te);
+            CodeAction ca2 = ca(uri, "Remove static modifier from element", d1, te2);
 
-        assertJavaCodeAction(codeActionParams, utils, ca, ca2);
+            assertJavaCodeAction(codeActionParams, utils, ca, ca2);
 
-        codeActionParams = createCodeActionParams(uri, d2);
-        te = te(24, 4, 25, 4, "");
-        ca = ca(uri, "Remove constraint annotation AssertTrue from element", d2, te);    
+            codeActionParams = createCodeActionParams(uri, d2);
+            te = te(24, 4, 25, 4, "");
+            ca = ca(uri, "Remove constraint annotation AssertTrue from element", d2, te);
 
-        assertJavaCodeAction(codeActionParams, utils, ca);
-        
-        codeActionParams = createCodeActionParams(uri, d3);
-        te = te(19, 4, 20, 4, "");
-        te2 = te(20, 10, 20, 17, "");
-        ca = ca(uri, "Remove constraint annotation AssertFalse from element", d3, te);
-        ca2 = ca(uri, "Remove static modifier from element", d3, te2);
+            assertJavaCodeAction(codeActionParams, utils, ca);
+
+            codeActionParams = createCodeActionParams(uri, d3);
+            te = te(19, 4, 20, 4, "");
+            te2 = te(20, 10, 20, 17, "");
+            ca = ca(uri, "Remove constraint annotation AssertFalse from element", d3, te);
+            ca2 = ca(uri, "Remove static modifier from element", d3, te2);
+        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -56,7 +56,6 @@ public class BeanValidationTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore
     public void fieldConstraintValidation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -71,10 +70,10 @@ public class BeanValidationTest extends BaseJakartaTest {
         // Test diagnostics
         Diagnostic d1 = d(10, 16, 23,
                 "The @AssertTrue annotation can only be used on boolean and Boolean type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertTrue");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.AssertTrue");
         Diagnostic d2 = d(13, 19, 24,
                 "The @AssertFalse annotation can only be used on boolean and Boolean type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertFalse");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.AssertFalse");
         Diagnostic d3 = d(17, 19, 29,
                 "The @DecimalMax annotation can only be used on: \n"
                 + "- BigDecimal \n"
@@ -82,7 +81,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "- CharSequence\n"
                 + "- byte, short, int, long (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "DecimalMax");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.DecimalMax");
         Diagnostic d4 = d(17, 19, 29,
                 "The @DecimalMin annotation can only be used on: \n"
                 + "- BigDecimal \n"
@@ -90,7 +89,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "- CharSequence\n"
                 + "- byte, short, int, long (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "DecimalMin");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.DecimalMin");
         Diagnostic d5 = d(20, 20, 26,
                 "The @Digits annotation can only be used on: \n"
                 + "- BigDecimal \n"
@@ -98,73 +97,73 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "- CharSequence\n"
                 + "- byte, short, int, long (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Digits");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Digits");
         Diagnostic d6 = d(23, 20, 32,
                 "The @Email annotation can only be used on String and CharSequence type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Email");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Email");
         Diagnostic d7 = d(26, 20, 34,
                 "The @FutureOrPresent annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "FutureOrPresent");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.FutureOrPresent");
         Diagnostic d8 = d(29, 19, 30,
                 "The @Future annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Future");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Future");
         Diagnostic d9 = d(33, 20, 23,
                 "The @Min annotation can only be used on \n"
                         + "- BigDecimal \n"
                         + "- BigInteger\n"
                         + "- byte, short, int, long (and their respective wrappers) \n"
                         + " type fields.",
-                        DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Min");
+                        DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Min");
         Diagnostic d10 = d(33, 20, 23,
                 "The @Max annotation can only be used on \n"
                 + "- BigDecimal \n"
                 + "- BigInteger\n"
                 + "- byte, short, int, long (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Max");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Max");
         Diagnostic d11 = d(36, 20, 27,
                 "The @Negative annotation can only be used on \n"
                 + "- BigDecimal \n"
                 + "- BigInteger\n"
                 + "- byte, short, int, long, float, double (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Negative");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Negative");
         Diagnostic d12 = d(39, 19, 25,
                 "The @NegativeOrZero annotation can only be used on \n"
                 + "- BigDecimal \n"
                 + "- BigInteger\n"
                 + "- byte, short, int, long, float, double (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "NegativeOrZero");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.NegativeOrZero");
         Diagnostic d13 = d(42, 20, 32,
                 "The @NotBlank annotation can only be used on String and CharSequence type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "NotBlank");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.NotBlank");
         Diagnostic d14 = d(45, 21, 31,
                 "The @Pattern annotation can only be used on String and CharSequence type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Pattern");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Pattern");
         Diagnostic d15 = d(48, 19, 33,
                 "The @Past annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Past");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Past");
         Diagnostic d16 = d(51, 19, 33,
                 "The @PastOrPresent annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "PastOrPresent");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.PastOrPresent");
         Diagnostic d17 = d(54, 21, 25,
                 "The @Positive annotation can only be used on \n"
                 + "- BigDecimal \n"
                 + "- BigInteger\n"
                 + "- byte, short, int, long, float, double (and their respective wrappers) \n"
                 + " type fields.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "Positive");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Positive");
         // not yet implemented
 //        Diagnostic d18 = d(11, 17, 24,
 //                "The @PositiveOrZero annotation can only be used on boolean and Boolean type fields.",
 //                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "PositiveOrZero");
         Diagnostic d19 = d(60, 27, 36,
                 "Constraint annotations are not allowed on static fields",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertTrue");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.AssertTrue");
         Diagnostic d20 = d(63, 27, 36,
                 "Constraint annotations are not allowed on static fields",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "Past");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.Past");
         
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8,
                 d9, d10, d11, d12, d13, d14, d15, d16, d17, d19, d20);
@@ -197,7 +196,6 @@ public class BeanValidationTest extends BaseJakartaTest {
     }
     
     @Test
-    @Ignore
     public void methodConstraintValidation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -212,13 +210,13 @@ public class BeanValidationTest extends BaseJakartaTest {
         // Test diagnostics
         Diagnostic d1 = d(20, 26, 38,
                 "Constraint annotations are not allowed on static methods",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertTrue");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.AssertTrue");
         Diagnostic d2 = d(25, 18, 28,
                 "The @AssertTrue annotation can only be used on boolean and Boolean type methods.",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "AssertTrue");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.AssertTrue");
         Diagnostic d3 = d(30, 23, 33,
                 "Constraint annotations are not allowed on static methods",
-                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "AssertFalse");
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.AssertFalse");
         
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
@@ -60,18 +60,20 @@ public class ManagedBeanConstructorTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        // test expected quick-fix
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
-        TextEdit te1 = te(15, 44, 21, 1,
-                "\nimport jakarta.inject.Inject;\n\n@Dependent\npublic class ManagedBeanConstructor {\n	private int a;\n	\n	@Inject\n	");
-        TextEdit te2 = te(19, 1, 19, 1,
-        		"protected ManagedBeanConstructor() {\n\t}\n\n\t");
-        TextEdit te3 = te(19, 1, 19, 1,
-                "public ManagedBeanConstructor() {\n\t}\n\n\t");
-        CodeAction ca1 = ca(uri, "Insert @Inject", d, te1);
-        CodeAction ca2 = ca(uri, "Add a no-arg protected constructor to this class", d, te2);
-        CodeAction ca3 = ca(uri, "Add a no-arg public constructor to this class", d, te3);
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2, ca3);
+        if (CHECK_CODE_ACTIONS) {
+            // test expected quick-fix
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
+            TextEdit te1 = te(15, 44, 21, 1,
+                    "\nimport jakarta.inject.Inject;\n\n@Dependent\npublic class ManagedBeanConstructor {\n	private int a;\n	\n	@Inject\n	");
+            TextEdit te2 = te(19, 1, 19, 1,
+                    "protected ManagedBeanConstructor() {\n\t}\n\n\t");
+            TextEdit te3 = te(19, 1, 19, 1,
+                    "public ManagedBeanConstructor() {\n\t}\n\n\t");
+            CodeAction ca1 = ca(uri, "Insert @Inject", d, te1);
+            CodeAction ca2 = ca(uri, "Add a no-arg protected constructor to this class", d, te2);
+            CodeAction ca3 = ca(uri, "Add a no-arg public constructor to this class", d, te3);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2, ca3);
+        }
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
@@ -41,7 +41,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class ManagedBeanConstructorTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void managedBeanAnnotations() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -65,17 +65,19 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
-        // Assert for the diagnostic d1
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        TextEdit te1 = te(4, 0, 5, 0, "@Dependent\n");
-        CodeAction ca1 = ca(uri, "Replace current scope with @Dependent", d1, te1);
-        assertJavaCodeAction(codeActionParams1, utils, ca1);
-        
-        // Assert for the diagnostic d2
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-        TextEdit te2 = te(4, 0, 5, 0, "@Dependent\n");
-        CodeAction ca2 = ca(uri, "Replace current scope with @Dependent", d2, te2);
-        assertJavaCodeAction(codeActionParams2, utils, ca2);
+        if (CHECK_CODE_ACTIONS) {
+            // Assert for the diagnostic d1
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+            TextEdit te1 = te(4, 0, 5, 0, "@Dependent\n");
+            CodeAction ca1 = ca(uri, "Replace current scope with @Dependent", d1, te1);
+            assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+            // Assert for the diagnostic d2
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            TextEdit te2 = te(4, 0, 5, 0, "@Dependent\n");
+            CodeAction ca2 = ca(uri, "Replace current scope with @Dependent", d2, te2);
+            assertJavaCodeAction(codeActionParams2, utils, ca2);
+        }
     }
     
     @Test
@@ -107,32 +109,34 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        // Assert for the diagnostic d1
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        TextEdit te1 = te(11, 33, 12, 4, "");
-        TextEdit te2 = te(11, 14, 11, 33, "");
-        CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te2);
-        CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te1);
-        
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
-        
-        // Assert for the diagnostic d2
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-        TextEdit te3 = te(14, 33, 15, 4, "");
-        TextEdit te4 = te(14, 14, 14, 33, "");
-        CodeAction ca3 = ca(uri, "Remove @RequestScoped", d2, te3);
-        CodeAction ca4 = ca(uri, "Remove @ApplicationScoped", d2, te4);
-        
-        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
-        
-        // Assert for the diagnostic d3
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
-        TextEdit te5 = te(9, 19, 10, 0, "");
-        TextEdit te6 = te(9, 0, 9, 19, "");
-        CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
-        CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
-        
-        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        if (CHECK_CODE_ACTIONS) {
+            // Assert for the diagnostic d1
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+            TextEdit te1 = te(11, 33, 12, 4, "");
+            TextEdit te2 = te(11, 14, 11, 33, "");
+            CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te2);
+            CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te1);
+
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+
+            // Assert for the diagnostic d2
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            TextEdit te3 = te(14, 33, 15, 4, "");
+            TextEdit te4 = te(14, 14, 14, 33, "");
+            CodeAction ca3 = ca(uri, "Remove @RequestScoped", d2, te3);
+            CodeAction ca4 = ca(uri, "Remove @ApplicationScoped", d2, te4);
+
+            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+
+            // Assert for the diagnostic d3
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+            TextEdit te5 = te(9, 19, 10, 0, "");
+            TextEdit te6 = te(9, 0, 9, 19, "");
+            CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
+            CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
+
+            assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        }
     }
 
     @Test
@@ -156,23 +160,25 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
-        TextEdit te1 = te(14, 4, 15, 4, "");
-        TextEdit te2 = te(15, 4, 16, 4, "");
-        CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
-        CodeAction ca2 = ca(uri, "Remove @Inject", d1, te2);
+            TextEdit te1 = te(14, 4, 15, 4, "");
+            TextEdit te2 = te(15, 4, 16, 4, "");
+            CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
+            CodeAction ca2 = ca(uri, "Remove @Inject", d1, te2);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
 
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
-        TextEdit te3 = te(9, 4, 10, 4, "");
-        TextEdit te4 = te(10, 4, 11, 4, "");
-        CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
-        CodeAction ca4 = ca(uri, "Remove @Inject", d2, te4);
+            TextEdit te3 = te(9, 4, 10, 4, "");
+            TextEdit te4 = te(10, 4, 11, 4, "");
+            CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
+            CodeAction ca4 = ca(uri, "Remove @Inject", d2, te4);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        }
     }
 
     @Test
@@ -221,89 +227,90 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
-        
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
-        TextEdit te1 = te(9, 4, 10, 4, "");
-        TextEdit te2 = te(10, 32, 10, 42, "");
-        CodeAction ca1 = ca(uri, "Remove @Inject", d1, te1);
-        CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
-        
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            TextEdit te1 = te(9, 4, 10, 4, "");
+            TextEdit te2 = te(10, 32, 10, 42, "");
+            CodeAction ca1 = ca(uri, "Remove @Inject", d1, te1);
+            CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
 
-        TextEdit te3 = te(15, 4, 16, 4, "");
-        TextEdit te4 = te(16, 32, 16, 42, "");
-        CodeAction ca3 = ca(uri, "Remove @Inject", d2, te3);
-        CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
-        
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
-        TextEdit te5 = te(21, 4, 22, 4, "");
-        TextEdit te6 = te(22, 37, 22, 52, "");
-        CodeAction ca5 = ca(uri, "Remove @Inject", d3, te5);
-        CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
+            TextEdit te3 = te(15, 4, 16, 4, "");
+            TextEdit te4 = te(16, 32, 16, 42, "");
+            CodeAction ca3 = ca(uri, "Remove @Inject", d2, te3);
+            CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
 
-        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
-        
-        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
 
-        TextEdit te7 = te(27, 4, 28, 4, "");
-        TextEdit te8 = te(28, 40, 28, 50, "");
-        TextEdit te9 = te(28, 64, 28, 74, "");
-        CodeAction ca7 = ca(uri, "Remove @Inject", d4, te7);
-        CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
-        CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
 
-        assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
-        
-        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+            TextEdit te5 = te(21, 4, 22, 4, "");
+            TextEdit te6 = te(22, 37, 22, 52, "");
+            CodeAction ca5 = ca(uri, "Remove @Inject", d3, te5);
+            CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
 
-        TextEdit te10 = te(33, 4, 34, 4, "");
-        TextEdit te11 = te(34, 45, 34, 55, "");
-        TextEdit te12 = te(34, 69, 34, 84, "");
-        CodeAction ca10 = ca(uri, "Remove @Inject", d5, te10);
-        CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
-        CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
+            assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
 
-        assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
-        
-        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
+            JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
 
-        TextEdit te13 = te(39, 4, 40, 4, "");
-        TextEdit te14 = te(40, 45, 40, 55, "");
-        TextEdit te15 = te(40, 69, 40, 84, "");
-        CodeAction ca13 = ca(uri, "Remove @Inject", d6, te13);
-        CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
-        CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+            TextEdit te7 = te(27, 4, 28, 4, "");
+            TextEdit te8 = te(28, 40, 28, 50, "");
+            TextEdit te9 = te(28, 64, 28, 74, "");
+            CodeAction ca7 = ca(uri, "Remove @Inject", d4, te7);
+            CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
+            CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
 
-        assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
-        
-        JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+            assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
 
-        TextEdit te16 = te(45, 4, 46, 4, "");
-        TextEdit te17 = te(46, 53, 46, 63, "");
-        TextEdit te18 = te(46, 77, 46, 87, "");
-        TextEdit te19 = te(46, 101, 46, 116, "");
-        CodeAction ca16 = ca(uri, "Remove @Inject", d7, te16);
-        CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
-        CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
-        CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+            JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
 
-        assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
-        
-        JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+            TextEdit te10 = te(33, 4, 34, 4, "");
+            TextEdit te11 = te(34, 45, 34, 55, "");
+            TextEdit te12 = te(34, 69, 34, 84, "");
+            CodeAction ca10 = ca(uri, "Remove @Inject", d5, te10);
+            CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
+            CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
 
-        TextEdit te20 = te(50, 4, 51, 4, "");
-        TextEdit te21 = te(51, 54, 51, 89, "");
-        CodeAction ca20 = ca(uri, "Remove @Inject", d8, te20);
-        CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+            assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
 
-        assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
+            JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
 
+            TextEdit te13 = te(39, 4, 40, 4, "");
+            TextEdit te14 = te(40, 45, 40, 55, "");
+            TextEdit te15 = te(40, 69, 40, 84, "");
+            CodeAction ca13 = ca(uri, "Remove @Inject", d6, te13);
+            CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
+            CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+
+            assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
+
+            JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+
+            TextEdit te16 = te(45, 4, 46, 4, "");
+            TextEdit te17 = te(46, 53, 46, 63, "");
+            TextEdit te18 = te(46, 77, 46, 87, "");
+            TextEdit te19 = te(46, 101, 46, 116, "");
+            CodeAction ca16 = ca(uri, "Remove @Inject", d7, te16);
+            CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
+            CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
+            CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+
+            assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
+
+            JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+
+            TextEdit te20 = te(50, 4, 51, 4, "");
+            TextEdit te21 = te(51, 54, 51, 89, "");
+            CodeAction ca20 = ca(uri, "Remove @Inject", d8, te20);
+            CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+
+            assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
+        }
     }
 
     @Test
@@ -369,89 +376,89 @@ public class ManagedBeanTest extends BaseJakartaTest {
         
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12);
 
-        
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
-        TextEdit te1 = te(11, 4, 12, 4, "");
-        TextEdit te2 = te(12, 32, 12, 42, "");
-        CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
-        CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
+            TextEdit te1 = te(11, 4, 12, 4, "");
+            TextEdit te2 = te(12, 32, 12, 42, "");
+            CodeAction ca1 = ca(uri, "Remove @Produces", d1, te1);
+            CodeAction ca2 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name'", d1, te2);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
-        
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
 
-        TextEdit te3 = te(17, 4, 18, 4, "");
-        TextEdit te4 = te(18, 32, 18, 42, "");
-        CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
-        CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
-        
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+            TextEdit te3 = te(17, 4, 18, 4, "");
+            TextEdit te4 = te(18, 32, 18, 42, "");
+            CodeAction ca3 = ca(uri, "Remove @Produces", d2, te3);
+            CodeAction ca4 = ca(uri, "Remove the '@Observes' modifier from parameter 'name'", d2, te4);
 
-        TextEdit te5 = te(23, 4, 24, 4, "");
-        TextEdit te6 = te(24, 37, 24, 52, "");
-        CodeAction ca5 = ca(uri, "Remove @Produces", d3, te5);
-        CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
+            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
 
-        assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
-        
-        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
 
-        TextEdit te7 = te(29, 4, 30, 4, "");
-        TextEdit te8 = te(30, 40, 30, 50, "");
-        TextEdit te9 = te(30, 64, 30, 74, "");
-        CodeAction ca7 = ca(uri, "Remove @Produces", d4, te7);
-        CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
-        CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
+            TextEdit te5 = te(23, 4, 24, 4, "");
+            TextEdit te6 = te(24, 37, 24, 52, "");
+            CodeAction ca5 = ca(uri, "Remove @Produces", d3, te5);
+            CodeAction ca6 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name'", d3, te6);
 
-        assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
-        
-        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+            assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
 
-        TextEdit te10 = te(35, 4, 36, 4, "");
-        TextEdit te11 = te(36, 45, 36, 55, "");
-        TextEdit te12 = te(36, 69, 36, 84, "");
-        CodeAction ca10 = ca(uri, "Remove @Produces", d5, te10);
-        CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
-        CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
+            JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
 
-        assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
-        
-        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
+            TextEdit te7 = te(29, 4, 30, 4, "");
+            TextEdit te8 = te(30, 40, 30, 50, "");
+            TextEdit te9 = te(30, 64, 30, 74, "");
+            CodeAction ca7 = ca(uri, "Remove @Produces", d4, te7);
+            CodeAction ca8 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d4, te8);
+            CodeAction ca9 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d4, te9);
 
-        TextEdit te13 = te(41, 4, 42, 4, "");
-        TextEdit te14 = te(42, 45, 42, 55, "");
-        TextEdit te15 = te(42, 69, 42, 84, "");
-        CodeAction ca13 = ca(uri, "Remove @Produces", d6, te13);
-        CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
-        CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+            assertJavaCodeAction(codeActionParams4, utils, ca7, ca8, ca9);
 
-        assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
-        
-        JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+            JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
 
-        TextEdit te16 = te(47, 4, 48, 4, "");
-        TextEdit te17 = te(48, 53, 48, 63, "");
-        TextEdit te18 = te(48, 77, 48, 87, "");
-        TextEdit te19 = te(48, 101, 48, 116, "");
-        CodeAction ca16 = ca(uri, "Remove @Produces", d7, te16);
-        CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
-        CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
-        CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+            TextEdit te10 = te(35, 4, 36, 4, "");
+            TextEdit te11 = te(36, 45, 36, 55, "");
+            TextEdit te12 = te(36, 69, 36, 84, "");
+            CodeAction ca10 = ca(uri, "Remove @Produces", d5, te10);
+            CodeAction ca11 = ca(uri, "Remove the '@Observes' modifier from parameter 'name1'", d5, te11);
+            CodeAction ca12 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d5, te12);
 
-        assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
-        
-        JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+            assertJavaCodeAction(codeActionParams5, utils, ca10, ca11, ca12);
 
-        TextEdit te20 = te(53, 4, 54, 4, "");
-        TextEdit te21 = te(54, 54, 54, 89, "");
-        CodeAction ca20 = ca(uri, "Remove @Produces", d8, te20);
-        CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+            JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d6);
 
-        assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
-        
+            TextEdit te13 = te(41, 4, 42, 4, "");
+            TextEdit te14 = te(42, 45, 42, 55, "");
+            TextEdit te15 = te(42, 69, 42, 84, "");
+            CodeAction ca13 = ca(uri, "Remove @Produces", d6, te13);
+            CodeAction ca14 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d6, te14);
+            CodeAction ca15 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d6, te15);
+
+            assertJavaCodeAction(codeActionParams6, utils, ca13, ca14, ca15);
+
+            JakartaJavaCodeActionParams codeActionParams7 = createCodeActionParams(uri, d7);
+
+            TextEdit te16 = te(47, 4, 48, 4, "");
+            TextEdit te17 = te(48, 53, 48, 63, "");
+            TextEdit te18 = te(48, 77, 48, 87, "");
+            TextEdit te19 = te(48, 101, 48, 116, "");
+            CodeAction ca16 = ca(uri, "Remove @Produces", d7, te16);
+            CodeAction ca17 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d7, te17);
+            CodeAction ca18 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d7, te18);
+            CodeAction ca19 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d7, te19);
+
+            assertJavaCodeAction(codeActionParams7, utils, ca16, ca17, ca18, ca19);
+
+            JakartaJavaCodeActionParams codeActionParams8 = createCodeActionParams(uri, d8);
+
+            TextEdit te20 = te(53, 4, 54, 4, "");
+            TextEdit te21 = te(54, 54, 54, 89, "");
+            CodeAction ca20 = ca(uri, "Remove @Produces", d8, te20);
+            CodeAction ca21 = ca(uri, "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d8, te21);
+
+            assertJavaCodeAction(codeActionParams8, utils, ca20, ca21);
+        }
     }
     
     @Test

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -42,7 +42,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class ManagedBeanTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void managedBeanAnnotations() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -81,7 +80,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
     }
     
     @Test
-    @Ignore
     public void scopeDeclaration() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -140,7 +138,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore
     public void producesAndInject() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -182,7 +179,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore
     public void injectAndDisposesObservesObservesAsync() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -314,7 +310,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore
     public void producesAndDisposesObservesObservesAsync() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -359,19 +354,19 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
         
         Diagnostic d9 = d(30, 18, 39,
-                "A disposer method cannot have parameter(s) annotated with @Observes",
+                "A disposer method cannot have parameter(s) annotated with @jakarta.enterprise.event.Observes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
         
         Diagnostic d10 = d(42, 18, 44,
-                "A disposer method cannot have parameter(s) annotated with @ObservesAsync",
+                "A disposer method cannot have parameter(s) annotated with @jakarta.enterprise.event.ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
         
         Diagnostic d11 = d(48, 18, 52,
-                "A disposer method cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                "A disposer method cannot have parameter(s) annotated with @jakarta.enterprise.event.Observes, @jakarta.enterprise.event.ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
         
         Diagnostic d12 = d(54, 18, 53,
-                "A disposer method cannot have parameter(s) annotated with @Observes, @ObservesAsync",
+                "A disposer method cannot have parameter(s) annotated with @jakarta.enterprise.event.Observes, @jakarta.enterprise.event.ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveDisposesOrConflictedAnnotations");
         
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
  */
 public abstract class BaseJakartaTest extends MavenImportingTestCase {
 
+    protected static final boolean CHECK_CODE_ACTIONS = false;
+
     protected TestFixtureBuilder<IdeaProjectTestFixture> myProjectBuilder;
 
     @Override

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
@@ -77,57 +77,58 @@ public class DependencyInjectionTest extends BaseJakartaTest {
         
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
-        
-        
-        /* create expected quickFixes
-         * 
-         */
-        
-        // for d1
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-        TextEdit te = JakartaForJavaAssert.te(16, 4, 17, 4,
-                "");
-        CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
-        TextEdit te1 = JakartaForJavaAssert.te(17, 11, 17, 17,
-                "");
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this field", d1, te1);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
-        
-        // for d2
-        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d2);
-        te = JakartaForJavaAssert.te(32, 4, 33, 4,
-                "");
-        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d2, te);
-        te1 = JakartaForJavaAssert.te(33, 10, 33, 19,
-                "");
-        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", d2, te1);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
-        
-        // for d3
-        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d3);
-        te = JakartaForJavaAssert.te(25, 4, 26, 4,
-                "");
-        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te);
-        te1 = JakartaForJavaAssert.te(26, 10, 26, 16,
-                "");
-        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", d3, te1);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
-        
-        // for d4
-        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d4);
-        te = JakartaForJavaAssert.te(42, 4, 43, 4,
-                "");
-        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d4, te);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
-        
-        // for d5
-        codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d5);
-        te = JakartaForJavaAssert.te(36, 4, 37, 4,
-                "");
-        ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d5, te);
-        te1 = JakartaForJavaAssert.te(37, 10, 37, 17,
-                "");
-        ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", d5, te1);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+
+        if (CHECK_CODE_ACTIONS) {
+            /* create expected quickFixes
+             *
+             */
+
+            // for d1
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+            TextEdit te = JakartaForJavaAssert.te(16, 4, 17, 4,
+                    "");
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
+            TextEdit te1 = JakartaForJavaAssert.te(17, 11, 17, 17,
+                    "");
+            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this field", d1, te1);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+
+            // for d2
+            codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+            te = JakartaForJavaAssert.te(32, 4, 33, 4,
+                    "");
+            ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d2, te);
+            te1 = JakartaForJavaAssert.te(33, 10, 33, 19,
+                    "");
+            ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", d2, te1);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+
+            // for d3
+            codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+            te = JakartaForJavaAssert.te(25, 4, 26, 4,
+                    "");
+            ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te);
+            te1 = JakartaForJavaAssert.te(26, 10, 26, 16,
+                    "");
+            ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", d3, te1);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+
+            // for d4
+            codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d4);
+            te = JakartaForJavaAssert.te(42, 4, 43, 4,
+                    "");
+            ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d4, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+
+            // for d5
+            codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d5);
+            te = JakartaForJavaAssert.te(36, 4, 37, 4,
+                    "");
+            ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d5, te);
+            te1 = JakartaForJavaAssert.te(37, 10, 37, 17,
+                    "");
+            ca1 = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", d5, te1);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca, ca1);
+        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 public class DependencyInjectionTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void DependencyInjectionDiagnostics() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -57,23 +56,23 @@ public class DependencyInjectionTest extends BaseJakartaTest {
          */
         Diagnostic d1 = JakartaForJavaAssert.d(17, 27, 35, "The @Inject annotation must not define a final field.",
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrFinal");
-        d1.setData("field");
+        d1.setData("io.openliberty.sample.jakarta.di.Greeting");
 
         Diagnostic d2 = JakartaForJavaAssert.d(33, 25, 39, "The @Inject annotation must not define an abstract method.",
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrAbstract");
-        d2.setData("method");
+        d2.setData("void");
         
         Diagnostic d3 = JakartaForJavaAssert.d(26, 22, 33, "The @Inject annotation must not define a final method.",
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrFinal");
-        d3.setData("method");
+        d3.setData("void");
  
         Diagnostic d4 = JakartaForJavaAssert.d(43, 23, 36, "The @Inject annotation must not define a generic method.",
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectForGeneric");
-        d4.setData("method");
+        d4.setData("java.util.List<T>");
         
         Diagnostic d5 = JakartaForJavaAssert.d(37, 23, 35, "The @Inject annotation must not define a static method.",
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInjectOrStatic");
-        d5.setData("method");
+        d5.setData("void");
         
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
@@ -67,19 +67,19 @@ public class MultipleConstructorInjectTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInject");
         
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1,d2,d3);
-       
-        // test expected quick-fix
-        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-        TextEdit te = JakartaForJavaAssert.te(21, 4, 22, 4,"");
-        CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca);
-        
-        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
-        TextEdit te2 = JakartaForJavaAssert.te(30, 4, 31, 4,"");
-        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te2);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
-        
-        
+
+        if (CHECK_CODE_ACTIONS) {
+            // test expected quick-fix
+            JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+            TextEdit te = JakartaForJavaAssert.te(21, 4, 22, 4, "");
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca);
+
+            JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+            TextEdit te2 = JakartaForJavaAssert.te(30, 4, 31, 4, "");
+            CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te2);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
+        }
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 public class MultipleConstructorInjectTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void multipleInject() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -57,12 +57,14 @@ public class ResourceMethodTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-jax_rs", "NonPublicResourceMethod");
         
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
-        
-        // Test for quick-fix code action
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
-        TextEdit te = JakartaForJavaAssert.te(20, 4, 20, 11, "public"); // range may need to change
-        CodeAction ca = JakartaForJavaAssert.ca(uri, "Make method public", d, te);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+
+        if (CHECK_CODE_ACTIONS) {
+            // Test for quick-fix code action
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+            TextEdit te = JakartaForJavaAssert.te(20, 4, 20, 11, "public"); // range may need to change
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Make method public", d, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        }
     }
 
     @Test
@@ -84,17 +86,18 @@ public class ResourceMethodTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
+        if (CHECK_CODE_ACTIONS) {
+            // Test for quick-fix code action
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
 
-        // Test for quick-fix code action
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+            TextEdit te1 = JakartaForJavaAssert.te(21, 112, 21, 130, "");
+            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam1", d, te1);
 
-        TextEdit te1 = JakartaForJavaAssert.te(21, 112, 21, 130, "");
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam1", d, te1);
+            TextEdit te2 = JakartaForJavaAssert.te(21, 47, 21, 68, "");
+            CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d, te2);
 
-        TextEdit te2 = JakartaForJavaAssert.te(21, 47, 21, 68, "");
-        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d, te2);
-
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+        }
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 public class ResourceMethodTest extends BaseJakartaTest {
     
     @Test
-    @Ignore
     public void NonPublicMethod() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -68,7 +67,6 @@ public class ResourceMethodTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore
     public void multipleEntityParamsMethod() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -63,18 +63,20 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
-        // test code actions
-        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-        TextEdit te1 = JakartaForJavaAssert.te(17, 4, 18, 4, "");
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d1, te1);
-        
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
+        if (CHECK_CODE_ACTIONS) {
+            // test code actions
+            JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+            TextEdit te1 = JakartaForJavaAssert.te(17, 4, 18, 4, "");
+            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d1, te1);
 
-        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
-        TextEdit te2 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
-        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d2, te2);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
 
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
+            JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+            TextEdit te2 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
+            CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @JsonbCreator", d2, te2);
+
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
+        }
     }
     
     @Test
@@ -140,40 +142,41 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
   
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
 
+        if (CHECK_CODE_ACTIONS) {
+            // Test code actions
+            // Quick fix for the field "id"
+            JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+            TextEdit te1 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
+            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d1, te1);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
 
-        // Test code actions
-        // Quick fix for the field "id"
-        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-        TextEdit te1 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d1, te1);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
-        
-        // Quick fix for the field "name"
-        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
-        TextEdit te3 = JakartaForJavaAssert.te(24, 4, 25, 4, "");
-        TextEdit te4 = JakartaForJavaAssert.te(23, 4, 24, 4, "");
-        CodeAction ca3 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d2, te3);
-        CodeAction ca4 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d2, te4);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
-       
-        // Quick fix for the field "favoriteLanguage"
-        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
-        TextEdit te5 = JakartaForJavaAssert.te(29, 4, 30, 4, "");
-        TextEdit te6 = JakartaForJavaAssert.te(27, 4, 29, 4, "");
-        CodeAction ca5 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d3, te5);
-        CodeAction ca6 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty, @JsonbAnnotation", d3, te6);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
-        
-        // Quick fix for the accessor "getId"
-        JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, d5);
-        TextEdit te7 = JakartaForJavaAssert.te(41, 4, 42, 4, "");
-        CodeAction ca7 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d5, te7);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, ca7);
+            // Quick fix for the field "name"
+            JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+            TextEdit te3 = JakartaForJavaAssert.te(24, 4, 25, 4, "");
+            TextEdit te4 = JakartaForJavaAssert.te(23, 4, 24, 4, "");
+            CodeAction ca3 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d2, te3);
+            CodeAction ca4 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d2, te4);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
 
-        // Quick fix for the accessor "setId"
-        JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, d6);
-        TextEdit te8 = JakartaForJavaAssert.te(48, 4, 49, 4, "");
-        CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
+            // Quick fix for the field "favoriteLanguage"
+            JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+            TextEdit te5 = JakartaForJavaAssert.te(29, 4, 30, 4, "");
+            TextEdit te6 = JakartaForJavaAssert.te(27, 4, 29, 4, "");
+            CodeAction ca5 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d3, te5);
+            CodeAction ca6 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty, @JsonbAnnotation", d3, te6);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+
+            // Quick fix for the accessor "getId"
+            JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, d5);
+            TextEdit te7 = JakartaForJavaAssert.te(41, 4, 42, 4, "");
+            CodeAction ca7 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d5, te7);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, ca7);
+
+            // Quick fix for the accessor "setId"
+            JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, d6);
+            TextEdit te8 = JakartaForJavaAssert.te(48, 4, 49, 4, "");
+            CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
+        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void deleteExtraJsonbCreatorAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -80,13 +79,12 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
     }
     
     @Test
-    @Ignore
     public void JsonbTransientNotMutuallyExclusive() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
 
         VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
-                + "src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java");
+                + "/src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 public class JakartaJsonpTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void invalidPointerTarget() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
@@ -40,7 +40,6 @@ import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAs
 public class JakartaPersistenceTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void deleteMapKeyOrMapKeyClass() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -83,9 +82,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
         }
     }
 
-    
     @Test
-    @Ignore
     public void completeMapKeyJoinColumnAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -116,30 +113,31 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
                 "A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.",
                 DiagnosticSeverity.Error, "jakarta-persistence", "SupplyAttributesToAnnotations");
         
-        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5); 
-        
-        // test quick fixes
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        TextEdit te1 = te(10, 4, 11, 23,  "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")");
-        CodeAction ca1 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d1, te1);
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1);
-        
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d3);
-        TextEdit te2 = te(14, 4, 15, 52,  "@MapKeyJoinColumn(referencedColumnName = \"rcn2\", name = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"\")");
-        CodeAction ca2 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d3, te2);
+        if (CHECK_CODE_ACTIONS) {
+            // test quick fixes
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+            TextEdit te1 = te(10, 4, 11, 23, "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")");
+            CodeAction ca1 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d1, te1);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca2);
-        
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d5);
-        TextEdit te3 = te(18, 4, 19, 23,  "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"rcn1\")");
-        CodeAction ca3 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d5, te3);
+            assertJavaCodeAction(codeActionParams1, utils, ca1);
 
-        assertJavaCodeAction(codeActionParams3, utils, ca3);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d3);
+            TextEdit te2 = te(14, 4, 15, 52, "@MapKeyJoinColumn(referencedColumnName = \"rcn2\", name = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"\")");
+            CodeAction ca2 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d3, te2);
+
+            assertJavaCodeAction(codeActionParams2, utils, ca2);
+
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d5);
+            TextEdit te3 = te(18, 4, 19, 23, "@MapKeyJoinColumn(name = \"\", referencedColumnName = \"\")\n\t@MapKeyJoinColumn(name = \"n1\", referencedColumnName = \"rcn1\")");
+            CodeAction ca3 = ca(uri, "Add the missing attributes to the @MapKeyJoinColumn annotation", d5, te3);
+
+            assertJavaCodeAction(codeActionParams3, utils, ca3);
+        }
     }
 
     @Test
-    @Ignore
     public void addEmptyConstructor() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -158,18 +156,19 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        // test quick fixes
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
-        TextEdit te1 = te(7, 4, 7, 4,  "protected EntityMissingConstructor() {\n\t}\n\n\t");
-        CodeAction ca1 = ca(uri, "Add a no-arg protected constructor to this class", d, te1);
-        TextEdit te2 = te(7, 4, 7, 4,  "public EntityMissingConstructor() {\n\t}\n\n\t");
-        CodeAction ca2 = ca(uri, "Add a no-arg public constructor to this class", d, te2);
+        if (CHECK_CODE_ACTIONS) {
+            // test quick fixes
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
+            TextEdit te1 = te(7, 4, 7, 4, "protected EntityMissingConstructor() {\n\t}\n\n\t");
+            CodeAction ca1 = ca(uri, "Add a no-arg protected constructor to this class", d, te1);
+            TextEdit te2 = te(7, 4, 7, 4, "public EntityMissingConstructor() {\n\t}\n\n\t");
+            CodeAction ca2 = ca(uri, "Add a no-arg public constructor to this class", d, te2);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        }
     }
 
     @Test
-    @Ignore
     public void removeFinalModifiers() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -185,59 +184,61 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
         Diagnostic d1 = d(10, 21, 28,
                 "A class using the @Entity annotation cannot contain any methods that are declared final",
                 DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalMethods");
-        d1.setData("method");
+        d1.setData("int");
 
         Diagnostic d2 = d(7, 14, 15,
                 "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
                 DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
-        d2.setData("field");
+        d2.setData("int");
 
         Diagnostic d3 = d(8, 17, 18,
                 "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
                 DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
-        d3.setData("field");
+        d3.setData("java.lang.String");
 
         Diagnostic d4 = d(8, 30, 31,
                 "A class using the @Entity annotation cannot contain any persistent instance variables that are declared final",
                 DiagnosticSeverity.Error, "jakarta-persistence", "RemoveFinalVariables");
-        d4.setData("field");
+        d4.setData("java.lang.String");
 
         Diagnostic d5 = d(5, 19, 33,
                 "A class using the @Entity annotation must not be final.",
                 DiagnosticSeverity.Error, "jakarta-persistence", "InvalidClass");
-        d5.setData("type");
+        d5.setData("io.openliberty.sample.jakarta.persistence.FinalModifiers");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
 
-        // test quick fixes
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        TextEdit te1 = te(10, 10, 10, 16, "");
-        CodeAction ca1 = ca(uri,  "Remove the 'final' modifier from this method", d1, te1);
+        if (CHECK_CODE_ACTIONS) {
+            // test quick fixes
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+            TextEdit te1 = te(10, 10, 10, 16, "");
+            CodeAction ca1 = ca(uri, "Remove the 'final' modifier from this method", d1, te1);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1);
+            assertJavaCodeAction(codeActionParams1, utils, ca1);
 
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-        TextEdit te2 = te(7, 4, 7, 10, "");
-        CodeAction ca2 = ca(uri,  "Remove the 'final' modifier from this field", d2, te2);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            TextEdit te2 = te(7, 4, 7, 10, "");
+            CodeAction ca2 = ca(uri, "Remove the 'final' modifier from this field", d2, te2);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca2);
+            assertJavaCodeAction(codeActionParams2, utils, ca2);
 
-        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
-        TextEdit te3 = te(8, 4, 8, 10, "");
-        CodeAction ca3 = ca(uri,  "Remove the 'final' modifier from this field", d3, te3);
+            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+            TextEdit te3 = te(8, 4, 8, 10, "");
+            CodeAction ca3 = ca(uri, "Remove the 'final' modifier from this field", d3, te3);
 
-        assertJavaCodeAction(codeActionParams3, utils, ca3);
+            assertJavaCodeAction(codeActionParams3, utils, ca3);
 
-        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
-        TextEdit te4 = te(8, 4, 8, 10, "");
-        CodeAction ca4 = ca(uri,  "Remove the 'final' modifier from this field", d4, te4);
+            JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d4);
+            TextEdit te4 = te(8, 4, 8, 10, "");
+            CodeAction ca4 = ca(uri, "Remove the 'final' modifier from this field", d4, te4);
 
-        assertJavaCodeAction(codeActionParams4, utils, ca4);
+            assertJavaCodeAction(codeActionParams4, utils, ca4);
 
-        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
-        TextEdit te5 = te(5, 6, 5, 12, "");
-        CodeAction ca5 = ca(uri, "Remove the 'final' modifier from this class", d5, te5);
+            JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d5);
+            TextEdit te5 = te(5, 6, 5, 12, "");
+            CodeAction ca5 = ca(uri, "Remove the 'final' modifier from this class", d5, te5);
 
-        assertJavaCodeAction(codeActionParams5, utils, ca5);
+            assertJavaCodeAction(codeActionParams5, utils, ca5);
+        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
@@ -62,23 +62,25 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
-        TextEdit te1 = te(15, 4, 16, 4, "");
-        TextEdit te2 = te(14, 4, 15, 4, "");
-        CodeAction ca1 = ca(uri, "Remove @MapKeyClass", d1, te1);
-        CodeAction ca2 = ca(uri, "Remove @MapKey", d1, te2);
+            TextEdit te1 = te(15, 4, 16, 4, "");
+            TextEdit te2 = te(14, 4, 15, 4, "");
+            CodeAction ca1 = ca(uri, "Remove @MapKeyClass", d1, te1);
+            CodeAction ca2 = ca(uri, "Remove @MapKey", d1, te2);
 
-        assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
 
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
-        TextEdit te3 = te(9, 13, 10, 27, "");
-        TextEdit te4 = te(9, 4, 10, 4, "");
-        CodeAction ca3 = ca(uri, "Remove @MapKeyClass", d2, te3);
-        CodeAction ca4 = ca(uri, "Remove @MapKey", d2, te4);
+            TextEdit te3 = te(9, 13, 10, 27, "");
+            TextEdit te4 = te(9, 4, 10, 4, "");
+            CodeAction ca3 = ca(uri, "Remove @MapKeyClass", d2, te3);
+            CodeAction ca4 = ca(uri, "Remove @MapKey", d2, te4);
 
-        assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        }
     }
 
     

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 public class JakartaServletTest extends BaseJakartaTest {
 
     @Test
-    @Ignore // getAllSuperTypes() returns nothing for tests. See #232
     public void ExtendWebServlet() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -54,7 +53,7 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         // expected
         Diagnostic d = JakartaForJavaAssert.d(5, 13, 34, "Annotated classes with @WebServlet must extend the HttpServlet class.",
-                DiagnosticSeverity.Warning, "jakarta-servlet", "ExtendHttpServlet");
+                DiagnosticSeverity.Error, "jakarta-servlet", "ExtendHttpServlet");
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
@@ -68,7 +67,6 @@ public class JakartaServletTest extends BaseJakartaTest {
     }
 
     @Test
-    @Ignore // getAllSuperTypes() returns nothing for tests. See #232
     public void CompleteWebServletAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
@@ -81,7 +79,7 @@ public class JakartaServletTest extends BaseJakartaTest {
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d = JakartaForJavaAssert.d(9, 0, 13,
-                "The annotation @WebServlet must define the attribute urlPatterns or the attribute value.",
+                "The @WebServlet annotation must define the attribute 'urlPatterns' or 'value'.",
                 DiagnosticSeverity.Error, "jakarta-servlet", "CompleteHttpServletAttributes");
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -58,11 +58,13 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        // test associated quick-fix code action
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
-        TextEdit te = JakartaForJavaAssert.te(5, 34, 5, 34, " extends HttpServlet");
-        CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontExtendHttpServlet' extend 'HttpServlet'", d, te);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        if (CHECK_CODE_ACTIONS) {
+            // test associated quick-fix code action
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+            TextEdit te = JakartaForJavaAssert.te(5, 34, 5, 34, " extends HttpServlet");
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontExtendHttpServlet' extend 'HttpServlet'", d, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        }
     }
 
     @Test
@@ -84,13 +86,15 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
-        TextEdit te1 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(value = \"\")\n");
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Add the `value` attribute to @WebServlet", d, te1);
+        if (CHECK_CODE_ACTIONS) {
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+            TextEdit te1 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(value = \"\")\n");
+            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Add the `value` attribute to @WebServlet", d, te1);
 
-        TextEdit te2 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(urlPatterns = \"\")\n");
-        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Add the `urlPatterns` attribute to @WebServlet", d, te2);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+            TextEdit te2 = JakartaForJavaAssert.te(9, 0, 10, 0, "@WebServlet(urlPatterns = \"\")\n");
+            CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Add the `urlPatterns` attribute to @WebServlet", d, te2);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
+        }
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -70,15 +70,17 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         );
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
-        
-        // Expected code actions
-        JakartaJavaCodeActionParams codeActionsParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-        String newText = "\nimport jakarta.websocket.server.PathParam;\nimport jakarta.websocket.server.ServerEndpoint;\nimport jakarta.websocket.Session;\n\n" 
-                        + "/**\n * Expected Diagnostics are related to validating that the parameters have the \n * valid annotation @PathParam (code: AddPathParamsAnnotation)\n * See issue #247 (onOpen) and #248 (onClose)\n */\n" 
-                        + "@ServerEndpoint(value = \"/infos\")\npublic class AnnotationTest {\n    // @PathParam missing annotation for \"String missingAnnotation\"\n    @OnOpen\n    public void OnOpen(Session session, @PathParam(value = \"\") ";
-        TextEdit te = JakartaForJavaAssert.te(5, 32, 18, 40, newText);
-        CodeAction ca = JakartaForJavaAssert.ca(uri, "Insert @jakarta.websocket.server.PathParam", d1, te);
-        JakartaForJavaAssert.assertJavaCodeAction(codeActionsParams, utils, ca);
+
+        if (CHECK_CODE_ACTIONS) {
+            // Expected code actions
+            JakartaJavaCodeActionParams codeActionsParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+            String newText = "\nimport jakarta.websocket.server.PathParam;\nimport jakarta.websocket.server.ServerEndpoint;\nimport jakarta.websocket.Session;\n\n"
+                    + "/**\n * Expected Diagnostics are related to validating that the parameters have the \n * valid annotation @PathParam (code: AddPathParamsAnnotation)\n * See issue #247 (onOpen) and #248 (onClose)\n */\n"
+                    + "@ServerEndpoint(value = \"/infos\")\npublic class AnnotationTest {\n    // @PathParam missing annotation for \"String missingAnnotation\"\n    @OnOpen\n    public void OnOpen(Session session, @PathParam(value = \"\") ";
+            TextEdit te = JakartaForJavaAssert.te(5, 32, 18, 40, newText);
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Insert @jakarta.websocket.server.PathParam", d1, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionsParams, utils, ca);
+        }
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 public class JakartaWebSocketTest extends BaseJakartaTest {
 
     @Test
-    @Ignore
     public void addPathParamsAnnotation() throws Exception {
         Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
         IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/379.

This PR enables the remaining Jakarta diagnostic tests. Added guards around checks for code actions since Jakarta quick fixes are not enabled yet. Work to enable the testing of code actions can be done with the activation of the quick fixes.