### PR TITLE
Fixes 321

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/RemoveLibertyProjectAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RemoveLibertyProjectAction.java
@@ -45,8 +45,7 @@ public class RemoveLibertyProjectAction extends LibertyProjectAction {
 
     @Override
     protected void executeLibertyAction(LibertyModule libertyModule) {
-        Project project = libertyModule.getProject();
-        String projectName = project.getName();
+        String projectName = libertyModule.getName();
         final int result = Messages.showYesNoDialog(
                 LocalizedResourceUtil.getMessage("liberty.project.remove.confirmation.dialog.message", projectName),
                 getChooseDialogTitle(),


### PR DESCRIPTION
Fixes #321
Fixed the issue of showing the wrong project name for the 'remove project' dialog message.