### PR TITLE
Enable container tests for Gradle test runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, ls-integration, test-automation ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,6 @@ dependencies {
     testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
 
-    // Test: Logging Network Calls.
-    testImplementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
-
     // Test: Video Recording.
     testImplementation 'com.automation-remarks:video-recorder-junit5:2.0'
 
@@ -144,10 +141,10 @@ runIdeForUiTests {
     systemProperty "robot-server.port", "8082"
     systemProperty "ide.mac.message.dialogs.as.sheets", "false"
     systemProperty "jb.privacy.policy.text", "<!--999.999-->"
+    systemProperty "jb.consents.confirmation.enabled", "false"
     systemProperty "idea.trust.all.projects", "true"
     systemProperty "ide.show.tips.on.startup.default.value", "false"
     systemProperty "ide.mac.file.chooser.native", "false"
-    systemProperty "jb.consents.confirmation.enabled", "false"
     systemProperty "jbScreenMenuBar.enabled", "false"
     systemProperty "apple.laf.useScreenMenuBar", "false"
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
@@ -24,7 +24,7 @@ public class GradleSingleModMPProjectTest extends SingleModMPProjectTestCommon {
      * Single module Microprofile project name.
      */
     private static final String SM_MP_PROJECT_NAME = "singleModGradleMP";
-    
+
     /**
      * The path to the folder containing the test projects.
      */
@@ -33,7 +33,7 @@ public class GradleSingleModMPProjectTest extends SingleModMPProjectTestCommon {
     /**
      * Project port.
      */
-    private final int SM_MP_PROJECT_PORT = 9090;
+    private final int SM_MP_PROJECT_PORT = 9080;
 
     /**
      * Project resource URI.

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
@@ -9,14 +9,10 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.it;
 
-import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.stepsProcessing.StepLogger;
 import com.intellij.remoterobot.stepsProcessing.StepWorker;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -201,140 +197,5 @@ public class MavenSingleModMPProjectTest extends SingleModMPProjectTestCommon {
     public void validateTestReportsExist() {
         TestUtils.validateTestReportExists(pathToITReport);
         TestUtils.validateTestReportExists(pathToUTReport);
-    }
-
-    /**
-     * Tests dashboard startInContainer/stop actions run from the project's drop-down action menu.
-     * Notes:
-     * 1, Once issue <a href="https://github.com/OpenLiberty/liberty-tools-intellij/issues/299">...</a> is resolved,
-     * this method should be moved to SingleModProjectTestCommon.
-     * 2. This test is restricted to Linux only because, on other platforms, the docker build process
-     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
-     * timeout set by the plugins and there is currently no way to extend this timeout through the
-     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
-     */
-    @Test
-    @Video
-    @EnabledOnOs({OS.LINUX})
-    public void testStartInContainerActionUsingDropDownMenu() {
-        String testName = "testStartInContainerActionUsingDropDownMenu";
-        String absoluteWLPPath = Paths.get(PROJECTS_PATH, SM_MP_PROJECT_NAME, WLP_INSTALL_PATH).toString();
-
-        // Start dev mode in a container.
-        UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Start in container", false, 3);
-        try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, SM_MP_PROJECT_RES_URI, SM_MP_PROJECT_PORT, SM_MP_PROJECT_OUTPUT, absoluteWLPPath, true);
-        } finally {
-            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
-                // Stop dev mode.
-                UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", false, 3);
-
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
-            }
-        }
-    }
-
-    /**
-     * Tests dashboard startInContainer/stop actions run from the project's drop-down action menu
-     * and the Liberty tool window toolbar play button.
-     * Notes:
-     * 1, Once issue <a href="https://github.com/OpenLiberty/liberty-tools-intellij/issues/299">...</a> is resolved,
-     * this method should be moved to SingleModProjectTestCommon.
-     * 2. This test is restricted to Linux only because, on other platforms, the docker build process
-     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
-     * timeout set by the plugins and there is currently no way to extend this timeout through the
-     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
-     */
-    @Test
-    @Video
-    @EnabledOnOs({OS.LINUX})
-    public void testStartInContainerActionUsingPlayToolbarButton() {
-        String testName = "testStartInContainerActionUsingPlayToolbarButton";
-        String absoluteWLPPath = Paths.get(PROJECTS_PATH, SM_MP_PROJECT_NAME, WLP_INSTALL_PATH).toString();
-
-        // Start dev mode in a container.
-        UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Start in container", true, 3);
-        try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, SM_MP_PROJECT_RES_URI, SM_MP_PROJECT_PORT, SM_MP_PROJECT_OUTPUT, absoluteWLPPath, true);
-        } finally {
-            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
-                // Stop dev mode.
-                UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", true, 3);
-
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
-            }
-        }
-    }
-
-    /**
-     * Tests dashboard startInContainer/stop actions run from the project's pop-up action menu.
-     * Notes:
-     * 1, Once issue <a href="https://github.com/OpenLiberty/liberty-tools-intellij/issues/299">...</a> is resolved,
-     * this method should be moved to SingleModProjectTestCommon.
-     * 2. This test is restricted to Linux only because, on other platforms, the docker build process
-     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
-     * timeout set by the plugins and there is currently no way to extend this timeout through the
-     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
-     */
-    @Test
-    @Video
-    @EnabledOnOs({OS.LINUX})
-    public void testStartInContainerActionUsingPopUpMenu() {
-        String testName = "testStartInContainerActionUsingPopUpMenu";
-        String absoluteWLPPath = Paths.get(PROJECTS_PATH, SM_MP_PROJECT_NAME, WLP_INSTALL_PATH).toString();
-
-        // Start dev mode in a container.
-        UIBotTestUtils.runActionLTWPopupMenu(remoteRobot, SM_MP_PROJECT_NAME, "Liberty: Start in container", 3);
-
-        try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, SM_MP_PROJECT_RES_URI, SM_MP_PROJECT_PORT, SM_MP_PROJECT_OUTPUT, absoluteWLPPath, true);
-        } finally {
-            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
-                // Stop dev mode.
-                UIBotTestUtils.runActionLTWPopupMenu(remoteRobot, SM_MP_PROJECT_NAME, "Liberty: Stop", 3);
-
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
-            }
-        }
-    }
-
-    /**
-     * Tests dashboard startInContainer/stop actions run from the search everywhere panel.
-     * Notes:
-     * 1, Once issue <a href="https://github.com/OpenLiberty/liberty-tools-intellij/issues/299">...</a> is resolved,
-     * this method should be moved to SingleModProjectTestCommon.
-     * 2. This test is restricted to Linux only because, on other platforms, the docker build process
-     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
-     * timeout set by the plugins and there is currently no way to extend this timeout through the
-     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
-     */
-    @Test
-    @Video
-    @EnabledOnOs({OS.LINUX})
-    public void testStartInContainerActionUsingSearch() {
-        String testName = "testStartInContainerActionUsingSearch";
-        String absoluteWLPPath = Paths.get(PROJECTS_PATH, SM_MP_PROJECT_NAME, WLP_INSTALL_PATH).toString();
-
-        // Start dev mode in a container.
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Start in container", 3);
-
-        try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, SM_MP_PROJECT_RES_URI, SM_MP_PROJECT_PORT, SM_MP_PROJECT_OUTPUT, absoluteWLPPath, true);
-        } finally {
-            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
-                // Stop dev mode.
-                UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Stop", 3);
-
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
-            }
-        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -13,6 +13,8 @@ import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.RemoteRobot;
 import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -757,6 +759,133 @@ public abstract class SingleModMPProjectTestCommon {
         } finally {
             // clean up the created configurations.
             UIBotTestUtils.deleteLibertyRunConfigurations(remoteRobot);
+        }
+    }
+
+    /**
+     * Tests dashboard startInContainer/stop actions run from the project's drop-down action menu.
+     * Notes:
+     * 1. This test is restricted to Linux only because, on other platforms, the docker build process
+     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
+     * timeout set by the plugins and there is currently no way to extend this timeout through the
+     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
+     */
+    @Test
+    @Video
+    @EnabledOnOs({OS.LINUX})
+    public void testStartInContainerActionUsingDropDownMenu() {
+        String testName = "testStartInContainerActionUsingDropDownMenu";
+        String absoluteWLPPath = Paths.get(getProjectsDirPath(), getSmMPProjectName(), getWLPInstallPath()).toString();
+
+        // Start dev mode in a container.
+        UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Start in container", false, 3);
+        try {
+            // Validate that the project started.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+        } finally {
+            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
+                // Stop dev mode.
+                UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", false, 3);
+
+                // Validate that the server stopped.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+            }
+        }
+    }
+
+    /**
+     * Tests dashboard startInContainer/stop actions run from the project's drop-down action menu
+     * and the Liberty tool window toolbar play button.
+     * Notes:
+     * 1. This test is restricted to Linux only because, on other platforms, the docker build process
+     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
+     * timeout set by the plugins and there is currently no way to extend this timeout through the
+     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
+     */
+    @Test
+    @Video
+    @EnabledOnOs({OS.LINUX})
+    public void testStartInContainerActionUsingPlayToolbarButton() {
+        String testName = "testStartInContainerActionUsingPlayToolbarButton";
+        String absoluteWLPPath = Paths.get(getProjectsDirPath(), getSmMPProjectName(), getBuildFileName()).toString();
+
+        // Start dev mode in a container.
+        UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Start in container", true, 3);
+        try {
+            // Validate that the project started.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+        } finally {
+            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
+                // Stop dev mode.
+                UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", true, 3);
+
+                // Validate that the server stopped.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+            }
+        }
+    }
+
+    /**
+     * Tests dashboard startInContainer/stop actions run from the project's pop-up action menu.
+     * Notes:
+     * 1. This test is restricted to Linux only because, on other platforms, the docker build process
+     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
+     * timeout set by the plugins and there is currently no way to extend this timeout through the
+     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
+     */
+    @Test
+    @Video
+    @EnabledOnOs({OS.LINUX})
+    public void testStartInContainerActionUsingPopUpMenu() {
+        String testName = "testStartInContainerActionUsingPopUpMenu";
+        String absoluteWLPPath = Paths.get(getProjectsDirPath(), getSmMPProjectName(), getWLPInstallPath()).toString();
+
+        // Start dev mode in a container.
+        UIBotTestUtils.runActionLTWPopupMenu(remoteRobot, getSmMPProjectName(), "Liberty: Start in container", 3);
+
+        try {
+            // Validate that the project started.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+        } finally {
+            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
+                // Stop dev mode.
+                UIBotTestUtils.runActionLTWPopupMenu(remoteRobot, getSmMPProjectName(), "Liberty: Stop", 3);
+
+                // Validate that the server stopped.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+            }
+        }
+    }
+
+    /**
+     * Tests dashboard startInContainer/stop actions run from the search everywhere panel.
+     * Notes:
+     * 1. This test is restricted to Linux only because, on other platforms, the docker build process
+     * driven by the Liberty Maven/Gradle plugins take longer than ten minutes. Ten minutes is the
+     * timeout set by the plugins and there is currently no way to extend this timeout through the
+     * Liberty Tools plugin(i.e. set dockerBuildTimeout).
+     */
+    @Test
+    @Video
+    @EnabledOnOs({OS.LINUX})
+    public void testStartInContainerActionUsingSearch() {
+        String testName = "testStartInContainerActionUsingSearch";
+        String absoluteWLPPath = Paths.get(getProjectsDirPath(), getSmMPProjectName(), getWLPInstallPath()).toString();
+
+        // Start dev mode in a container.
+        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Start in container", 3);
+
+        try {
+            // Validate that the project started.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+        } finally {
+            if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
+                // Stop dev mode.
+                UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Stop", 3);
+
+                // Validate that the server stopped.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+            }
         }
     }
 

--- a/src/test/resources/files/smNLTRestProject/gradle/server.xml
+++ b/src/test/resources/files/smNLTRestProject/gradle/server.xml
@@ -14,8 +14,8 @@
         <feature>jsonb-2.0</feature>
     </featureManager>
 
-    <httpEndpoint host="*" httpPort="9091"
-                  httpsPort="9054" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="9080"
+                  httpsPort="9443" id="defaultHttpEndpoint"/>
 
     <webApplication contextRoot="/" location="singleModGradleRESTNoLTXmlCfg.war"/>
 

--- a/src/test/resources/projects/gradle/sampleGradleMPLSApp/build.gradle
+++ b/src/test/resources/projects/gradle/sampleGradleMPLSApp/build.gradle
@@ -35,8 +35,8 @@ liberty {
 }
 
 ext {
-    liberty.server.var.'default.http.port' = '9090'
-    liberty.server.var.'default.https.port' = '9453'
+    liberty.server.var.'default.http.port' = '9080'
+    liberty.server.var.'default.https.port' = '9443'
     liberty.server.var.'project.name' = project.name
 }
 

--- a/src/test/resources/projects/gradle/singleModGradleMP/build.gradle
+++ b/src/test/resources/projects/gradle/singleModGradleMP/build.gradle
@@ -35,8 +35,8 @@ liberty {
 }
 
 ext {
-    liberty.server.var.'default.http.port' = '9090'
-    liberty.server.var.'default.https.port' = '9453'
+    liberty.server.var.'default.http.port' = '9080'
+    liberty.server.var.'default.https.port' = '9443'
     liberty.server.var.'project.name' = project.name
 }
 

--- a/src/test/resources/projects/gradle/singleModGradleRESTNoLTXmlCfg/build.gradle
+++ b/src/test/resources/projects/gradle/singleModGradleRESTNoLTXmlCfg/build.gradle
@@ -37,5 +37,5 @@ test {
         events 'PASSED', 'FAILED', 'SKIPPED'
     }
 
-    systemProperty 'http.port', 9091
+    systemProperty 'http.port', 9080
 }

--- a/src/test/resources/projects/gradle/singleModGradleRESTNoLTXmlCfg/src/main/liberty/config/myLibertyConfig.xml
+++ b/src/test/resources/projects/gradle/singleModGradleRESTNoLTXmlCfg/src/main/liberty/config/myLibertyConfig.xml
@@ -14,8 +14,8 @@
         <feature>jsonb-2.0</feature>
     </featureManager>
 
-    <httpEndpoint host="*" httpPort="9091"
-                  httpsPort="9454" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="9080"
+                  httpsPort="9443" id="defaultHttpEndpoint"/>
 
     <webApplication contextRoot="/" location="singleModGradleRESTNoLTXmlCfg.war"/>
 


### PR DESCRIPTION
Result from skills transfer prep.
This PR:
- Enables container tests for Gradle test runs.
- Standardizes the use of default ports in the Gradle test projects (required to enable container tests).
- Cleanup unnecessary code/config.