### PR TITLE
Fixes #160 'Run in container' checkbox option in Run/Debug Config

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -125,8 +125,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
             throw new ExecutionException(e);
         }
         // run the start dev mode action
-        boolean isContainer = runInContainer();
-        AnAction action = ActionManager.getInstance().getAction(isContainer ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
+        AnAction action = ActionManager.getInstance().getAction(runInContainer() ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
 
         // set custom start params
         if (getParams() != null) {

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -133,8 +133,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         } else {
             libertyModule.setCustomStartParams("");
         }
-        // FIXME implement runInContainer checkbox from run config see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
-         libertyModule.setRunInContainer(runInContainer());
+        libertyModule.setRunInContainer(runInContainer());
 
         if (executor.getId().equals(DefaultDebugExecutor.EXECUTOR_ID)) {
             libertyModule.setDebugMode(true);

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -81,7 +81,6 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         getOptions().setBuildFile(buildFile);
     }
 
-    // FIXME runInContainer, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
     public Boolean runInContainer() {
         return getOptions().runInContainer();
     }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -119,7 +119,8 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
             throw new ExecutionException(e);
         }
         // run the start dev mode action
-        AnAction action = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_START_ACTION_ID);
+        boolean isContainer = runInContainer();
+        AnAction action = ActionManager.getInstance().getAction(isContainer ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
         LibertyDevStartAction libAction = (LibertyDevStartAction) action;
 
         // set custom start params
@@ -129,7 +130,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
             libertyModule.setCustomStartParams("");
         }
         // FIXME implement runInContainer checkbox from run config see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
-        // libertyModule.setRunInContainer(runInContainer());
+         libertyModule.setRunInContainer(runInContainer());
 
         if (executor.getId().equals(DefaultDebugExecutor.EXECUTOR_ID)) {
             libertyModule.setDebugMode(true);

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -19,10 +19,15 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.JDOMExternalizerUtil;
+import com.intellij.openapi.util.WriteExternalException;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.actions.LibertyDevStartAction;
 import io.openliberty.tools.intellij.util.Constants;
+import org.jdom.Element;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +41,8 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
 
     private final LibertyModules libertyModules;
     private LibertyModule libertyModule;
+    @NonNls
+    private static final String RUN_IN_CONTAINER_TAG = "RUN_IN_CONTAINER";
 
     public LibertyRunConfiguration(Project project, ConfigurationFactory factory, String name) {
         super(name, getRunConfigurationModule(project), factory);
@@ -121,7 +128,6 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         // run the start dev mode action
         boolean isContainer = runInContainer();
         AnAction action = ActionManager.getInstance().getAction(isContainer ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
-        LibertyDevStartAction libAction = (LibertyDevStartAction) action;
 
         // set custom start params
         if (getParams() != null) {
@@ -154,4 +160,15 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         return null;
     }
 
+    @Override
+    public void writeExternal(@NotNull Element element) throws WriteExternalException {
+        super.writeExternal(element);
+        JDOMExternalizerUtil.writeField(element, RUN_IN_CONTAINER_TAG, String.valueOf(getOptions().runInContainer()));
+    }
+
+    @Override
+    public void readExternal(@NotNull Element element) throws InvalidDataException {
+        super.readExternal(element);
+        getOptions().setRunInContainer( Boolean.parseBoolean(JDOMExternalizerUtil.readField(element, RUN_IN_CONTAINER_TAG, Boolean.FALSE.toString())));
+    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.util.JDOMExternalizerUtil;
 import com.intellij.openapi.util.WriteExternalException;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
-import io.openliberty.tools.intellij.actions.LibertyDevStartAction;
 import io.openliberty.tools.intellij.util.Constants;
 import org.jdom.Element;
 import org.jetbrains.annotations.NonNls;

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.openliberty.tools.intellij.runConfiguration.LibertyRunSettingsEditor">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -37,6 +37,33 @@
           <text resource-bundle="messages/LibertyBundles" key="run.config.liberty.project"/>
           <toolTipText resource-bundle="messages/LibertyBundles" key="run.config.liberty.project.tool.tip"/>
         </properties>
+      </component>
+      <component id="7181e" class="com.intellij.ui.StateRestoringCheckBox" binding="runInContainerCheckBox" custom-create="true" default-binding="true">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="true"/>
+          <selected value="false"/>
+          <text value="Run in container"/>
+          <verticalAlignment value="3"/>
+        </properties>
+      </component>
+      <component id="1d145" class="javax.swing.JRadioButton" binding="radioButton1" default-binding="true">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="RadioButton"/>
+        </properties>
+      </component>
+      <component id="d3e68" class="javax.swing.JTextField" binding="textField1" default-binding="true">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.openliberty.tools.intellij.runConfiguration.LibertyRunSettingsEditor">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -38,7 +38,7 @@
           <toolTipText resource-bundle="messages/LibertyBundles" key="run.config.liberty.project.tool.tip"/>
         </properties>
       </component>
-      <component id="7181e" class="com.intellij.ui.StateRestoringCheckBox" binding="runInContainerCheckBox" custom-create="true" default-binding="true">
+      <component id="7181e" class="com.intellij.ui.StateRestoringCheckBox" binding="runInContainerCheckBox" custom-create="true" >
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -48,22 +48,6 @@
           <text value="Run in container"/>
           <verticalAlignment value="3"/>
         </properties>
-      </component>
-      <component id="1d145" class="javax.swing.JRadioButton" binding="radioButton1" default-binding="true">
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="RadioButton"/>
-        </properties>
-      </component>
-      <component id="d3e68" class="javax.swing.JTextField" binding="textField1" default-binding="true">
-        <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties/>
       </component>
     </children>
   </grid>

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
@@ -20,8 +20,6 @@ import io.openliberty.tools.intellij.LibertyModules;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * Editor associated with Liberty run & debug configurations. Defines when configuration changes are updated, default values, etc.
@@ -32,24 +30,14 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
     private LabeledComponent<EditorTextField> editableParams;
     private LabeledComponent<ComboBox> libertyModule;
     private StateRestoringCheckBox runInContainerCheckBox;
-    private JRadioButton radioButton1;
     private JTextField textField1;
 
-    private boolean isRunInContainerSelected = false;
+//    private boolean isRunInContainerSelected = false;
     // FIXME runInContainer
 //     private LabeledComponent<StateRestoringCheckBox> runInContainer;
 
     public LibertyRunSettingsEditor(Project project) {
         libertyModule.getComponent().setModel(new DefaultComboBoxModel(LibertyModules.getInstance().getLibertyBuildFilesAsString(project).toArray()));
-        runInContainerCheckBox.addItemListener(e -> {
-            if (e.getStateChange() == 1) {
-                isRunInContainerSelected = true;
-                fireEditorStateChanged();
-            } else {
-                isRunInContainerSelected = false;
-                fireEditorStateChanged();
-            }
-        });
     }
 
     @Override
@@ -66,7 +54,7 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         }
         // FIXME runInContainer state is not being saved, cannot "Apply" run in container checkbox change to run config, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
         // runInContainer.getComponent().setSelected(configuration.runInContainer());
-        runInContainerCheckBox.setSelected(isRunInContainerSelected);
+        runInContainerCheckBox.setSelected(configuration.runInContainer());
         editableParams.getComponent().setText(configuration.getParams());
     }
 
@@ -74,9 +62,9 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
     protected void applyEditorTo(@NotNull LibertyRunConfiguration configuration) throws ConfigurationException {
         configuration.setParams(editableParams.getComponent().getText());
         configuration.setBuildFile(String.valueOf(libertyModule.getComponent().getSelectedItem()));
+        configuration.setRunInContainer(runInContainerCheckBox.isSelected());
+
         // FIXME runInContainer
-        configuration.setRunInContainer( true);
-        configuration.setRunInContainer( radioButton1.isSelected());
         configuration.setParams(textField1.getText());
          //configuration.setRunInContainer(runInContainer.getComponent().isSelected());
     }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
@@ -15,10 +15,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.ui.EditorTextField;
+import com.intellij.ui.StateRestoringCheckBox;
 import io.openliberty.tools.intellij.LibertyModules;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 /**
  * Editor associated with Liberty run & debug configurations. Defines when configuration changes are updated, default values, etc.
@@ -28,12 +31,25 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
     private JPanel root;
     private LabeledComponent<EditorTextField> editableParams;
     private LabeledComponent<ComboBox> libertyModule;
+    private StateRestoringCheckBox runInContainerCheckBox;
+    private JRadioButton radioButton1;
+    private JTextField textField1;
 
+    private boolean isRunInContainerSelected = false;
     // FIXME runInContainer
-    // private LabeledComponent<StateRestoringCheckBox> runInContainer;
+//     private LabeledComponent<StateRestoringCheckBox> runInContainer;
 
     public LibertyRunSettingsEditor(Project project) {
         libertyModule.getComponent().setModel(new DefaultComboBoxModel(LibertyModules.getInstance().getLibertyBuildFilesAsString(project).toArray()));
+        runInContainerCheckBox.addItemListener(e -> {
+            if (e.getStateChange() == 1) {
+                isRunInContainerSelected = true;
+                fireEditorStateChanged();
+            } else {
+                isRunInContainerSelected = false;
+                fireEditorStateChanged();
+            }
+        });
     }
 
     @Override
@@ -50,6 +66,7 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         }
         // FIXME runInContainer state is not being saved, cannot "Apply" run in container checkbox change to run config, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
         // runInContainer.getComponent().setSelected(configuration.runInContainer());
+        runInContainerCheckBox.setSelected(isRunInContainerSelected);
         editableParams.getComponent().setText(configuration.getParams());
     }
 
@@ -58,7 +75,10 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         configuration.setParams(editableParams.getComponent().getText());
         configuration.setBuildFile(String.valueOf(libertyModule.getComponent().getSelectedItem()));
         // FIXME runInContainer
-        // configuration.setRunInContainer(runInContainer.getComponent().isSelected());
+        configuration.setRunInContainer( true);
+        configuration.setRunInContainer( radioButton1.isSelected());
+        configuration.setParams(textField1.getText());
+         //configuration.setRunInContainer(runInContainer.getComponent().isSelected());
     }
 
     @NotNull
@@ -74,7 +94,6 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         editableParams = new LabeledComponent<>();
         editableParams.setComponent(new EditorTextField());
         // FIXME runInContainer
-        // runInContainer = new LabeledComponent<>();
-        // runInContainer.setComponent(new StateRestoringCheckBox());
+        runInContainerCheckBox = new StateRestoringCheckBox();
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunSettingsEditor.java
@@ -30,11 +30,6 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
     private LabeledComponent<EditorTextField> editableParams;
     private LabeledComponent<ComboBox> libertyModule;
     private StateRestoringCheckBox runInContainerCheckBox;
-    private JTextField textField1;
-
-//    private boolean isRunInContainerSelected = false;
-    // FIXME runInContainer
-//     private LabeledComponent<StateRestoringCheckBox> runInContainer;
 
     public LibertyRunSettingsEditor(Project project) {
         libertyModule.getComponent().setModel(new DefaultComboBoxModel(LibertyModules.getInstance().getLibertyBuildFilesAsString(project).toArray()));
@@ -52,8 +47,6 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
                 break;
             }
         }
-        // FIXME runInContainer state is not being saved, cannot "Apply" run in container checkbox change to run config, see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
-        // runInContainer.getComponent().setSelected(configuration.runInContainer());
         runInContainerCheckBox.setSelected(configuration.runInContainer());
         editableParams.getComponent().setText(configuration.getParams());
     }
@@ -63,10 +56,6 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         configuration.setParams(editableParams.getComponent().getText());
         configuration.setBuildFile(String.valueOf(libertyModule.getComponent().getSelectedItem()));
         configuration.setRunInContainer(runInContainerCheckBox.isSelected());
-
-        // FIXME runInContainer
-        configuration.setParams(textField1.getText());
-         //configuration.setRunInContainer(runInContainer.getComponent().isSelected());
     }
 
     @NotNull
@@ -81,7 +70,6 @@ public class LibertyRunSettingsEditor extends SettingsEditor<LibertyRunConfigura
         libertyModule.setComponent(comboBox);
         editableParams = new LabeledComponent<>();
         editableParams.setComponent(new EditorTextField());
-        // FIXME runInContainer
         runInContainerCheckBox = new StateRestoringCheckBox();
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>open-liberty.intellij</id>
     <name>Liberty Tools</name>
 
-    <vendor url="https://openliberty.io/">Open-Liberty</vendor>
+    <vendor url="https://github.com/OpenLiberty/liberty-tools-intellij/issues">Open-Liberty</vendor>
 
     <category>Framework Integration</category>
 


### PR DESCRIPTION
Fixes #160 

Added checkbox in run/debug config window.
When the checkbox is selected, will run liberty:devc/libertyDevc when starting dev mode.