### PR TITLE
Proof-of-concept for unifying the design for MicroProfile and Jakarta EE code actions.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -41,6 +41,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ListenerDiagnost
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ServletDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.CodeActionHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4jakarta.commons.*;
@@ -66,7 +67,7 @@ public class PropertiesManagerForJakarta {
     }
 
     private List<DiagnosticsCollector> diagnosticsCollectors = new ArrayList<>();
-    private JakartaCodeActionHandler codeActionHandler = new JakartaCodeActionHandler();
+    private final CodeActionHandler codeActionHandler;
 
     private PropertiesManagerForJakarta() {
         diagnosticsCollectors.add(new ServletDiagnosticsCollector());
@@ -83,7 +84,7 @@ public class PropertiesManagerForJakarta {
         diagnosticsCollectors.add(new DependencyInjectionDiagnosticsCollector());
         diagnosticsCollectors.add(new JsonpDiagnosticCollector());
         diagnosticsCollectors.add(new WebSocketDiagnosticsCollector());
-        codeActionHandler = new JakartaCodeActionHandler();
+        codeActionHandler = new CodeActionHandler("jakarta");
     }
 
     /**
@@ -405,7 +406,24 @@ public class PropertiesManagerForJakarta {
 
     public List<CodeAction> getCodeAction(JakartaJavaCodeActionParams params, IPsiUtils utils) {
         return ApplicationManager.getApplication().runReadAction((Computable<List<CodeAction>>) () -> {
-            return codeActionHandler.codeAction(params, utils);
+            final List<? extends CodeAction> unresolvedCodeActions = codeActionHandler.codeAction(adapt(params), utils);
+            if (unresolvedCodeActions != null) {
+                final List<CodeAction> resolvedCodeActions = new ArrayList<>(unresolvedCodeActions.size());
+                unresolvedCodeActions.forEach(unresolvedCodeAction -> {
+                    if (unresolvedCodeAction != null) {
+                        resolvedCodeActions.add(codeActionHandler.resolveCodeAction(unresolvedCodeAction, utils));
+                    }
+                });
+                return resolvedCodeActions;
+            }
+            return null;
         });
+    }
+
+    private MicroProfileJavaCodeActionParams adapt(JakartaJavaCodeActionParams params) {
+        MicroProfileJavaCodeActionParams mpParams = new MicroProfileJavaCodeActionParams(params.getTextDocument(), params.getRange(), params.getContext());
+        mpParams.setResourceOperationSupported(params.isResourceOperationSupported());
+        mpParams.setResolveSupported(true);
+        return mpParams;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -18,13 +18,20 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyModifiersProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.ExtendedCodeAction;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCodeActionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4mp.commons.CodeActionResolveData;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Quick fix for ResourceMethodDiagnosticsCollector that uses
@@ -33,26 +40,57 @@ import java.util.List;
  * @author Matthew Shocrylas
  *
  */
-public class NonPublicResourceMethodQuickFix {
+public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipant {
+
+    private static final Logger LOGGER = Logger.getLogger(NonPublicResourceMethodQuickFix.class.getName());
 
     private final static String TITLE_MESSAGE = "Make method public";
+
+    @Override
+    public String getParticipantId() {
+        return NonPublicResourceMethodQuickFix.class.getName();
+    }
 
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic)  {
 
         final PsiElement node = context.getCoveredNode();
-        final PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
         final PsiMethod parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
 
         if (parentMethod != null) {
-            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
-                    context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
-
-            // Convert the proposal to LSP4J CodeAction
-            CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
-            codeAction.setTitle(TITLE_MESSAGE);
-            return Collections.singletonList(codeAction);
+            return Collections.singletonList(createCodeAction(context, diagnostic));
         }
         return Collections.emptyList();
     }
 
+    @Override
+    public CodeAction resolveCodeAction(JavaCodeActionResolveContext context) {
+
+        final CodeAction toResolve = context.getUnresolved();
+        final PsiElement node = context.getCoveredNode();
+        final PsiClass parentType = PsiTreeUtil.getParentOfType(node, PsiClass.class);
+        final PsiMethod parentMethod = PsiTreeUtil.getParentOfType(node, PsiMethod.class);
+
+        assert parentMethod != null;
+        ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
+        try {
+            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+            toResolve.setEdit(we);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e);
+        }
+        return toResolve;
+    }
+
+    private CodeAction createCodeAction(JavaCodeActionContext context, Diagnostic diagnostic) {
+        ExtendedCodeAction codeAction = new ExtendedCodeAction(TITLE_MESSAGE);
+        codeAction.setRelevance(0);
+        codeAction.setDiagnostics(Collections.singletonList(diagnostic));
+        codeAction.setKind(CodeActionKind.QuickFix);
+        codeAction.setData(new CodeActionResolveData(context.getUri(), getParticipantId(),
+                context.getParams().getRange(), Collections.emptyMap(),
+                context.getParams().isResourceOperationSupported(),
+                context.getParams().isCommandConfigurationUpdateSupported()));
+        return codeAction;
+    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -87,7 +87,7 @@ public class PropertiesManagerForJava {
     private final CodeActionHandler codeActionHandler;
 
     private PropertiesManagerForJava() {
-        this.codeActionHandler = new CodeActionHandler();
+        this.codeActionHandler = new CodeActionHandler("mp");
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
@@ -47,6 +47,12 @@ import java.util.stream.Collectors;
  */
 public class CodeActionHandler {
 
+	private final String group;
+
+	public CodeActionHandler(String group) {
+		this.group = group;
+	}
+
 	/**
 	 * Returns all the code actions applicable for the context given by the
 	 * parameters.
@@ -98,6 +104,7 @@ public class CodeActionHandler {
 				// Get list of code action definition for the given kind
 				List<io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.JavaCodeActionDefinition> codeActionDefinitions = io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.JavaCodeActionDefinition.EP.extensions()
 						.filter(definition -> definition.isAdaptedForCodeAction(context))
+						.filter(definition -> group.equals(definition.getGroup()))
 						.filter(definition -> codeActionKind.equals(definition.getKind()))
 						.collect(Collectors.toList());
 				if (codeActionDefinitions != null) {
@@ -201,6 +208,7 @@ public class CodeActionHandler {
 
 		IJavaCodeActionParticipant participant = JavaCodeActionDefinition.EP.extensions()
 				.filter(definition -> unresolved.getKind().startsWith(definition.getKind()))
+				.filter(definition -> group.equals(definition.getGroup()))
 				.filter(definition -> participantId.equals(definition.getParticipantId()))
 				.findFirst().orElse(null);
 		return participant.resolveCodeAction(context.copy());

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/JavaCodeActionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/JavaCodeActionDefinition.java
@@ -41,10 +41,14 @@ public class JavaCodeActionDefinition extends BaseKeyedLazyInstance<IJavaCodeAct
 
 	private static final Logger LOGGER = Logger.getLogger(JavaCodeActionDefinition.class.getName());
 	private static final String KIND_ATTR = "kind";
+	private static final String GROUP_ATTR = "group";
 	private static final String TARGET_DIAGNOSTIC_ATTR = "targetDiagnostic";
 
-	@Attribute("kind")
+	@Attribute(KIND_ATTR)
 	private String kind;
+
+	@Attribute(GROUP_ATTR)
+	private String group;
 
 	@Attribute(TARGET_DIAGNOSTIC_ATTR)
 	@RequiredElement
@@ -93,6 +97,15 @@ public class JavaCodeActionDefinition extends BaseKeyedLazyInstance<IJavaCodeAct
 	public String getKind() {
 		return !StringUtils.isEmpty(kind) ? kind : CodeActionKind.QuickFix;
 	}
+
+	/**
+	 * Returns the name of the group which this code action is
+	 * a member or null.
+	 *
+	 * @return the name of the group which this code action is
+	 * a member or null.
+	 */
+	public @Nullable String getGroup() { return group; }
 
 	/**
 	 * Returns the target diagnostic and null otherwise.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,34 +123,49 @@
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.MicroProfileRestClientCodeLensParticipant"/>
 
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-config#NO_VALUE_ASSIGNED_TO_PROPERTY"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.config.java.NoValueAssignedToPropertyQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-config#NO_VALUE_ASSIGNED_TO_PROPERTY"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.config.java.InsertDefaultValueAnnotationAttributeQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-health#ImplementHealthCheck"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.java.ImplementHealthCheckQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-health#HealthAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.java.HealthAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-metrics#ApplicationScopedAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.metrics.java.ApplicationScopedAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-restclient#InjectAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.InjectAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-restclient#RestClientAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.RestClientAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-restclient#InjectAndRestClientAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.InjectAndRestClientAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
+                                   group="mp"
                                    targetDiagnostic="microprofile-restclient#RegisterRestClientAnnotationMissing"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.RegisterRestClientAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="source"
+                                   group="mp"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.openapi.java.MicroProfileGenerateOpenAPIOperation"/>
+
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-jax_rs#NonPublicResourceMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NonPublicResourceMethodQuickFix"/>
 
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>


### PR DESCRIPTION
This is a starting point for merging MP and Jakarta EE on to one design for code actions. I only transformed one Jakarta EE quick fix to provide an example. A similar pattern can be applied for transforming the rest of them. We should enable the automated tests for Jakarta EE code actions: https://github.com/OpenLiberty/liberty-tools-intellij/issues/476 as we complete this work.