### PR TITLE
Transform the Jakarta EE diagnostic collectors on to a common extension point shared with MicroProfile.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -13,12 +13,16 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaDiagnosticsParticipant;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.JavaDiagnosticsContext;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
@@ -28,7 +32,7 @@ import org.eclipse.lsp4j.Range;
  * Abstract class for collecting Java diagnostics.
  *
  */
-public class AbstractDiagnosticsCollector implements DiagnosticsCollector {
+public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollector, IJavaDiagnosticsParticipant {
 
     /**
      * Constructor
@@ -82,6 +86,25 @@ public class AbstractDiagnosticsCollector implements DiagnosticsCollector {
             diagnostic.setCode(code);
         diagnostic.setSeverity(severity);
         return diagnostic;
+    }
+
+    /**
+     * Collect diagnostics according to the context.
+     *
+     * @param context the java diagnostics context
+     *
+     * @return diagnostics list and null otherwise.
+     *
+     */
+    @Override
+    public final List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context) {
+        PsiFile typeRoot = context.getTypeRoot();
+        if (typeRoot instanceof PsiJavaFile) {
+            List<Diagnostic> diagnostics = new ArrayList<>();
+            collectDiagnostics((PsiJavaFile) typeRoot, diagnostics);
+            return diagnostics;
+        }
+        return Collections.emptyList();
     }
 
     /**
@@ -301,4 +324,5 @@ public class AbstractDiagnosticsCollector implements DiagnosticsCollector {
     protected static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
     }
+
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2022 Red Hat, Inc.
+ * Copyright (c) 2020,2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -12,44 +12,30 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 
-import com.intellij.lang.jvm.JvmTypeDeclaration;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.JakartaCodeActionHandler;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.di.DependencyInjectionDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSClassDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.ResourceMethodDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb.JsonbDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonp.JsonpDiagnosticCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceMapKeyDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.FilterDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ListenerDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ServletDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.DiagnosticsHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
-import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.*;
-import org.eclipse.lsp4mp.commons.*;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,25 +51,13 @@ public class PropertiesManagerForJakarta {
         return INSTANCE;
     }
 
-    private List<DiagnosticsCollector> diagnosticsCollectors = new ArrayList<>();
     private JakartaCodeActionHandler codeActionHandler = new JakartaCodeActionHandler();
 
+    private final DiagnosticsHandler diagnosticsHandler;
+
     private PropertiesManagerForJakarta() {
-        diagnosticsCollectors.add(new ServletDiagnosticsCollector());
-        diagnosticsCollectors.add(new AnnotationDiagnosticsCollector());
-        diagnosticsCollectors.add(new FilterDiagnosticsCollector());
-        diagnosticsCollectors.add(new ListenerDiagnosticsCollector());
-        diagnosticsCollectors.add(new BeanValidationDiagnosticsCollector());
-        diagnosticsCollectors.add(new PersistenceEntityDiagnosticsCollector());
-        diagnosticsCollectors.add(new PersistenceMapKeyDiagnosticsCollector());
-        diagnosticsCollectors.add(new ResourceMethodDiagnosticsCollector());
-        diagnosticsCollectors.add(new Jax_RSClassDiagnosticsCollector());
-        diagnosticsCollectors.add(new JsonbDiagnosticsCollector());
-        diagnosticsCollectors.add(new ManagedBeanDiagnosticsCollector());
-        diagnosticsCollectors.add(new DependencyInjectionDiagnosticsCollector());
-        diagnosticsCollectors.add(new JsonpDiagnosticCollector());
-        diagnosticsCollectors.add(new WebSocketDiagnosticsCollector());
         codeActionHandler = new JakartaCodeActionHandler();
+        diagnosticsHandler = new DiagnosticsHandler("jakarta");
     }
 
     /**
@@ -94,40 +68,7 @@ public class PropertiesManagerForJakarta {
      * @return diagnostics for the given uris list.
      */
     public List<PublishDiagnosticsParams> diagnostics(JakartaDiagnosticsParams params, IPsiUtils utils) {
-        List<String> uris = params.getUris();
-        if (uris == null) {
-            return Collections.emptyList();
-        }
-        DocumentFormat documentFormat = params.getDocumentFormat();
-        List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
-        for (String uri : uris) {
-            List<Diagnostic> diagnostics = new ArrayList<>();
-            PublishDiagnosticsParams publishDiagnostic = new PublishDiagnosticsParams(uri, diagnostics);
-            publishDiagnostics.add(publishDiagnostic);
-            collectDiagnostics(uri, utils, documentFormat, diagnostics);
-        }
-        return publishDiagnostics;
-    }
-
-    private void collectDiagnostics(String uri, IPsiUtils utils, DocumentFormat documentFormat, List<Diagnostic> diagnostics) {
-        PsiFile typeRoot = ApplicationManager.getApplication().runReadAction((Computable<PsiFile>) () -> resolveTypeRoot(uri, utils));
-        if (typeRoot == null) {
-            return;
-        }
-
-        try {
-            if (typeRoot instanceof PsiJavaFile) {
-                Module module = ApplicationManager.getApplication().runReadAction((ThrowableComputable<Module, IOException>) () -> utils.getModule(uri));
-                DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
-                    PsiJavaFile unit = (PsiJavaFile) typeRoot;
-                    for (DiagnosticsCollector collector : diagnosticsCollectors) {
-                        collector.collectDiagnostics(unit, diagnostics);
-                    }
-                });
-            }
-        } catch (IOException e) {
-            LOGGER.warn(e.getLocalizedMessage(), e);
-        }
+        return diagnosticsHandler.collectDiagnostics(adapt(params), utils);
     }
 
     /**
@@ -407,5 +348,12 @@ public class PropertiesManagerForJakarta {
         return ApplicationManager.getApplication().runReadAction((Computable<List<CodeAction>>) () -> {
             return codeActionHandler.codeAction(params, utils);
         });
+    }
+
+    private MicroProfileJavaDiagnosticsParams adapt(JakartaDiagnosticsParams params) {
+        MicroProfileJavaDiagnosticsParams mpParams = new MicroProfileJavaDiagnosticsParams(params.getUris(),
+                new MicroProfileJavaDiagnosticsSettings(Collections.emptyList()));
+        mpParams.setDocumentFormat(params.getDocumentFormat());
+        return mpParams;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2023 Red Hat, Inc.
+ * Copyright (c) 2020, 2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020, 2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.psi.PsiFile;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.corrections.JavaDiagnosticsDefinition;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DiagnosticsHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsHandler.class);
+
+    private final String group;
+
+    public DiagnosticsHandler(String group) {
+        this.group = group;
+    }
+
+    public List<PublishDiagnosticsParams> collectDiagnostics(MicroProfileJavaDiagnosticsParams params, IPsiUtils utils) {
+        List<String> uris = params.getUris();
+        if (uris == null) {
+            return Collections.emptyList();
+        }
+        DocumentFormat documentFormat = params.getDocumentFormat();
+        List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<>();
+        for (String uri : uris) {
+            List<Diagnostic> diagnostics = new ArrayList<>();
+            PublishDiagnosticsParams publishDiagnostic = new PublishDiagnosticsParams(uri, diagnostics);
+            publishDiagnostics.add(publishDiagnostic);
+            collectDiagnostics(uri, utils, documentFormat, params.getSettings(), diagnostics);
+        }
+        return publishDiagnostics;
+    }
+
+    private void collectDiagnostics(String uri, IPsiUtils utils, DocumentFormat documentFormat,
+                                    MicroProfileJavaDiagnosticsSettings settings, List<Diagnostic> diagnostics) {
+        PsiFile typeRoot = ApplicationManager.getApplication().runReadAction((Computable<PsiFile>) () -> resolveTypeRoot(uri, utils));
+        if (typeRoot == null) {
+            return;
+        }
+
+        try {
+            Module module = ApplicationManager.getApplication().runReadAction((ThrowableComputable<Module, IOException>) () -> utils.getModule(uri));
+            DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
+                // Collect all adapted diagnostic definitions
+                JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, module, documentFormat, settings);
+                List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.extensions()
+                        .filter(definition -> definition.isAdaptedForDiagnostics(context))
+                        .filter(definition -> group.equals(definition.getGroup()))
+                        .collect(Collectors.toList());
+                if (definitions.isEmpty()) {
+                    return;
+                }
+
+                // Begin, collect, end participants
+                definitions.forEach(definition -> definition.beginDiagnostics(context));
+                definitions.forEach(definition -> {
+                    List<Diagnostic> collectedDiagnostics = definition.collectDiagnostics(context);
+                    if (collectedDiagnostics != null && !collectedDiagnostics.isEmpty()) {
+                        diagnostics.addAll(collectedDiagnostics);
+                    }
+                });
+                definitions.forEach(definition -> definition.endDiagnostics(context));
+            });
+        } catch (IOException e) {
+            LOGGER.warn(e.getLocalizedMessage(), e);
+        }
+    }
+
+    // REVISIT: Make this a public method on a common utility class?
+    private static PsiFile resolveTypeRoot(String uri, IPsiUtils utils) {
+        return utils.resolveCompilationUnit(uri);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -25,8 +25,6 @@ import org.eclipse.lsp4j.Diagnostic;
  */
 public interface IJavaDiagnosticsParticipant {
 
-	public static final ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaDiagnosticsParticipant");
-
 	/**
 	 * Returns true if diagnostics must be collected for the given context and false
 	 * otherwise.

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2023 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html
@@ -11,10 +11,9 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics;
 
-import java.util.List;
-
-import com.intellij.openapi.extensions.ExtensionPointName;
 import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.List;
 
 /**
  * Java diagnostics participants API.

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.corrections;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.serviceContainer.BaseKeyedLazyInstance;
+import com.intellij.util.xmlb.annotations.Attribute;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaDiagnosticsParticipant;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.JavaDiagnosticsContext;
+import org.eclipse.lsp4j.Diagnostic;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Wrapper class around {@link IJavaDiagnosticsParticipant} participants.
+ */
+public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJavaDiagnosticsParticipant>
+        implements IJavaDiagnosticsParticipant {
+
+    public static final ExtensionPointName<JavaDiagnosticsDefinition> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaDiagnosticsParticipant");
+
+    private static final Logger LOGGER = Logger.getLogger(JavaDiagnosticsDefinition.class.getName());
+    private static final String GROUP_ATTR = "group";
+    private static final String IMPLEMENTATION_CLASS_ATTR = "implementationClass";
+
+    @Attribute(GROUP_ATTR)
+    private String group;
+
+    @Attribute(IMPLEMENTATION_CLASS_ATTR)
+    public String implementationClass;
+
+    @Override
+    public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
+        try {
+            return getInstance().isAdaptedForDiagnostics(context);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void beginDiagnostics(JavaDiagnosticsContext context) {
+        try {
+            getInstance().beginDiagnostics(context);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
+        }
+    }
+
+    @Override
+    public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context) {
+        try {
+            List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
+            return diagnostics != null ? diagnostics : Collections.emptyList();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public void endDiagnostics(JavaDiagnosticsContext context) {
+        try {
+            getInstance().endDiagnostics(context);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);
+        }
+    }
+
+    public @Nullable String getGroup() {
+        return group;
+    }
+
+    @Override
+    protected @Nullable String getImplementationClassName() {
+        return implementationClass;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,7 +35,7 @@
         <extensionPoint name="javaHoverParticipant"
                         interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.hover.IJavaHoverParticipant"/>
         <extensionPoint name="javaDiagnosticsParticipant"
-                        interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaDiagnosticsParticipant"/>
+                        beanClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.corrections.JavaDiagnosticsDefinition"/>
         <extensionPoint name="projectLabelProvider"
                         interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.IProjectLabelProvider"/>
         <extensionPoint name="javaDefinitionParticipant"
@@ -93,14 +93,63 @@
         <javaHoverParticipant
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.config.java.MicroProfileConfigHoverParticipant"/>
 
+        <!-- MicroProfile Diagnostic Participants -->
         <javaDiagnosticsParticipant
-                implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.validators.JavaASTDiagnosticsParticipant"/>
+                group="mp"
+                implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.validators.JavaASTDiagnosticsParticipant"/>
         <javaDiagnosticsParticipant
-                implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.java.MicroProfileHealthDiagnosticsParticipant"/>
+                group="mp"
+                implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.java.MicroProfileHealthDiagnosticsParticipant"/>
         <javaDiagnosticsParticipant
-                implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.MicroProfileRestClientDiagnosticsParticipant"/>
+                group="mp"
+                implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.restclient.java.MicroProfileRestClientDiagnosticsParticipant"/>
         <javaDiagnosticsParticipant
-                implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.metrics.java.MicroProfileMetricsDiagnosticsParticipant"/>
+                group="mp"
+                implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.metrics.java.MicroProfileMetricsDiagnosticsParticipant"/>
+
+        <!-- Jakarta Diagnostic Participants -->
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.AnnotationDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.di.DependencyInjectionDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.Jax_RSClassDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.ResourceMethodDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb.JsonbDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonp.JsonpDiagnosticCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceMapKeyDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.FilterDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ListenerDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ServletDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector"/>
 
         <projectLabelProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileProjectLabelProvider"/>


### PR DESCRIPTION
Resolves #501.

1. Transformed `AbstractDiagnosticsCollector` so that it implements `IJavaDiagnosticsParticipant`. This is the base class for all of the Jakarta EE diagnostic collectors.
2. Created `JavaDiagnosticsDefinition`, a bean wrapper class around `IJavaDiagnosticsParticipant` which includes a group field to distinguish between diagnostics for different language servers (e.g. MP vs. Jakarta EE).
3. Refactored diagnostics related code from the MP `PropertiesManagerForJava` into its own class: `DiagnosticsHandler`, enhancing this code to use the group field when filtering the list of diagnostics collectors.
4. Plugged the `DiagnosticsHandler` into the `PropertiesManagerForJakarta`, replacing the diagnostics related code from this class.
5. Changed the definition of the `javaDiagnosticsParticipant` in the plugin.xml to be the `JavaDiagnosticsDefinition` bean class, allowing a group attribute to be specified for each of the diagnostics collectors.
6. Specified a `javaDiagnosticsParticipant` in the plugin.xml for each of the Jakarta EE diagnostics and updated all of the existing `javaDiagnosticsParticipant`s to specify that those diagnostics apply to MicroProfile by adding the group field.