### PR TITLE
Add filewatcher to enable custom config support for LCLS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     // Test: Video Recording.
     testImplementation 'com.automation-remarks:video-recorder-junit5:2.0'
 
+    // define jars to grab locally (if falling back to mavenLocal() repo)
     lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.6.0:uber') {
         transitive = false
     }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageClient.java
@@ -45,7 +45,6 @@ public class LibertyConfigLanguageClient extends LanguageClientImpl implements L
     public void processConfigXml(List<String> uris) {
         LanguageServerWrapper wrapper = getLanguageServerWrapper();
         if (wrapper != null) {
-            // TODO: test on Windows, may need to use uri-normalizing methods from LCLS
             List<FileEvent> fileEvents = uris.stream()
                     .map(uri -> new FileEvent(uri, FileChangeType.Changed)).toList();
             DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams();

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageClient.java
@@ -10,37 +10,47 @@
  ******************************************************************************/
 package io.openliberty.tools.intellij.liberty.lsp;
 
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.libraries.Library;
-import com.intellij.openapi.vfs.VirtualFile;
-import io.openliberty.tools.intellij.lsp4mp.MicroProfileProjectService;
-import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageClientImpl;
-import org.apache.commons.lang3.tuple.Pair;
+import java.util.List;
+
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBusConnection;
+
+import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageClientImpl;
+import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageServerWrapper;
 
 /**
  * Client for Liberty language server
  * Adapted from https://github.com/redhat-developer/intellij-quarkus/blob/2585eb422beeb69631076d2c39196d6eca2f5f2e/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
  */
-public class LibertyConfigLanguageClient extends LanguageClientImpl implements MicroProfileProjectService.Listener {
+public class LibertyConfigLanguageClient extends LanguageClientImpl implements LibertyCustomConfigManager.Listener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LibertyConfigLanguageClient.class);
 
+    private final MessageBusConnection connection;
+
     public LibertyConfigLanguageClient(Project project) {
         super(project);
+        connection = project.getMessageBus().connect(project);
+        connection.subscribe(LibertyCustomConfigManager.TOPIC, this);
+        LibertyCustomConfigManager.getInstance(project);
     }
 
     @Override
-    public void libraryUpdated(Library library) {
-        // not needed for Liberty LS
-    }
-
-    @Override
-    public void sourceUpdated(List<Pair<Module, VirtualFile>> sources) {
-        // not needed for Liberty LS
+    public void processConfigXml(List<String> uris) {
+        LanguageServerWrapper wrapper = getLanguageServerWrapper();
+        if (wrapper != null) {
+            // TODO: test on Windows, may need to use uri-normalizing methods from LCLS
+            List<FileEvent> fileEvents = uris.stream()
+                    .map(uri -> new FileEvent(uri, FileChangeType.Changed)).toList();
+            DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams();
+            params.setChanges(fileEvents);
+            wrapper.getInitializedServer().thenAccept(ls -> ls.getWorkspaceService().didChangeWatchedFiles(params));
+        }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigListener.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
 package io.openliberty.tools.intellij.liberty.lsp;
 
 import com.intellij.openapi.diagnostic.Logger;

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigListener.java
@@ -1,0 +1,35 @@
+package io.openliberty.tools.intellij.liberty.lsp;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import io.openliberty.tools.intellij.lsp4mp.lsp4ij.LSPIJUtils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class LibertyCustomConfigListener implements BulkFileListener {
+    private final static Logger LOGGER = Logger.getInstance(LibertyCustomConfigListener.class);
+
+    private final LibertyCustomConfigManager manager;
+    public static final String LIBERTY_PLUGIN_CONFIG_XML = "liberty-plugin-config.xml"; 
+
+    public LibertyCustomConfigListener(LibertyCustomConfigManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public void after(@NotNull List<? extends VFileEvent> events) {
+        // filter file events to only liberty-plugin-config.xml
+        List<String> pluginConfigList = events.stream()
+                .map(event -> LSPIJUtils.toUri(event.getFile()).toString())
+                .filter(this::isPluginConfigXml)
+                .toList();
+        manager.handleProcessConfigXml(pluginConfigList);
+    }
+
+    private boolean isPluginConfigXml(String uri) {
+        return uri.endsWith(LIBERTY_PLUGIN_CONFIG_XML);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
@@ -1,0 +1,50 @@
+package io.openliberty.tools.intellij.liberty.lsp;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.util.messages.MessageBusConnection;
+import com.intellij.util.messages.Topic;
+
+import java.util.List;
+
+public class LibertyCustomConfigManager implements LibraryTable.Listener, Disposable {
+
+    private final static Logger LOGGER = Logger.getInstance(LibertyCustomConfigManager.class);
+
+    private final Project project;
+    private final MessageBusConnection appConnection;
+    private final LibertyCustomConfigListener listener;
+
+    @Override
+    public void dispose() {
+
+    }
+
+    public interface Listener {
+        void processConfigXml(List<String> uris);
+    }
+
+    public static LibertyCustomConfigManager getInstance(Project project) {
+        return project.getService(LibertyCustomConfigManager.class);
+    }
+
+    public static final Topic<Listener> TOPIC = Topic.create(LibertyCustomConfigManager.class.getName(), Listener.class);
+
+
+    public LibertyCustomConfigManager(Project project) {
+        this.project = project;
+        LibraryTablesRegistrar.getInstance().getLibraryTable(project).addListener(this, project);
+        listener = new LibertyCustomConfigListener(this);
+        appConnection = ApplicationManager.getApplication().getMessageBus().connect(project);
+        appConnection.subscribe(VirtualFileManager.VFS_CHANGES, listener);
+    }
+
+    protected void handleProcessConfigXml(List<String> uris) {
+        project.getMessageBus().syncPublisher(TOPIC).processConfigXml(uris);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
 package io.openliberty.tools.intellij.liberty.lsp;
 
 import com.intellij.openapi.Disposable;

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
@@ -32,7 +32,7 @@ public class LibertyCustomConfigManager implements LibraryTable.Listener, Dispos
 
     @Override
     public void dispose() {
-
+        this.appConnection.disconnect();
     }
 
     public interface Listener {
@@ -48,7 +48,6 @@ public class LibertyCustomConfigManager implements LibraryTable.Listener, Dispos
 
     public LibertyCustomConfigManager(Project project) {
         this.project = project;
-        LibraryTablesRegistrar.getInstance().getLibraryTable(project).addListener(this, project);
         listener = new LibertyCustomConfigListener(this);
         appConnection = ApplicationManager.getApplication().getMessageBus().connect(project);
         appConnection.subscribe(VirtualFileManager.VFS_CHANGES, listener);

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyCustomConfigManager.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class LibertyCustomConfigManager implements LibraryTable.Listener, Dispos
         void processConfigXml(List<String> uris);
     }
 
-    public static LibertyCustomConfigManager getInstance(Project project) {
+    public static LibertyCustomConfigManager getInstance(@NotNull Project project) {
         return project.getService(LibertyCustomConfigManager.class);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
@@ -9,11 +9,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.liberty.lsp;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-
 import javax.swing.Icon;
 
 import com.intellij.openapi.fileTypes.PlainTextLanguage;
@@ -26,8 +21,6 @@ import com.intellij.openapi.util.NlsContexts;
 import com.intellij.openapi.vfs.VirtualFile;
 
 import io.openliberty.tools.intellij.LibertyPluginIcons;
-
-import static io.openliberty.tools.intellij.util.Constants.SERVER_ENV_GLOB_PATTERN;
 
 /**
  * Custom file type for server.env files
@@ -43,9 +36,7 @@ public class ServerEnvFileType extends LanguageFileType implements FileTypeIdent
 
     @Override
     public boolean isMyFileType(@NotNull VirtualFile file) {
-        Path path = Paths.get(file.getPath());
-        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + SERVER_ENV_GLOB_PATTERN);
-        return matcher.matches(path);
+        return file.getPath().endsWith(".env");
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvFileType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation.
+ * Copyright (c) 2022, 2023 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvSubstitutor.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/ServerEnvSubstitutor.java
@@ -21,13 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-
-import static io.openliberty.tools.intellij.util.Constants.SERVER_ENV_GLOB_PATTERN;
-
 /**
  * Language Substitutor for Liberty server.env files
  * To re-use the IntelliJ parsing for Properties files on server.env files, categorize server.env files that are in a recognized
@@ -47,8 +40,6 @@ public class ServerEnvSubstitutor extends LanguageSubstitutor {
     }
 
     private boolean isLibertyServerEnvFile(VirtualFile file) {
-        Path path = Paths.get(file.getPath());
-        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + SERVER_ENV_GLOB_PATTERN);
-        return matcher.matches(path);
+        return file.getPath().endsWith(".env");
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageClientImpl.java
@@ -49,6 +49,9 @@ public class LanguageClientImpl implements LanguageClient {
     protected final LanguageServer getLanguageServer() {
         return server;
     }
+    protected final LanguageServerWrapper getLanguageServerWrapper() {
+        return wrapper;
+    }
 
     @Override
     public void telemetryEvent(Object object) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
@@ -363,11 +363,11 @@ public class LanguageServerWrapper {
             ResponseMessage responseMessage = (ResponseMessage) message;
             LOGGER.warn("", new ResponseErrorException(responseMessage.getError()));
         } else if (LOGGER.isDebugEnabled()) {
-            LOGGER.info(message.getClass().getSimpleName() + '\n' + message.toString());
+            LOGGER.warn(message.getClass().getSimpleName() + ": " + this.serverDefinition.id + '\n' + message.toString());
         }
-//        else {
-//            LOGGER.warn(message.getClass().getSimpleName() + '\n' + message.toString());
-//        }
+        // else {
+        //     LOGGER.warn(message.getClass().getSimpleName() + ": " + this.serverDefinition.id + '\n' + message.toString());
+        // }
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp4ij/LanguageServerWrapper.java
@@ -365,9 +365,9 @@ public class LanguageServerWrapper {
         } else if (LOGGER.isDebugEnabled()) {
             LOGGER.warn(message.getClass().getSimpleName() + ": " + this.serverDefinition.id + '\n' + message.toString());
         }
-        // else {
-        //     LOGGER.warn(message.getClass().getSimpleName() + ": " + this.serverDefinition.id + '\n' + message.toString());
-        // }
+//        else {
+//            LOGGER.warn(message.getClass().getSimpleName() + ": " + this.serverDefinition.id + '\n' + message.toString());
+//        }
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2023 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -85,5 +85,5 @@ public final class Constants {
     /**
      * Constants for langauge servers
      */
-    public static final String SERVER_ENV_GLOB_PATTERN = "**/{src/main/liberty/config,usr/servers/**}/server.env";
+    public static final String SERVER_ENV_GLOB_PATTERN = "**/*.env";
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -83,10 +83,8 @@ public final class Constants {
             });
 
     /**
-     * Constants for langauge servers
+     * Constants for language servers
      */
-    public static final String SERVER_ENV_GLOB_PATTERN = "**/*.env";
-
     public static final String LIBERTY_XML_SERVER = "LemMinX";
     public static final String LIBERTY_CONFIG_SERVER="Liberty Config";
     public static final String JAKARTA_LANG_SERVER="Eclipse LSP4Jakarta";

--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -37,7 +37,7 @@
                 clientImpl="io.openliberty.tools.intellij.liberty.lsp.LibertyConfigLanguageClient"
                 serverInterface="org.eclipse.lsp4mp.ls.api.MicroProfileLanguageServerAPI"/>
         <languageMapping language="Properties" serverId="libertyls"
-                         filePattern="**/{src/main/liberty/config,usr/servers/**}/{bootstrap.properties,server.env}"/>
+                         filePattern="**/{*.properties,*.env}"/>
 
         <!-- Jakarta LS -->
         <server id="jakartals" class="io.openliberty.tools.intellij.lsp4jakarta.lsp.JakartaLanguageServer"
@@ -64,6 +64,8 @@
         <inspectionToolProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.diagnostics.LSPInspectionToolProvider"/>
         <projectService serviceImplementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.LanguageServiceAccessor"/>
+        <!-- Enable watcher to handle custom liberty config files and provide LCLS support -->
+        <projectService serviceImplementation="io.openliberty.tools.intellij.liberty.lsp.LibertyCustomConfigManager"/>
         <!-- TODO re-enable goto handler -->
         <!-- <gotoDeclarationHandler
                 implementation="io.openliberty.tools.intellij.lsp4mp.lsp4ij.operations.navigation.LSPGotoDeclarationHandler"/> -->

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -35,9 +35,9 @@ prefetchDependencies() {
 
     # Run through dev mode server install/create and feature installation for the Maven app.
     cd "src/test/resources/projects/maven/singleModMavenMP"
-    ./mvnw liberty:install-server
+    ./mvnw liberty:install-server -ntp
     ./mvnw liberty:create
-    ./mvnw liberty:install-feature
+    ./mvnw liberty:install-feature -ntp
 
     # Run through dev mode server install/create and feature installation for the Gradle app.
     cd "$workingDir"


### PR DESCRIPTION
Resolves #490 
Add file listener - notify LCLS to process `liberty-plugin-config.xml` files when a filechange is detected.

Also requires LCLS 2.1 or 2.1-SNAPSHOT
Merging this change does not break existing support for LCLS files.


## Notes
Currently this only works if `liberty-plugin-config.xml` changes _**after**_ IntelliJ/LCLS is initialized. 
Liberty Tools IntelliJ doesn't initialize workspace folders, which is how the custom config files are discovered on LCLS initialization. Related to #483

**Also to note**, it seems the intellij-quarkus plugin has made changes to enable workspace folders, and also enable the LSP protocol for `workspace/didChangeWatchedFiles`, which may replace these changes at some point in the future.