### PR TITLE
Part of #511: Refactor the implementation for FilterImplementationQuickFix and ListenerImplementationQuickFix

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/JakartaCodeActionHandler.java
@@ -91,8 +91,6 @@ public class JakartaCodeActionHandler {
             List<CodeAction> codeActions = new ArrayList<>();
 
             HttpServletQuickFix HttpServletQuickFix = new HttpServletQuickFix();
-            FilterImplementationQuickFix FilterImplementationQuickFix = new FilterImplementationQuickFix();
-            ListenerImplementationQuickFix ListenerImplementationQuickFix = new ListenerImplementationQuickFix();
             CompleteServletAnnotationQuickFix CompleteServletAnnotationQuickFix = new CompleteServletAnnotationQuickFix();
             CompleteFilterAnnotationQuickFix CompleteFilterAnnotationQuickFix = new CompleteFilterAnnotationQuickFix();
             PersistenceAnnotationQuickFix PersistenceAnnotationQuickFix = new PersistenceAnnotationQuickFix();
@@ -127,12 +125,6 @@ public class JakartaCodeActionHandler {
                 try {
                     if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE)) {
                         codeActions.addAll(HttpServletQuickFix.getCodeActions(context, diagnostic));
-                    }
-                    if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_FILTER)) {
-                        codeActions.addAll(FilterImplementationQuickFix.getCodeActions(context, diagnostic));
-                    }
-                    if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_LISTENER)) {
-                        codeActions.addAll(ListenerImplementationQuickFix.getCodeActions(context, diagnostic));
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_MISSING_RESOURCE_NAME_ATTRIBUTE)) {
                         codeActions.addAll(AddResourceMissingNameQuickFix.getCodeActions(context, diagnostic));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ServletDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ServletDiagnosticsCollector.java
@@ -112,6 +112,25 @@ public class ServletDiagnosticsCollector extends AbstractDiagnosticsCollector {
                                 ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES, null,
                                 DiagnosticSeverity.Error));
                     }
+
+
+                    /* Filter implementation diagnostic check */
+                    PsiClass filterInterface = facade.findClass(ServletConstants.FILTER_FQ_NAME,
+                            GlobalSearchScope.allScope(type.getProject()));
+                    if (!type.isInheritor(filterInterface, true)) {
+                        diagnostics.add(createDiagnostic(type, unit,
+                                Messages.getMessage("WebServletMustImplementFilter"),
+                                ServletConstants.DIAGNOSTIC_CODE_FILTER, null, DiagnosticSeverity.Error));
+                    }
+
+                    /* Listener implementation diagnostic check */
+                    /*PsiClass listenerInterface = facade.findClass(ServletConstants.LISTENER_FQ_NAME,
+                            GlobalSearchScope.allScope(type.getProject()));
+                    if (!type.isInheritor(filterInterface, true)) {
+                        diagnostics.add(createDiagnostic(type, unit,
+                                Messages.getMessage("WebServletMustImplementListener"),
+                                ServletConstants.DIAGNOSTIC_CODE_LISTENER, null, DiagnosticSeverity.Error));
+                    }*/
                 }
             }
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -167,6 +167,16 @@
                                    targetDiagnostic="jakarta-jax_rs#NonPublicResourceMethod"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs.NonPublicResourceMethodQuickFix"/>
 
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-jax_rs#ImplementListener"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.ListenerImplementationQuickFix"/>
+
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-jax_rs#ImplementFilter"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet.FilterImplementationQuickFix"/>
+
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>
 

--- a/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -163,6 +163,8 @@ WebServletMustExtend = Annotated classes with @WebServlet must extend the HttpSe
 WebServletShouldExtend = Annotated classes with @WebServlet should extend the HttpServlet class.
 WebServletMustDefine = The @WebServlet annotation must define the attribute 'urlPatterns' or 'value'.
 WebServletCannotHaveBoth = The @WebServlet annotation cannot have both 'value' and 'urlPatterns' attributes specified at once.
+WebServletMustImplementFilter = Annotated classes with @WebServlet must implement the Filter interface.
+WebServletMustImplementListener = Annotated classes with @WebServlet must implement the Listener interface.
 
 # WebSocketDiagnosticsCollector
 WebSocketParamType = Invalid parameter type. When using {0}, parameter must be of type: \n- {1}\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -95,4 +95,56 @@ public class JakartaServletTest extends BaseJakartaTest {
         }
     }
 
+    @Test
+    public void implementFilter() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementFilter.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = JakartaForJavaAssert.d(5, 13, 34, "Annotated classes with @WebServlet must implement the Filter interface.",
+                DiagnosticSeverity.Error, "jakarta-servlet", "ImplementFilter");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        if (CHECK_CODE_ACTIONS) {
+            // test associated quick-fix code action
+            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+            TextEdit te = JakartaForJavaAssert.te(5, 34, 5, 34, " implements Filter");
+            CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontImplementFilter' implement 'Filter'", d, te);
+            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        }
+    }
+
+    @Test
+    public void implementListener() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementListener.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = JakartaForJavaAssert.d(5, 13, 34, "Annotated classes with @WebServlet must implement the Listener interface.",
+                DiagnosticSeverity.Error, "jakarta-servlet", "ImplementListener");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+        if (CHECK_CODE_ACTIONS) {
+        // test associated quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+        TextEdit te = JakartaForJavaAssert.te(5, 34, 5, 34, " implements Listener");
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontImplementListener' implement 'Listener'", d, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
+        }
+    }
+
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementFilter.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementFilter.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.servlet;
+
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet(name = "filterdemo", urlPatterns = { "/filter" })
+public class DontImplementFilter {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementListener.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/servlet/DontImplementListener.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.servlet;
+
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet(name = "listenerdemo", urlPatterns = { "/listener" })
+public class DontImplementListener {
+
+}


### PR DESCRIPTION
Part of #511 

- Refactored FilterImplementationQuickFix
- Refactored ListenerImplementationQuickFix
- Code action participants added to the plugin.xml
- Missing tests added for Filter and Listener implementation quickfixes
