### PR TITLE
Fixed Listener leak error with 232 version of maven-test-framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,11 +157,6 @@ test {
         showStandardStreams = true
         exceptionFormat = 'full'
     }
-
-    filter {
-        // disable lsp4jakarta integration tests until listener leak issue is resolved: https://github.com/OpenLiberty/liberty-tools-intellij/issues/541
-        excludeTestsMatching "io.openliberty.tools.intellij.lsp4jakarta.it.*"
-    }
 }
 
 tasks {

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -48,9 +48,7 @@ public abstract class BaseJakartaTest extends MavenImportingTestCase {
 
     @Override
     protected void setUpFixtures() throws Exception {
-        super.setUpFixtures();
-        //myTestFixture = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(getName()).getFixture();
-        //myTestFixture.setUp();
+        //Don't call super.setUpFixtures() here, that will create FocusListener leak.
         myProjectBuilder = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(getName());
         final JavaTestFixtureFactory factory = JavaTestFixtureFactory.getFixtureFactory();
         ModuleFixtureBuilder moduleBuilder = myProjectBuilder.addModule(JavaModuleFixtureBuilder.class);


### PR DESCRIPTION
Fixes #541 

Fixed Listener leak error with 232 version of maven-test-framework.
Enabled integration tests.