### PR TITLE
Check if an object is a LibertyModuleNode before trying to cast it.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -314,13 +314,15 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             }
 
             // select icon for node based on project type
-            LibertyModuleNode moduleNode = (LibertyModuleNode) value;
-            if (moduleNode.isGradleProjectType()) {
-                setIcon(LibertyPluginIcons.gradleIcon);
-            } else if (moduleNode.isMavenProjectType()) {
-                setIcon(LibertyPluginIcons.mavenIcon);
-            } else {
-                setIcon(LibertyPluginIcons.libertyIcon);
+            if (value instanceof LibertyModuleNode) {
+                LibertyModuleNode moduleNode = (LibertyModuleNode) value;
+                if (moduleNode.isGradleProjectType()) {
+                    setIcon(LibertyPluginIcons.gradleIcon);
+                } else if (moduleNode.isMavenProjectType()) {
+                    setIcon(LibertyPluginIcons.mavenIcon);
+                } else {
+                    setIcon(LibertyPluginIcons.libertyIcon);
+                }
             }
 
             return this;


### PR DESCRIPTION
Fixes #561 

Hopefully by avoiding the ClassCastException the IntelliJ framework can continue to render projects and it will not allow the project to disappear and reappear in the projects view. I was not able to reproduce the project disappear/reappear bug,