### PR TITLE
Remove recorder setup from test workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,8 +40,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: liberty-tools-intellij
-      - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v2
       - name: 'Install required integration test software'
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/setup.sh


### PR DESCRIPTION
Removes FFmpeg setup as it is not used to record the tests.