### PR TITLE
Upgrade to LSP4Jakarta 0.2.0. Unify MP / Jakarta EE completion support.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, code-action-unification ]
+    branches: [ main, useLSP4IJ1201 ]
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: MicroShed/lsp4ij
           path: lsp4ij
-          ref: q1101
+          ref: q1201
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation ('io.openliberty.tools:liberty-langserver:2.1-SNAPSHOT') {
         exclude group: 'org.eclipse.lsp4j'
     }
-    implementation ('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.1.1') {
+    implementation ('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.2.0') {
         exclude group: 'org.eclipse.lsp4mp'
         exclude group: 'org.eclipse.lsp4j'
     }
@@ -117,7 +117,7 @@ dependencies {
     lsp('io.openliberty.tools:liberty-langserver:2.1-SNAPSHOT:jar-with-dependencies') {
         transitive = false
     }
-    lsp('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.1.1:jar-with-dependencies') {
+    lsp('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.2.0:jar-with-dependencies') {
         transitive = false
     }
     implementation files(new File(buildDir, 'server')) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Red Hat, Inc. and others
+ * Copyright (c) 2019, 2024 Red Hat, Inc. and others
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -24,6 +24,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.*;
 import org.eclipse.lsp4jakarta.ls.api.JakartaLanguageClientAPI;
@@ -34,8 +35,6 @@ import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 import org.eclipse.lsp4mp.commons.utils.JSONUtility;
 import org.microshed.lsp4ij.client.CoalesceByKey;
 import org.microshed.lsp4ij.client.IndexAwareLanguageClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,54 +44,17 @@ import java.util.concurrent.CompletableFuture;
  * Adapted from https://github.com/redhat-developer/intellij-quarkus/blob/2585eb422beeb69631076d2c39196d6eca2f5f2e/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
  * to match LSP4MP, Language Server for MicroProfile
  */
-public class JakartaLanguageClient extends IndexAwareLanguageClient implements JakartaLanguageClientAPI, MicroProfileProjectService.Listener {
-  private static final Logger LOGGER = LoggerFactory.getLogger(JakartaLanguageClient.class);
+public final class JakartaLanguageClient extends IndexAwareLanguageClient implements JakartaLanguageClientAPI, MicroProfileProjectService.Listener {
 
   public JakartaLanguageClient(Project project) {
     super(project);
   }
 
-  // Support the message "jakarta/java/classpath"
-  /** public CompletableFuture<List<String>> getContextBasedFilter(JakartaClasspathParams classpathParams) {
-    String uri = classpathParams.getUri();
-    List<String> snippetContexts = classpathParams.getSnippetCtx();
-    Project project = getProject();
-    var coalesceBy = new CoalesceByKey("jakarta/java/classpath", uri, snippetContexts);
-    return runAsBackground("Computing Jakarta context",
-            monitor -> PropertiesManagerForJakarta.getInstance().getExistingContextsFromClassPath(uri, snippetContexts, project), coalesceBy);
-  } **/
-
-  // Support the message "jakarta/java/cursorcontext"
-  /** public CompletableFuture<JavaCursorContextResult> getJavaCursorContext(JakartaJavaCompletionParams params) {
-    var coalesceBy = new CoalesceByKey("jakarta/java/cursorcontext", params.getUri(), params.getPosition());
-    return runAsBackground("Computing Java cursor context",
-            monitor -> {
-              IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-              return PropertiesManagerForJakarta.getInstance().javaCursorContext(params, utils);
-            }, coalesceBy);
-  } **/
-
-  // Support the message "jakarta/java/diagnostics"
-  /** public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaDiagnosticsParams jakartaParams) {
-    var coalesceBy = new CoalesceByKey("jakarta/java/diagnostics", jakartaParams.getUris());
-    IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    return runAsBackground("Computing Jakarta Java diagnostics",
-            monitor -> PropertiesManagerForJakarta.getInstance().diagnostics(jakartaParams, utils), coalesceBy);
-  } **/
-
-  // Support the message "jakarta/java/codeaction
-  /** public CompletableFuture<List<CodeAction>> getCodeAction(JakartaJavaCodeActionParams params) {
-    IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/codeAction", params.getUri());
-    return runAsBackground("Computing Jakarta code actions",
-            monitor -> (List<CodeAction>) PropertiesManagerForJakarta.getInstance().getCodeAction(params, utils), coalesceBy);
-  } **/
-
   // Support the message "jakarta/java/diagnostics"
   @Override
   public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaJavaDiagnosticsParams jakartaJavaDiagnosticsParams) {
-    var coalesceBy = new CoalesceByKey("jakarta/java/diagnostics", jakartaJavaDiagnosticsParams.getUris());
-    IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    final var coalesceBy = new CoalesceByKey("jakarta/java/diagnostics", jakartaJavaDiagnosticsParams.getUris());
     return runAsBackground("Computing Jakarta Java diagnostics",
             monitor -> PropertiesManagerForJakarta.getInstance().diagnostics(jakartaJavaDiagnosticsParams, utils), coalesceBy);
   }
@@ -101,7 +63,7 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   @Override
   public CompletableFuture<List<CodeAction>> getJavaCodeAction(JakartaJavaCodeActionParams jakartaJavaCodeActionParams) {
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/codeAction", jakartaJavaCodeActionParams.getUri());
+    final var coalesceBy = new CoalesceByKey("jakarta/java/codeAction", jakartaJavaCodeActionParams.getUri());
     return runAsBackground("Computing Jakarta code actions",
             monitor -> (List<CodeAction>) PropertiesManagerForJakarta.getInstance().getCodeAction(jakartaJavaCodeActionParams, utils), coalesceBy);
   }
@@ -110,24 +72,31 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   @Override
   public CompletableFuture<CodeAction> resolveCodeAction(CodeAction codeAction) {
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/resolveCodeAction");
+    final var coalesceBy = new CoalesceByKey("jakarta/java/resolveCodeAction");
     return runAsBackground("Computing Java resolve code actions", monitor -> {
-      CodeActionResolveData data = JSONUtility.toModel(codeAction.getData(), CodeActionResolveData.class);
+      final CodeActionResolveData data = JSONUtility.toModel(codeAction.getData(), CodeActionResolveData.class);
       codeAction.setData(data);
       return PropertiesManagerForJakarta.getInstance().resolveCodeAction(codeAction, utils);
     }, coalesceBy);
   }
 
+  // Support the message "jakarta/java/completion"
   @Override
   public CompletableFuture<JakartaJavaCompletionResult> getJavaCompletion(JakartaJavaCompletionParams jakartaJavaCompletionParams) {
-    return null;
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    final var coalesceBy = new CoalesceByKey("jakarta/java/completion", jakartaJavaCompletionParams.getUri(), jakartaJavaCompletionParams.getPosition());
+    return runAsBackground("Computing Java completion", monitor -> {
+      final CompletionList completionList = PropertiesManagerForJakarta.getInstance().completion(jakartaJavaCompletionParams, utils);
+      final JavaCursorContextResult cursorContext = PropertiesManagerForJakarta.getInstance().javaCursorContext(jakartaJavaCompletionParams, utils);
+      return new JakartaJavaCompletionResult(completionList, cursorContext);
+    }, coalesceBy);
   }
 
   // Support the message "jakarta/java/projectLabels"
   @Override
   public CompletableFuture<ProjectLabelInfoEntry> getJavaProjectLabels(JakartaJavaProjectLabelsParams jakartaJavaProjectLabelsParams) {
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/projectLabels",
+    final var coalesceBy = new CoalesceByKey("jakarta/java/projectLabels",
             jakartaJavaProjectLabelsParams.getUri(), jakartaJavaProjectLabelsParams.getTypes());
     return runAsBackground("Computing Java projects labels",
             monitor -> adapt(ProjectLabelManager.getInstance().getProjectLabelInfo(adapt(jakartaJavaProjectLabelsParams), utils)), coalesceBy);
@@ -137,7 +106,7 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   @Override
   public CompletableFuture<List<ProjectLabelInfoEntry>> getAllJavaProjectLabels() {
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/workspaceLabels");
+    final var coalesceBy = new CoalesceByKey("jakarta/java/workspaceLabels");
     return runAsBackground("Computing All Java projects labels",
             monitor -> adapt(ProjectLabelManager.getInstance().getProjectLabelInfo(utils)), coalesceBy);
   }
@@ -146,7 +115,7 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   @Override
   public CompletableFuture<JakartaJavaFileInfo> getJavaFileInfo(JakartaJavaFileInfoParams jakartaJavaFileInfoParams) {
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
-    var coalesceBy = new CoalesceByKey("jakarta/java/fileInfo", jakartaJavaFileInfoParams.getUri());
+    final var coalesceBy = new CoalesceByKey("jakarta/java/fileInfo", jakartaJavaFileInfoParams.getUri());
     return runAsBackground("Computing Java file info",
             monitor -> adapt(PropertiesManagerForJava.getInstance().fileInfo(adapt(jakartaJavaFileInfoParams), utils)), coalesceBy);
   }
@@ -158,7 +127,6 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
 
   @Override
   public void sourceUpdated(List<Pair<Module, VirtualFile>> sources) {
-    int i = 0;
     // not needed for Jakarta LS
   }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
@@ -18,18 +18,26 @@ import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PropertiesManagerForJakarta;
 import io.openliberty.tools.intellij.lsp4mp.MicroProfileProjectService;
-import org.microshed.lsp4ij.client.CoalesceByKey;
-import org.microshed.lsp4ij.client.IndexAwareLanguageClient;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.ProjectLabelManager;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.PropertiesManagerForJava;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4jakarta.api.JakartaLanguageClientAPI;
 import org.eclipse.lsp4jakarta.commons.*;
+import org.eclipse.lsp4jakarta.ls.api.JakartaLanguageClientAPI;
+import org.eclipse.lsp4mp.commons.JavaFileInfo;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaFileInfoParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
+import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
+import org.eclipse.lsp4mp.commons.utils.JSONUtility;
+import org.microshed.lsp4ij.client.CoalesceByKey;
+import org.microshed.lsp4ij.client.IndexAwareLanguageClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -45,42 +53,102 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   }
 
   // Support the message "jakarta/java/classpath"
-  @Override
-  public CompletableFuture<List<String>> getContextBasedFilter(JakartaClasspathParams classpathParams) {
+  /** public CompletableFuture<List<String>> getContextBasedFilter(JakartaClasspathParams classpathParams) {
     String uri = classpathParams.getUri();
     List<String> snippetContexts = classpathParams.getSnippetCtx();
     Project project = getProject();
     var coalesceBy = new CoalesceByKey("jakarta/java/classpath", uri, snippetContexts);
     return runAsBackground("Computing Jakarta context",
             monitor -> PropertiesManagerForJakarta.getInstance().getExistingContextsFromClassPath(uri, snippetContexts, project), coalesceBy);
-  }
+  } **/
 
   // Support the message "jakarta/java/cursorcontext"
-  @Override
-  public CompletableFuture<JavaCursorContextResult> getJavaCursorContext(JakartaJavaCompletionParams params) {
+  /** public CompletableFuture<JavaCursorContextResult> getJavaCursorContext(JakartaJavaCompletionParams params) {
     var coalesceBy = new CoalesceByKey("jakarta/java/cursorcontext", params.getUri(), params.getPosition());
     return runAsBackground("Computing Java cursor context",
             monitor -> {
               IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
               return PropertiesManagerForJakarta.getInstance().javaCursorContext(params, utils);
             }, coalesceBy);
-  }
+  } **/
 
   // Support the message "jakarta/java/diagnostics"
-  @Override
-  public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaDiagnosticsParams jakartaParams) {
+  /** public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaDiagnosticsParams jakartaParams) {
     var coalesceBy = new CoalesceByKey("jakarta/java/diagnostics", jakartaParams.getUris());
     IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
     return runAsBackground("Computing Jakarta Java diagnostics",
             monitor -> PropertiesManagerForJakarta.getInstance().diagnostics(jakartaParams, utils), coalesceBy);
-  }
+  } **/
 
   // Support the message "jakarta/java/codeaction
-  public CompletableFuture<List<CodeAction>> getCodeAction(JakartaJavaCodeActionParams params) {
+  /** public CompletableFuture<List<CodeAction>> getCodeAction(JakartaJavaCodeActionParams params) {
     IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
     var coalesceBy = new CoalesceByKey("jakarta/java/codeAction", params.getUri());
     return runAsBackground("Computing Jakarta code actions",
-            monitor -> PropertiesManagerForJakarta.getInstance().getCodeAction(params, utils), coalesceBy);
+            monitor -> (List<CodeAction>) PropertiesManagerForJakarta.getInstance().getCodeAction(params, utils), coalesceBy);
+  } **/
+
+  // Support the message "jakarta/java/diagnostics"
+  @Override
+  public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaJavaDiagnosticsParams jakartaJavaDiagnosticsParams) {
+    var coalesceBy = new CoalesceByKey("jakarta/java/diagnostics", jakartaJavaDiagnosticsParams.getUris());
+    IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    return runAsBackground("Computing Jakarta Java diagnostics",
+            monitor -> PropertiesManagerForJakarta.getInstance().diagnostics(jakartaJavaDiagnosticsParams, utils), coalesceBy);
+  }
+
+  // Support the message "jakarta/java/codeaction"
+  @Override
+  public CompletableFuture<List<CodeAction>> getJavaCodeAction(JakartaJavaCodeActionParams jakartaJavaCodeActionParams) {
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    var coalesceBy = new CoalesceByKey("jakarta/java/codeAction", jakartaJavaCodeActionParams.getUri());
+    return runAsBackground("Computing Jakarta code actions",
+            monitor -> (List<CodeAction>) PropertiesManagerForJakarta.getInstance().getCodeAction(jakartaJavaCodeActionParams, utils), coalesceBy);
+  }
+
+  // Support the message "jakarta/java/resolveCodeAction"
+  @Override
+  public CompletableFuture<CodeAction> resolveCodeAction(CodeAction codeAction) {
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    var coalesceBy = new CoalesceByKey("jakarta/java/resolveCodeAction");
+    return runAsBackground("Computing Java resolve code actions", monitor -> {
+      CodeActionResolveData data = JSONUtility.toModel(codeAction.getData(), CodeActionResolveData.class);
+      codeAction.setData(data);
+      return PropertiesManagerForJakarta.getInstance().resolveCodeAction(codeAction, utils);
+    }, coalesceBy);
+  }
+
+  @Override
+  public CompletableFuture<JakartaJavaCompletionResult> getJavaCompletion(JakartaJavaCompletionParams jakartaJavaCompletionParams) {
+    return null;
+  }
+
+  // Support the message "jakarta/java/projectLabels"
+  @Override
+  public CompletableFuture<ProjectLabelInfoEntry> getJavaProjectLabels(JakartaJavaProjectLabelsParams jakartaJavaProjectLabelsParams) {
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    var coalesceBy = new CoalesceByKey("jakarta/java/projectLabels",
+            jakartaJavaProjectLabelsParams.getUri(), jakartaJavaProjectLabelsParams.getTypes());
+    return runAsBackground("Computing Java projects labels",
+            monitor -> adapt(ProjectLabelManager.getInstance().getProjectLabelInfo(adapt(jakartaJavaProjectLabelsParams), utils)), coalesceBy);
+  }
+
+  // Support the message "jakarta/java/workspaceLabels"
+  @Override
+  public CompletableFuture<List<ProjectLabelInfoEntry>> getAllJavaProjectLabels() {
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    var coalesceBy = new CoalesceByKey("jakarta/java/workspaceLabels");
+    return runAsBackground("Computing All Java projects labels",
+            monitor -> adapt(ProjectLabelManager.getInstance().getProjectLabelInfo(utils)), coalesceBy);
+  }
+
+  // Support the message "jakarta/java/fileInfo"
+  @Override
+  public CompletableFuture<JakartaJavaFileInfo> getJavaFileInfo(JakartaJavaFileInfoParams jakartaJavaFileInfoParams) {
+    final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+    var coalesceBy = new CoalesceByKey("jakarta/java/fileInfo", jakartaJavaFileInfoParams.getUri());
+    return runAsBackground("Computing Java file info",
+            monitor -> adapt(PropertiesManagerForJava.getInstance().fileInfo(adapt(jakartaJavaFileInfoParams), utils)), coalesceBy);
   }
 
   @Override
@@ -92,5 +160,50 @@ public class JakartaLanguageClient extends IndexAwareLanguageClient implements J
   public void sourceUpdated(List<Pair<Module, VirtualFile>> sources) {
     int i = 0;
     // not needed for Jakarta LS
+  }
+
+  // REVISIT: The "adapt" methods in this class are being used to convert between data structures
+  // from LSP4MP and LSPJakarta that are otherwise identical except for their class names. Once
+  // LSP4MP and LSP4Jakarta have a common/unified client API, the "adapt" methods can be removed.
+
+  private List<ProjectLabelInfoEntry> adapt(List<org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry> mpEntries) {
+    if (mpEntries != null) {
+      final List<ProjectLabelInfoEntry> jakartaEntries = new ArrayList<>();
+      mpEntries.forEach(x -> jakartaEntries.add(adapt(x)));
+      return jakartaEntries;
+    }
+    return null;
+  }
+
+  private ProjectLabelInfoEntry adapt(org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry mpEntry) {
+    return new ProjectLabelInfoEntry(mpEntry.getUri(), mpEntry.getName(), mpEntry.getLabels());
+  }
+
+  private MicroProfileJavaProjectLabelsParams adapt(JakartaJavaProjectLabelsParams params) {
+    if (params != null) {
+      final MicroProfileJavaProjectLabelsParams mpParams = new MicroProfileJavaProjectLabelsParams();
+      mpParams.setUri(params.getUri());
+      mpParams.setTypes(params.getTypes());
+      return mpParams;
+    }
+    return null;
+  }
+
+  private JakartaJavaFileInfo adapt(JavaFileInfo fileInfo) {
+    if (fileInfo != null) {
+      final JakartaJavaFileInfo jakartaFileInfo = new JakartaJavaFileInfo();
+      jakartaFileInfo.setPackageName(fileInfo.getPackageName());
+      return jakartaFileInfo;
+    }
+    return null;
+  }
+
+  private MicroProfileJavaFileInfoParams adapt(JakartaJavaFileInfoParams params) {
+    if (params != null) {
+      final MicroProfileJavaFileInfoParams mpParams = new MicroProfileJavaFileInfoParams();
+      mpParams.setUri(params.getUri());
+      return mpParams;
+    }
+    return null;
   }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JakartaProjectLabelProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JakartaProjectLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JakartaProjectLabelProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JakartaProjectLabelProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
+
+import com.intellij.openapi.module.Module;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.IProjectLabelProvider;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsConstants;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provides a Jakarta-specific label to a project if the project is a Jakarta
+ * project.
+ *
+ * Based on:
+ * https://github.com/eclipse/lsp4mp/blob/0.9.0/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/providers/MicroProfileProjectLabelProvider.java
+ *
+ * @author Angelo ZERR
+ *
+ */
+public class JakartaProjectLabelProvider implements IProjectLabelProvider {
+
+    /** Jakarta project label. */
+    public static final String JAKARTA_LABEL = "jakarta";
+
+    @Override
+    public List<String> getProjectLabels(Module project) {
+        if (isJakartaProject(project)) {
+            return Collections.singletonList(JAKARTA_LABEL);
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns true if <code>javaProject</code> is a Jakarta project. Returns
+     * false otherwise.
+     *
+     * @param javaProject the Java project to check
+     * @return true only if <code>javaProject</code> is a Jakarta project.
+     */
+    public static boolean isJakartaProject(Module javaProject) {
+        return PsiUtilsLSImpl.getInstance(javaProject.getProject()).findClass(javaProject, JaxRsConstants.JAKARTA_WS_RS_GET_ANNOTATION) != null;
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat, Inc.
+ * Copyright (c) 2020, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -13,38 +13,26 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.*;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.CompletionHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.DiagnosticsHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.CodeActionHandler;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.*;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeActionParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsSettings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PropertiesManagerForJakarta {
+public final class PropertiesManagerForJakarta {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesManagerForJakarta.class);
+    private static final String GROUP_NAME = "jakarta";
 
     private static final PropertiesManagerForJakarta INSTANCE = new PropertiesManagerForJakarta();
 
@@ -52,21 +40,23 @@ public class PropertiesManagerForJakarta {
         return INSTANCE;
     }
 
-    private List<DiagnosticsCollector> diagnosticsCollectors = new ArrayList<>();
+    private final CompletionHandler completionHandler;
+
     private final CodeActionHandler codeActionHandler;
 
     private final DiagnosticsHandler diagnosticsHandler;
 
     private PropertiesManagerForJakarta() {
-        codeActionHandler = new CodeActionHandler("jakarta");
-        diagnosticsHandler = new DiagnosticsHandler("jakarta");
+        completionHandler = new CompletionHandler(GROUP_NAME);
+        codeActionHandler = new CodeActionHandler(GROUP_NAME);
+        diagnosticsHandler = new DiagnosticsHandler(GROUP_NAME);
     }
 
     /**
      * Returns diagnostics for the given uris list.
      *
      * @param params the diagnostics parameters
-     * @param utils  the utilities class
+     * @param utils  the IPsiUtils
      * @return diagnostics for the given uris list.
      */
     public List<PublishDiagnosticsParams> diagnostics(JakartaJavaDiagnosticsParams params, IPsiUtils utils) {
@@ -74,67 +64,14 @@ public class PropertiesManagerForJakarta {
     }
 
     /**
-     * @brief Gets all snippet contexts that exist in the current project classpath
-     * @param uri             - String representing file from which to derive project
-     *                        classpath
-     * @param snippetContexts - get all the context fields from the snippets and
-     *                        check if they exist in this method
-     * @param project         - the IntelliJ project containing the uri
-     * @return List<String>
+     * Returns the CompletionItems given the completion item params
+     *
+     * @param params  the completion item params
+     * @param utils   the IPsiUtils
+     * @return the CompletionItems for the given the completion item params
      */
-    public List<String> getExistingContextsFromClassPath(String uri, List<String> snippetContexts, Project project) {
-        // ask the Java component if the classpath of the current module contains the specified Jakarta types.
-        JavaPsiFacade javaFacade = JavaPsiFacade.getInstance(project);
-        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
-        List<String> validCtx = new ArrayList<String>();
-        if (javaFacade != null && scope != null) {
-            for (String typeCtx : snippetContexts) {
-                Object type = ApplicationManager.getApplication().runReadAction((Computable<Object>) () -> javaFacade.findClass(typeCtx, scope));
-                validCtx.add(type != null ? typeCtx : null); // list will be the same size as input
-            }
-        } else {
-            // Error: none of these contexts will add to the completions
-            for (String typeCtx : snippetContexts) {
-                validCtx.add(null); // list will be the same size as input
-            }
-        }
-
-        // FOR NOW, append package name and class name to the list in order for LS to
-        // resolve ${packagename} and ${classname} variables
-        PsiFile typeRoot = ApplicationManager.getApplication().runReadAction((Computable<PsiFile>) () -> resolveTypeRoot(uri, project));
-        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
-            String className = "className";
-            String packageName = "packageName";
-            if (typeRoot instanceof PsiJavaFile) {
-                PsiJavaFile javaFile = (PsiJavaFile)typeRoot;
-                PsiClass[] classes = javaFile.getClasses();
-                if (classes.length > 0) {
-                    className = classes[0].getName();
-                } else {
-                    className = javaFile.getName();
-                    if (className.endsWith(".java") == true) {
-                        className = className.substring(0, className.length() - 5);
-                    }
-                }
-                packageName = javaFile.getPackageName();
-                if (packageName == null || packageName.isEmpty()) {
-                    Path path = javaFile.getParent().getVirtualFile().toNioPath(); // f=/U/me/proj/src/main/java/pkg  not /cls.java
-                    VirtualFile[] contentRoots = ProjectRootManager.getInstance(project).getContentSourceRoots();
-                    for (VirtualFile vf : contentRoots) {
-                        Path vfp = vf.toNioPath();
-                        if (path.startsWith(vfp)) {
-                            path = vfp.relativize(path); // remove the project part of the path
-                            break;
-                        }
-                    }
-                    packageName = path.toString().replace(File.separator, "."); // convert pkg1/pkg2
-                }
-            }
-            validCtx.add(packageName);
-            validCtx.add(className);
-            });
-
-        return validCtx;
+    public CompletionList completion(JakartaJavaCompletionParams params, IPsiUtils utils) {
+        return completionHandler.completion(adapt(params), utils);
     }
 
     /**
@@ -142,223 +79,59 @@ public class PropertiesManagerForJakarta {
      *
      * @param params  the completion params that provide the file and cursor
      *                position to get the context for
-     * @param utils   the jdt utils
+     * @param utils   the IPsiUtils
      * @return the cursor context for the given file and cursor position
      */
     public JavaCursorContextResult javaCursorContext(JakartaJavaCompletionParams params, IPsiUtils utils) {
-        JavaCursorContextResult result = ApplicationManager.getApplication().runReadAction((Computable<JavaCursorContextResult>) () -> {
-            String uri = params.getUri();
-            PsiFile typeRoot = resolveTypeRoot(uri, utils);
-            if (!(typeRoot instanceof PsiJavaFile)) {
-                return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
-            }
-            Document document = PsiDocumentManager.getInstance(typeRoot.getProject()).getDocument(typeRoot);
-            if (document == null) {
-                return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
-            }
-            Position completionPosition = params.getPosition();
-            int completionOffset = utils.toOffset(document, completionPosition.getLine(), completionPosition.getCharacter());
-
-            //CompilationUnit ast = ASTResolving.createQuickFixAST((ICompilationUnit) typeRoot);
-
-            JavaCursorContextKind kind = getJavaCursorContextKind((PsiJavaFile) typeRoot, completionOffset);
-            String prefix = getJavaCursorPrefix(document, completionOffset);
-            return new JavaCursorContextResult(kind, prefix);
-        });
-
-        return result;
-    }
-
-    private static JavaCursorContextKind getJavaCursorContextKind(PsiJavaFile javaFile, int completionOffset) {
-        if (javaFile.getClasses().length == 0) {
-            return JavaCursorContextKind.IN_EMPTY_FILE;
-        }
-
-        PsiElement element = javaFile.findElementAt(completionOffset);
-        PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiModifierListOwner.class);
-
-        if (parent == null) {
-            // We are likely before or after the class declaration
-            PsiElement firstClass = javaFile.getClasses()[0];
-
-            if (completionOffset <= firstClass.getTextOffset()) {
-                return JavaCursorContextKind.BEFORE_CLASS;
-            }
-
-            return JavaCursorContextKind.NONE;
-        }
-
-        if (parent instanceof PsiClass) {
-            PsiClass psiClass = (PsiClass) parent;
-            return getContextKindFromClass(completionOffset, psiClass, element);
-        }
-
-        if (parent instanceof PsiAnnotation) {
-            PsiAnnotation psiAnnotation = (PsiAnnotation) parent;
-            PsiAnnotationOwner annotationOwner = psiAnnotation.getOwner();
-            if (annotationOwner instanceof PsiClass) {
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_CLASS:JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
-            }
-            if (annotationOwner instanceof PsiMethod){
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_METHOD:JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
-            }
-            if (annotationOwner instanceof PsiField) {
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_FIELD:JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
-            }
-        }
-
-        if (parent instanceof PsiMethod) {
-            PsiMethod psiMethod = (PsiMethod) parent;
-            if (completionOffset == psiMethod.getTextRange().getStartOffset()) {
-                return JavaCursorContextKind.BEFORE_METHOD;
-            }
-            int methodStartOffset = getMethodStartOffset(psiMethod);
-            if (completionOffset <= methodStartOffset) {
-                if (psiMethod.getAnnotations().length > 0) {
-                    return JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
-                }
-                return JavaCursorContextKind.BEFORE_METHOD;
-            }
-        }
-
-        if (parent instanceof PsiField) {
-            PsiField psiField = (PsiField) parent;
-            if (completionOffset == psiField.getTextRange().getStartOffset()) {
-                return JavaCursorContextKind.BEFORE_FIELD;
-            }
-            int fieldStartOffset = getFieldStartOffset(psiField);
-            if (completionOffset <= fieldStartOffset) {
-                if (psiField.getAnnotations().length > 0) {
-                    return JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
-                }
-                return JavaCursorContextKind.BEFORE_FIELD;
-            }
-        }
-
-        return JavaCursorContextKind.NONE;
-    }
-
-    private static JavaCursorContextKind getContextKindFromClass(int completionOffset, PsiClass psiClass, PsiElement element) {
-        if (completionOffset <= psiClass.getTextRange().getStartOffset()) {
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-        int classStartOffset = getClassStartOffset(psiClass);
-        if (completionOffset <= classStartOffset) {
-            if (psiClass.getAnnotations().length > 0) {
-                return JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
-            }
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-
-        PsiElement nextElement = element.getNextSibling();
-
-        if (nextElement instanceof  PsiField) {
-            return JavaCursorContextKind.BEFORE_FIELD;
-        }
-        if (nextElement instanceof  PsiMethod) {
-            return JavaCursorContextKind.BEFORE_METHOD;
-        }
-        if (nextElement instanceof  PsiClass) {
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-
-        return JavaCursorContextKind.IN_CLASS;
-    }
-    private static int getClassStartOffset(PsiClass psiClass) {
-        int startOffset = psiClass.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiClass);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-        return startOffset;
-    }
-
-    private static int getMethodStartOffset(PsiMethod psiMethod) {
-        int startOffset = psiMethod.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiMethod);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-
-        PsiTypeElement returnTypeElement = psiMethod.getReturnTypeElement();
-        if (returnTypeElement != null) {
-            int returnTypeEndOffset = returnTypeElement.getTextRange().getStartOffset();
-            startOffset = Math.min(startOffset, returnTypeEndOffset);
-        }
-
-        return startOffset;
-    }
-
-    private static int getFieldStartOffset(PsiField psiField) {
-        int startOffset = psiField.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiField);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-
-        PsiTypeElement typeElement = psiField.getTypeElement();
-        if (typeElement != null) {
-            int typeElementOffset = typeElement.getTextRange().getStartOffset();
-            startOffset = Math.min(startOffset, typeElementOffset);
-        }
-
-        return startOffset;
-    }
-
-    private static int getFirstKeywordOffset(PsiModifierListOwner modifierOwner) {
-        PsiModifierList modifierList = modifierOwner.getModifierList();
-        if (modifierList != null) {
-            PsiElement[] modifiers = modifierList.getChildren();
-            for (PsiElement modifier : modifiers) {
-                if (modifier instanceof PsiKeyword) {
-                    return modifier.getTextRange().getStartOffset();
-                }
-            }
-        }
-        return -1;
-    }
-
-    private static String getJavaCursorPrefix(Document document, int completionOffset) {
-        String fileContents = document.getText();
-        int i;
-        for (i = completionOffset; i > 0 && !Character.isWhitespace(fileContents.charAt(i - 1)); i--) {
-        }
-        return fileContents.substring(i, completionOffset);
+        return adapt(completionHandler.javaCursorContext(adapt(params), utils));
     }
 
     /**
-     * Given the uri return a {@link PsiFile}. May return null if it can not
-     * associate the uri with a Java file or class file.
+     * Returns the list of code actions for the given diagnostics. The code
+     * actions in this list may have already been resolved, or they may be
+     * resolved later.
      *
-     * @param uri
-     * @param utils   JDT LS utilities
-     * @return compilation unit
+     * @param params  the code action parameters
+     * @param utils   the IPsiUtils
+     * @return the list of code actions for the given diagnostics
      */
-    private static PsiFile resolveTypeRoot(String uri, IPsiUtils utils) {
-        return utils.resolveCompilationUnit(uri);
-    }
-
-    private static PsiFile resolveTypeRoot(String uri, Project project) {
-        IPsiUtils utils = PsiUtilsLSImpl.getInstance(project);
-        return resolveTypeRoot(uri, utils);
-    }
-
     public List<? extends CodeAction> getCodeAction(JakartaJavaCodeActionParams params, IPsiUtils utils) {
         return ApplicationManager.getApplication().runReadAction((Computable<List<? extends CodeAction>>) () ->
                 codeActionHandler.codeAction(adapt(params), utils));
     }
 
+    /**
+     * Resolves and returns the given code action.
+     *
+     * @param unresolved the unresolved code action
+     * @param utils      the IPsiUtils
+     * @return the resolved code action
+     */
     public CodeAction resolveCodeAction(CodeAction unresolved, IPsiUtils utils) {
         return ApplicationManager.getApplication().runReadAction((Computable<CodeAction>) () ->
                 codeActionHandler.resolveCodeAction(unresolved, utils));
     }
 
+    // REVISIT: The "adapt" methods in this class are being used to convert between data structures
+    // from LSP4MP and LSPJakarta that are otherwise identical except for their class names. Once
+    // LSP4MP and LSP4Jakarta have a common/unified client API, the "adapt" methods can be removed.
+
+    private MicroProfileJavaCompletionParams adapt(JakartaJavaCompletionParams params) {
+        return new MicroProfileJavaCompletionParams(params.getUri(), params.getPosition());
+    }
+
+    private JavaCursorContextResult adapt(org.eclipse.lsp4mp.commons.JavaCursorContextResult contextResult) {
+        if (contextResult != null) {
+            var kind = contextResult.getKind();
+            return new JavaCursorContextResult(JavaCursorContextKind.forValue(kind.getValue()), contextResult.getPrefix());
+        }
+        return null;
+    }
+
     private MicroProfileJavaDiagnosticsParams adapt(JakartaJavaDiagnosticsParams params) {
+        JakartaJavaDiagnosticsSettings settings = params.getSettings();
         MicroProfileJavaDiagnosticsParams mpParams = new MicroProfileJavaDiagnosticsParams(params.getUris(),
-                new MicroProfileJavaDiagnosticsSettings(Collections.emptyList()));
+                new MicroProfileJavaDiagnosticsSettings(settings != null ? settings.getPatterns() : Collections.emptyList()));
         DocumentFormat df = params.getDocumentFormat();
         mpParams.setDocumentFormat(df != null ? org.eclipse.lsp4mp.commons.DocumentFormat.forValue(df.getValue()) : null);
         return mpParams;
@@ -367,7 +140,7 @@ public class PropertiesManagerForJakarta {
     private MicroProfileJavaCodeActionParams adapt(JakartaJavaCodeActionParams params) {
         MicroProfileJavaCodeActionParams mpParams = new MicroProfileJavaCodeActionParams(params.getTextDocument(), params.getRange(), params.getContext());
         mpParams.setResourceOperationSupported(params.isResourceOperationSupported());
-        mpParams.setResolveSupported(params.isResourceOperationSupported());
+        mpParams.setResolveSupported(params.isResolveSupported());
         return mpParams;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat, Inc.
+ * Copyright (c) 2020, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -19,26 +19,18 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.DiagnosticsHandler;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codelens.IJavaCodeLensParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codelens.JavaCodeLensContext;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.IJavaCompletionParticipant;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.JavaCompletionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.CompletionHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.definition.IJavaDefinitionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.definition.JavaDefinitionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.DiagnosticsHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.hover.IJavaHoverParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.hover.JavaHoverContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.CodeActionHandler;
-import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.CodeLens;
-import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4mp.commons.*;
-import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +48,10 @@ import java.util.stream.Collectors;
  * @see <a href="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerForJava.java">https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/PropertiesManagerForJava.java</a>
  *
  */
-public class PropertiesManagerForJava {
+public final class PropertiesManagerForJava {
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesManagerForJava.class);
+
+    private static final String GROUP_NAME = "mp";
 
     private static final PropertiesManagerForJava INSTANCE = new PropertiesManagerForJava();
 
@@ -65,13 +59,16 @@ public class PropertiesManagerForJava {
         return INSTANCE;
     }
 
+    private final CompletionHandler completionHandler;
+
     private final CodeActionHandler codeActionHandler;
 
     private final DiagnosticsHandler diagnosticsHandler;
 
     private PropertiesManagerForJava() {
-        this.codeActionHandler = new CodeActionHandler("mp");
-        this.diagnosticsHandler = new DiagnosticsHandler("mp");
+        this.completionHandler = new CompletionHandler(GROUP_NAME);
+        this.codeActionHandler = new CodeActionHandler(GROUP_NAME);
+        this.diagnosticsHandler = new DiagnosticsHandler(GROUP_NAME);
     }
 
     /**
@@ -155,49 +152,7 @@ public class PropertiesManagerForJava {
      * @return the CompletionItems for the given the completion item params
      */
     public CompletionList completion(MicroProfileJavaCompletionParams params, IPsiUtils utils) {
-        return ApplicationManager.getApplication().runReadAction((Computable<CompletionList>) () -> {
-            try {
-                String uri = params.getUri();
-                PsiFile typeRoot = resolveTypeRoot(uri, utils);
-                if (typeRoot == null) {
-                    return null;
-                }
-
-                Module module = utils.getModule(uri);
-                if (module == null) {
-                    return null;
-                }
-
-                Position completionPosition = params.getPosition();
-                int completionOffset = utils.toOffset(typeRoot, completionPosition.getLine(),
-                        completionPosition.getCharacter());
-
-                List<CompletionItem> completionItems = new ArrayList<>();
-                JavaCompletionContext completionContext = new JavaCompletionContext(uri, typeRoot, utils, module, completionOffset);
-
-                List<IJavaCompletionParticipant> completions = IJavaCompletionParticipant.EP_NAME.extensions()
-                        .filter(completion -> completion.isAdaptedForCompletion(completionContext))
-                        .collect(Collectors.toList());
-
-                if (completions.isEmpty()) {
-                    return null;
-                }
-
-                completions.forEach(completion -> {
-                    List<? extends CompletionItem> collectedCompletionItems = completion.collectCompletionItems(completionContext);
-                    if (collectedCompletionItems != null) {
-                        completionItems.addAll(collectedCompletionItems);
-                    }
-                });
-
-                CompletionList completionList = new CompletionList();
-                completionList.setItems(completionItems);
-                return completionList;
-            } catch (IOException e) {
-                LOGGER.warn(e.getLocalizedMessage(), e);
-                return null;
-            }
-        });
+        return completionHandler.completion(params, utils);
     }
 
     /**
@@ -317,182 +272,7 @@ public class PropertiesManagerForJava {
      * @return the cursor context for the given file and cursor position
      */
     public JavaCursorContextResult javaCursorContext(MicroProfileJavaCompletionParams params, IPsiUtils utils) {
-        String uri = params.getUri();
-        PsiFile typeRoot = resolveTypeRoot(uri, utils);
-        if (!(typeRoot instanceof PsiJavaFile)) {
-            return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
-        }
-        Document document = PsiDocumentManager.getInstance(typeRoot.getProject()).getDocument(typeRoot);
-        if (document == null) {
-            return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
-        }
-        Position completionPosition = params.getPosition();
-        int completionOffset = utils.toOffset(document, completionPosition.getLine(), completionPosition.getCharacter());
-
-        JavaCursorContextKind kind = getJavaCursorContextKind((PsiJavaFile) typeRoot, completionOffset);
-        String prefix = getJavaCursorPrefix(document, completionOffset);
-
-        return new JavaCursorContextResult(kind, prefix);
-    }
-
-    private static @NotNull JavaCursorContextKind getJavaCursorContextKind(PsiJavaFile javaFile, int completionOffset) {
-        if (javaFile.getClasses().length == 0) {
-            return JavaCursorContextKind.IN_EMPTY_FILE;
-        }
-
-        PsiElement element = javaFile.findElementAt(completionOffset);
-        PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiModifierListOwner.class);
-
-        if (parent == null) {
-            // We are likely before or after the class declaration
-            PsiElement firstClass = javaFile.getClasses()[0];
-
-            if (completionOffset <= firstClass.getTextOffset()) {
-                return JavaCursorContextKind.BEFORE_CLASS;
-            }
-
-            return JavaCursorContextKind.NONE;
-        }
-
-        if (parent instanceof PsiClass) {
-            PsiClass psiClass = (PsiClass) parent;
-            return getContextKindFromClass(completionOffset, psiClass, element);
-        }
-        if (parent instanceof PsiAnnotation) {
-            PsiAnnotation psiAnnotation = (PsiAnnotation) parent;
-            @Nullable PsiAnnotationOwner annotationOwner = psiAnnotation.getOwner();
-            if (annotationOwner instanceof PsiClass) {
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_CLASS:JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
-            }
-            if (annotationOwner instanceof PsiMethod){
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_METHOD:JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
-            }
-            if (annotationOwner instanceof PsiField) {
-                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_FIELD:JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
-            }
-        }
-        if (parent instanceof PsiMethod) {
-            PsiMethod psiMethod = (PsiMethod) parent;
-            if (completionOffset == psiMethod.getTextRange().getStartOffset()) {
-                return JavaCursorContextKind.BEFORE_METHOD;
-            }
-            int methodStartOffset = getMethodStartOffset(psiMethod);
-            if (completionOffset <= methodStartOffset) {
-                if (psiMethod.getAnnotations().length > 0) {
-                    return JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
-                }
-                return JavaCursorContextKind.BEFORE_METHOD;
-            }
-        }
-
-        if (parent instanceof PsiField) {
-            PsiField psiField = (PsiField) parent;
-            if (completionOffset == psiField.getTextRange().getStartOffset()) {
-                return JavaCursorContextKind.BEFORE_FIELD;
-            }
-            int fieldStartOffset = getFieldStartOffset(psiField);
-            if (completionOffset <= fieldStartOffset) {
-                if (psiField.getAnnotations().length > 0) {
-                    return JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
-                }
-                return JavaCursorContextKind.BEFORE_FIELD;
-            }
-        }
-
-        return JavaCursorContextKind.NONE;
-    }
-
-    @NotNull
-    private static JavaCursorContextKind getContextKindFromClass(int completionOffset, PsiClass psiClass, PsiElement element) {
-        if (completionOffset <= psiClass.getTextRange().getStartOffset()) {
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-        int classStartOffset = getClassStartOffset(psiClass);
-        if (completionOffset <= classStartOffset) {
-            if (psiClass.getAnnotations().length > 0) {
-                return JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
-            }
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-
-        PsiElement nextElement = element.getNextSibling();
-
-        if (nextElement instanceof  PsiField) {
-            return JavaCursorContextKind.BEFORE_FIELD;
-        }
-        if (nextElement instanceof  PsiMethod) {
-            return JavaCursorContextKind.BEFORE_METHOD;
-        }
-        if (nextElement instanceof  PsiClass) {
-            return JavaCursorContextKind.BEFORE_CLASS;
-        }
-
-        return JavaCursorContextKind.IN_CLASS;
-    }
-
-    private static @NotNull String getJavaCursorPrefix(@NotNull Document document, int completionOffset) {
-        String fileContents = document.getText();
-        int i;
-        for (i = completionOffset; i > 0 && !Character.isWhitespace(fileContents.charAt(i - 1)); i--) {
-        }
-        return fileContents.substring(i, completionOffset);
-    }
-
-    private static int getMethodStartOffset(PsiMethod psiMethod) {
-        int startOffset = psiMethod.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiMethod);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-
-        PsiTypeElement returnTypeElement = psiMethod.getReturnTypeElement();
-        if (returnTypeElement != null) {
-            int returnTypeEndOffset = returnTypeElement.getTextRange().getStartOffset();
-            startOffset = Math.min(startOffset, returnTypeEndOffset);
-        }
-
-        return startOffset;
-    }
-
-    private static int getClassStartOffset(PsiClass psiClass) {
-        int startOffset = psiClass.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiClass);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-        return startOffset;
-    }
-
-    private static int getFieldStartOffset(PsiField psiField) {
-        int startOffset = psiField.getTextOffset();
-
-        int modifierStartOffset = getFirstKeywordOffset(psiField);
-        if (modifierStartOffset > -1) {
-            return Math.min(startOffset, modifierStartOffset);
-        }
-
-        PsiTypeElement typeElement = psiField.getTypeElement();
-        if (typeElement != null) {
-            int typeElementOffset = typeElement.getTextRange().getStartOffset();
-            startOffset = Math.min(startOffset, typeElementOffset);
-        }
-
-        return startOffset;
-    }
-
-    private static int getFirstKeywordOffset(PsiModifierListOwner modifierOwner) {
-        PsiModifierList modifierList = modifierOwner.getModifierList();
-        if (modifierList != null) {
-            PsiElement[] modifiers = modifierList.getChildren();
-            for (PsiElement modifier : modifiers) {
-                if (modifier instanceof PsiKeyword) {
-                    return modifier.getTextRange().getStartOffset();
-                }
-            }
-        }
-        return -1;
+        return completionHandler.javaCursorContext(params, utils);
     }
 
     @Nullable

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
@@ -1,0 +1,292 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.Computable;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.completion.JavaCompletionDefinition;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4mp.commons.JavaCursorContextKind;
+import org.eclipse.lsp4mp.commons.JavaCursorContextResult;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class CompletionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompletionHandler.class);
+
+    private final String group;
+
+    public CompletionHandler(String group) {
+        this.group = group;
+    }
+
+    /**
+     * Returns the CompletionItems given the completion item params
+     *
+     * @param params  the completion item params
+     * @param utils   the IJDTUtils
+     * @return the CompletionItems for the given the completion item params
+     */
+    public CompletionList completion(MicroProfileJavaCompletionParams params, IPsiUtils utils) {
+        return ApplicationManager.getApplication().runReadAction((Computable<CompletionList>) () -> {
+            try {
+                String uri = params.getUri();
+                PsiFile typeRoot = resolveTypeRoot(uri, utils);
+                if (typeRoot == null) {
+                    return null;
+                }
+
+                Module module = utils.getModule(uri);
+                if (module == null) {
+                    return null;
+                }
+
+                Position completionPosition = params.getPosition();
+                int completionOffset = utils.toOffset(typeRoot, completionPosition.getLine(),
+                        completionPosition.getCharacter());
+
+                List<CompletionItem> completionItems = new ArrayList<>();
+                JavaCompletionContext completionContext = new JavaCompletionContext(uri, typeRoot, utils, module, completionOffset);
+
+                List<JavaCompletionDefinition> completions = JavaCompletionDefinition.EP_NAME.extensions()
+                        .filter(definition -> group.equals(definition.getGroup()))
+                        .filter(completion -> completion.isAdaptedForCompletion(completionContext))
+                        .collect(Collectors.toList());
+
+                if (completions.isEmpty()) {
+                    return null;
+                }
+
+                completions.forEach(completion -> {
+                    List<? extends CompletionItem> collectedCompletionItems = completion.collectCompletionItems(completionContext);
+                    if (collectedCompletionItems != null) {
+                        completionItems.addAll(collectedCompletionItems);
+                    }
+                });
+
+                CompletionList completionList = new CompletionList();
+                completionList.setItems(completionItems);
+                return completionList;
+            } catch (IOException e) {
+                LOGGER.warn(e.getLocalizedMessage(), e);
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Returns the cursor context for the given file and cursor position.
+     *
+     * @param params  the completion params that provide the file and cursor
+     *                position to get the context for
+     * @param utils   the jdt utils
+     * @return the cursor context for the given file and cursor position
+     */
+    public JavaCursorContextResult javaCursorContext(MicroProfileJavaCompletionParams params, IPsiUtils utils) {
+        String uri = params.getUri();
+        PsiFile typeRoot = resolveTypeRoot(uri, utils);
+        if (!(typeRoot instanceof PsiJavaFile)) {
+            return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
+        }
+        Document document = PsiDocumentManager.getInstance(typeRoot.getProject()).getDocument(typeRoot);
+        if (document == null) {
+            return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
+        }
+        Position completionPosition = params.getPosition();
+        int completionOffset = utils.toOffset(document, completionPosition.getLine(), completionPosition.getCharacter());
+
+        JavaCursorContextKind kind = getJavaCursorContextKind((PsiJavaFile) typeRoot, completionOffset);
+        String prefix = getJavaCursorPrefix(document, completionOffset);
+
+        return new JavaCursorContextResult(kind, prefix);
+    }
+
+    private static @NotNull JavaCursorContextKind getJavaCursorContextKind(PsiJavaFile javaFile, int completionOffset) {
+        if (javaFile.getClasses().length == 0) {
+            return JavaCursorContextKind.IN_EMPTY_FILE;
+        }
+
+        PsiElement element = javaFile.findElementAt(completionOffset);
+        PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiModifierListOwner.class);
+
+        if (parent == null) {
+            // We are likely before or after the class declaration
+            PsiElement firstClass = javaFile.getClasses()[0];
+
+            if (completionOffset <= firstClass.getTextOffset()) {
+                return JavaCursorContextKind.BEFORE_CLASS;
+            }
+
+            return JavaCursorContextKind.NONE;
+        }
+
+        if (parent instanceof PsiClass) {
+            PsiClass psiClass = (PsiClass) parent;
+            return getContextKindFromClass(completionOffset, psiClass, element);
+        }
+        if (parent instanceof PsiAnnotation) {
+            PsiAnnotation psiAnnotation = (PsiAnnotation) parent;
+            @Nullable PsiAnnotationOwner annotationOwner = psiAnnotation.getOwner();
+            if (annotationOwner instanceof PsiClass) {
+                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_CLASS:JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
+            }
+            if (annotationOwner instanceof PsiMethod){
+                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_METHOD:JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
+            }
+            if (annotationOwner instanceof PsiField) {
+                return (psiAnnotation.getStartOffsetInParent() == 0)? JavaCursorContextKind.BEFORE_FIELD:JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
+            }
+        }
+        if (parent instanceof PsiMethod) {
+            PsiMethod psiMethod = (PsiMethod) parent;
+            if (completionOffset == psiMethod.getTextRange().getStartOffset()) {
+                return JavaCursorContextKind.BEFORE_METHOD;
+            }
+            int methodStartOffset = getMethodStartOffset(psiMethod);
+            if (completionOffset <= methodStartOffset) {
+                if (psiMethod.getAnnotations().length > 0) {
+                    return JavaCursorContextKind.IN_METHOD_ANNOTATIONS;
+                }
+                return JavaCursorContextKind.BEFORE_METHOD;
+            }
+        }
+
+        if (parent instanceof PsiField) {
+            PsiField psiField = (PsiField) parent;
+            if (completionOffset == psiField.getTextRange().getStartOffset()) {
+                return JavaCursorContextKind.BEFORE_FIELD;
+            }
+            int fieldStartOffset = getFieldStartOffset(psiField);
+            if (completionOffset <= fieldStartOffset) {
+                if (psiField.getAnnotations().length > 0) {
+                    return JavaCursorContextKind.IN_FIELD_ANNOTATIONS;
+                }
+                return JavaCursorContextKind.BEFORE_FIELD;
+            }
+        }
+
+        return JavaCursorContextKind.NONE;
+    }
+
+    @NotNull
+    private static JavaCursorContextKind getContextKindFromClass(int completionOffset, PsiClass psiClass, PsiElement element) {
+        if (completionOffset <= psiClass.getTextRange().getStartOffset()) {
+            return JavaCursorContextKind.BEFORE_CLASS;
+        }
+        int classStartOffset = getClassStartOffset(psiClass);
+        if (completionOffset <= classStartOffset) {
+            if (psiClass.getAnnotations().length > 0) {
+                return JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
+            }
+            return JavaCursorContextKind.BEFORE_CLASS;
+        }
+
+        PsiElement nextElement = element.getNextSibling();
+
+        if (nextElement instanceof  PsiField) {
+            return JavaCursorContextKind.BEFORE_FIELD;
+        }
+        if (nextElement instanceof  PsiMethod) {
+            return JavaCursorContextKind.BEFORE_METHOD;
+        }
+        if (nextElement instanceof  PsiClass) {
+            return JavaCursorContextKind.BEFORE_CLASS;
+        }
+
+        return JavaCursorContextKind.IN_CLASS;
+    }
+
+    private static @NotNull String getJavaCursorPrefix(@NotNull Document document, int completionOffset) {
+        String fileContents = document.getText();
+        int i;
+        for (i = completionOffset; i > 0 && !Character.isWhitespace(fileContents.charAt(i - 1)); i--) {
+        }
+        return fileContents.substring(i, completionOffset);
+    }
+
+    private static int getMethodStartOffset(PsiMethod psiMethod) {
+        int startOffset = psiMethod.getTextOffset();
+
+        int modifierStartOffset = getFirstKeywordOffset(psiMethod);
+        if (modifierStartOffset > -1) {
+            return Math.min(startOffset, modifierStartOffset);
+        }
+
+        PsiTypeElement returnTypeElement = psiMethod.getReturnTypeElement();
+        if (returnTypeElement != null) {
+            int returnTypeEndOffset = returnTypeElement.getTextRange().getStartOffset();
+            startOffset = Math.min(startOffset, returnTypeEndOffset);
+        }
+
+        return startOffset;
+    }
+
+    private static int getClassStartOffset(PsiClass psiClass) {
+        int startOffset = psiClass.getTextOffset();
+
+        int modifierStartOffset = getFirstKeywordOffset(psiClass);
+        if (modifierStartOffset > -1) {
+            return Math.min(startOffset, modifierStartOffset);
+        }
+        return startOffset;
+    }
+
+    private static int getFieldStartOffset(PsiField psiField) {
+        int startOffset = psiField.getTextOffset();
+
+        int modifierStartOffset = getFirstKeywordOffset(psiField);
+        if (modifierStartOffset > -1) {
+            return Math.min(startOffset, modifierStartOffset);
+        }
+
+        PsiTypeElement typeElement = psiField.getTypeElement();
+        if (typeElement != null) {
+            int typeElementOffset = typeElement.getTextRange().getStartOffset();
+            startOffset = Math.min(startOffset, typeElementOffset);
+        }
+
+        return startOffset;
+    }
+
+    private static int getFirstKeywordOffset(PsiModifierListOwner modifierOwner) {
+        PsiModifierList modifierList = modifierOwner.getModifierList();
+        if (modifierList != null) {
+            PsiElement[] modifiers = modifierList.getChildren();
+            for (PsiElement modifier : modifiers) {
+                if (modifier instanceof PsiKeyword) {
+                    return modifier.getTextRange().getStartOffset();
+                }
+            }
+        }
+        return -1;
+    }
+
+    // REVISIT: Make this a public method on a common utility class?
+    private static PsiFile resolveTypeRoot(String uri, IPsiUtils utils) {
+        return utils.resolveCompilationUnit(uri);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2021, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,6 @@ import org.eclipse.lsp4j.CompletionItem;
  * @author datho7561
  */
 public interface IJavaCompletionParticipant {
-	public static final ExtensionPointName<IJavaCompletionParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaCompletionParticipant");
 
 	/**
 	 * Returns true if this completion feature should be active in this context, and false otherwise

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class DiagnosticsHandler {
+public final class DiagnosticsHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsHandler.class);
 
@@ -73,8 +73,8 @@ public class DiagnosticsHandler {
                 // Collect all adapted diagnostic definitions
                 JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, module, documentFormat, settings);
                 List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.extensions()
-                        .filter(definition -> definition.isAdaptedForDiagnostics(context))
                         .filter(definition -> group.equals(definition.getGroup()))
+                        .filter(definition -> definition.isAdaptedForDiagnostics(context))
                         .collect(Collectors.toList());
                 if (definitions.isEmpty()) {
                     return;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html
@@ -11,10 +11,9 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics;
 
-import java.util.List;
-
-import com.intellij.openapi.extensions.ExtensionPointName;
 import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.List;
 
 /**
  * Java diagnostics participants API.
@@ -24,8 +23,6 @@ import org.eclipse.lsp4j.Diagnostic;
  *
  */
 public interface IJavaDiagnosticsParticipant {
-
-	public static final ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaDiagnosticsParticipant");
 
 	/**
 	 * Returns true if diagnostics must be collected for the given context and false

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * @author Angelo ZERR
  *
  */
-public class CodeActionHandler {
+public final class CodeActionHandler {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CodeActionHandler.class);
 	private final String group;
@@ -99,8 +99,8 @@ public class CodeActionHandler {
 			for (String codeActionKind : codeActionKinds) {
 				// Get list of code action definition for the given kind
 				List<JavaCodeActionDefinition> codeActionDefinitions = JavaCodeActionDefinition.EP.extensions()
-						.filter(definition -> definition.isAdaptedForCodeAction(context))
 						.filter(definition -> group.equals(definition.getGroup()))
+						.filter(definition -> definition.isAdaptedForCodeAction(context))
 						.filter(definition -> codeActionKind.equals(definition.getKind()))
 						.collect(Collectors.toList());
 				if (codeActionDefinitions != null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.completion;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.serviceContainer.BaseKeyedLazyInstance;
+import com.intellij.util.xmlb.annotations.Attribute;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.IJavaCompletionParticipant;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.JavaCompletionContext;
+import org.eclipse.lsp4j.CompletionItem;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Wrapper class around {@link IJavaCompletionParticipant} participants.
+ */
+public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaCompletionParticipant>
+        implements IJavaCompletionParticipant {
+
+    public static final ExtensionPointName<JavaCompletionDefinition> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaCompletionParticipant");
+
+    private static final Logger LOGGER = Logger.getLogger(JavaCompletionDefinition.class.getName());
+    private static final String GROUP_ATTR = "group";
+    private static final String IMPLEMENTATION_CLASS_ATTR = "implementationClass";
+
+    @Attribute(GROUP_ATTR)
+    private String group;
+
+    @Attribute(IMPLEMENTATION_CLASS_ATTR)
+    public String implementationClass;
+
+    @Override
+    public boolean isAdaptedForCompletion(JavaCompletionContext context) {
+        try {
+            return getInstance().isAdaptedForCompletion(context);
+        }
+        catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling isAdaptedForCompletion", e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<? extends CompletionItem> collectCompletionItems(JavaCompletionContext context) {
+        try {
+            return getInstance().collectCompletionItems(context);
+        }
+        catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error while calling collectCompletionItems", e);
+            return Collections.emptyList();
+        }
+    }
+
+    public @Nullable String getGroup() {
+        return group;
+    }
+
+    @Override
+    protected @Nullable String getImplementationClassName() {
+        return implementationClass;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,7 @@
         <extensionPoint name="javaDefinitionParticipant"
                         interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.definition.IJavaDefinitionParticipant"/>
         <extensionPoint name="javaCompletionParticipant"
-                        interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.IJavaCompletionParticipant"/>
+                        beanClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.completion.JavaCompletionDefinition"/>
         <extensionPoint name="javaCodeLensParticipant"
                         interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codelens.IJavaCodeLensParticipant"/>
         <extensionPoint name="configSourceProvider"
@@ -164,8 +164,10 @@
         <javaDefinitionParticipant
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.faulttolerance.java.MicroProfileFaultToleranceDefinitionParticipant"/>
 
+        <!-- MicroProfile Completion Participants -->
         <javaCompletionParticipant
-                implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.faulttolerance.java.MicroProfileFaultToleranceCompletionParticipant"/>
+                group="mp"
+                implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.faulttolerance.java.MicroProfileFaultToleranceCompletionParticipant"/>
 
         <javaCodeLensParticipant
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.jaxrs.java.JaxRsCodeLensParticipant"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -151,6 +151,8 @@
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector"/>
 
         <projectLabelProvider
+                implementation="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JakartaProjectLabelProvider"/>
+        <projectLabelProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileProjectLabelProvider"/>
         <projectLabelProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MavenProjectLabelProvider"/>

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/GeneratedAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/GeneratedAnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -43,7 +43,7 @@ public class GeneratedAnnotationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/annotations/GeneratedAnnotation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // expected annotations

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +47,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // expected Diagnostics

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class PreDestroyAnnotationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/annotations/PreDestroyAnnotation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // expected annotations

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class ResourceAnnotationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/annotations/ResourceAnnotation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // expected annotations

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/ValidConstraints.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // should be no errors 
@@ -64,7 +64,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/FieldConstraintValidation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // Test diagnostics
@@ -204,7 +204,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/beanvalidation/MethodConstraintValidation.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // Test diagnostics

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanConstructorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation.
+* Copyright (c) 2021, 2024 IBM Corporation.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +49,7 @@ public class ManagedBeanConstructorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBeanConstructor.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostic

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostic
@@ -88,7 +88,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostic
@@ -146,7 +146,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndInjectTogether.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d1 = d(16, 18, 23, "The @Produces and @Inject annotations must not be used on the same field or property.",
@@ -187,7 +187,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d1 = d(10, 18, 31,
@@ -318,7 +318,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d1 = d(12, 18, 31,
@@ -465,7 +465,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/cdi/MultipleDisposes.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
         
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
         Diagnostic d = d(9, 18, 23,

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/JakartaForJavaAssert.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/JakartaForJavaAssert.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020, 2023 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PropertiesManagerForJaka
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Assert;
 
@@ -143,7 +143,7 @@ public class JakartaForJavaAssert {
         return new Position(line, character);
     }
 
-    public static void assertJavaDiagnostics(JakartaDiagnosticsParams params, IPsiUtils utils, Diagnostic... expected) {
+    public static void assertJavaDiagnostics(JakartaJavaDiagnosticsParams params, IPsiUtils utils, Diagnostic... expected) {
         List<PublishDiagnosticsParams> actual = PropertiesManagerForJakarta.getInstance().diagnostics(params, utils);
         assertDiagnostics(
                 actual != null && actual.size() > 0 ? actual.get(0).getDiagnostics() : Collections.emptyList(),

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class DependencyInjectionTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/di/GreetingServlet.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         /* create expected diagnostics

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation.
+* Copyright (c) 2021, 2024 IBM Corporation.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class MultipleConstructorInjectTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/di/MultipleConstructorWithInject.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceClassConstructorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceClassConstructorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation, Matthew Shocrylas and others.
+ * Copyright (c) 2021, 2024 IBM Corporation, Matthew Shocrylas and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -24,7 +24,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,7 +44,7 @@ public class ResourceClassConstructorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsEqualLen.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostics
@@ -69,7 +69,7 @@ public class ResourceClassConstructorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/RootResourceClassConstructorsDiffLen.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostics
@@ -89,7 +89,7 @@ public class ResourceClassConstructorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorClass.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostics
@@ -114,7 +114,7 @@ public class ResourceClassConstructorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NoPublicConstructorProviderClass.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
         Diagnostic d1 = JakartaForJavaAssert.d(19, 12, 44,

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation, Matthew Shocrylas, Bera Sogut and others.
+ * Copyright (c) 2021, 2024 IBM Corporation, Matthew Shocrylas, Bera Sogut and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class ResourceMethodTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/NotPublicResourceMethod.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
         
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
         
@@ -75,7 +75,7 @@ public class ResourceMethodTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -49,7 +49,7 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d1 = JakartaForJavaAssert.d(18, 11, 39,
@@ -87,7 +87,7 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jsonb/JsonbTransientDiagnostic.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
         // Diagnostic for the field "id"

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,7 +23,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +45,7 @@ public class JakartaJsonpTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/jsonp/CreatePointerInvalidTarget.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
         
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         
         Diagnostic d1 = JakartaForJavaAssert.d(20, 60, 64,

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2023 IBM Corporation and others.
+* Copyright (c) 2021, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +48,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d1 = d(16, 32, 42,
@@ -91,7 +91,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/persistence/MultipleMapKeyAnnotations.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
         
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test diagnostics are present
@@ -146,7 +146,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/persistence/EntityMissingConstructor.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test diagnostics are present
@@ -177,7 +177,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/persistence/FinalModifiers.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test diagnostics are present

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class JakartaServletTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/servlet/DontExtendHttpServlet.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // expected
@@ -81,7 +81,7 @@ public class JakartaServletTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/servlet/InvalidWebServlet.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d = JakartaForJavaAssert.d(9, 0, 13,

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2023 IBM Corporation and others.
+* Copyright (c) 2022, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/AnnotationTest.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // OnOpen PathParams Annotation check
@@ -103,7 +103,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/InvalidParamType.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // OnOpen Invalid Param Types
@@ -128,7 +128,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websockets/PathParamURIWarningTest.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d = JakartaForJavaAssert.d(22, 59, 77, "PathParam value does not match specified Endpoint URI.",
@@ -146,7 +146,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         Diagnostic d = JakartaForJavaAssert.d(6, 0, 27, "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
@@ -164,7 +164,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d1 = JakartaForJavaAssert.d(7, 0, 23, "Server endpoint paths must start with a leading '/'.", DiagnosticSeverity.Error,
                 "jakarta-websocket", "ChangeInvalidServerEndpoint");
@@ -183,7 +183,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d = JakartaForJavaAssert.d(6, 0, 46, "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
@@ -200,7 +200,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d = JakartaForJavaAssert.d(6, 0, 40, "Server endpoint paths must not use the same variable more than once in a path.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
@@ -217,7 +217,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
                 + "/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
 
-        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d1 = JakartaForJavaAssert.d(12, 4, 14,
                 "Classes annotated with @ServerEndpoint or @ClientEndpoint must have only one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",


### PR DESCRIPTION
This PR addresses: https://github.com/OpenLiberty/liberty-tools-intellij/issues/521 by upgrading to [LSP4Jakarta 0.2.0](https://github.com/eclipse/lsp4jakarta/releases/tag/0.2.0) and updating our implementation of the client to align with the changes that were made to the client API in this new version of LSP4Jakarta.

Notable changes in this PR:
- Updated the `JakartaLanguageClient` to support the LSP4Jakarta 0.2.0 client API and all of its messages.
  - Supported resolveCodeAction() as a separate message. LSP4Jakarta 0.2.0 does not call this method but the wiring is in place to work with a future version of LSP4Jakarta.
  - Supported new messages for project labels and file info. The code is shared with the MP client. Introduced a label provider for Jakarta projects (see `JakartaProjectLabelProvider`) and specified it as an extension.
  - Supported the new completion message which replaces the separate classpath and Java context messages. This aligns with the design of LSP4MP and has allowed us to unify the design for completion support across the MP and Jakarta EE clients.
- Refactored completion support in a similar way to diagnostics (see https://github.com/OpenLiberty/liberty-tools-intellij/pull/502) and code actions. MP and Jakarta EE share a common code path through the newly introduced `CompletionHandler`. Obsolete and redundant code has been removed.
- Updated unit tests for API changes introduced by LSP4Jakarta 0.2.0 (`JakartaDiagnosticsParams` -> `JakartaJavaDiagnosticsParams`).
- Enabled automated builds with [Microshed LSP4iJ 0.0.3](https://github.com/MicroShed/lsp4ij/tree/q1201).