### PR TITLE
Specify the correct tag for lsp4ij.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           repository: MicroShed/lsp4ij
           path: lsp4ij
+          ref: refs/tags/0.0.1
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The build.yaml on main currently pulls lsp4ij from the Microshed branch main. Now that new code has been merged into main we need to pull from the correct lsp4ij tag, 0.0.1. 

This should be our practice going forward, make a tag in lsp4ij and pull the tag into this build.