### PR TITLE
Fixes #198 -- Add code to shift focus correctly for each terminal

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,7 +32,7 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
         String runTestsCommand = " ";
-        ShellTerminalWidget widget = getAndFocusTerminalWidget(false, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -32,7 +32,7 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
         String runTestsCommand = " ";
-        ShellTerminalWidget widget = getTerminalWidget(false, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getAndFocusTerminalWidget(false, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -76,7 +76,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             }
         }
 
-        ShellTerminalWidget widget = getAndFocusTerminalWidget(true, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -76,7 +76,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             }
         }
 
-        ShellTerminalWidget widget = getTerminalWidget(true, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getAndFocusTerminalWidget(true, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,7 +30,7 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getAndFocusTerminalWidget(true, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -30,7 +30,7 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getTerminalWidget(true, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getAndFocusTerminalWidget(true, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,7 +31,7 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getAndFocusTerminalWidget(false, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
         String stopCmd = "q";
         if (widget == null) {
             return;

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -31,7 +31,7 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getTerminalWidget(false, project, buildFile, getActionCommandName());
+        ShellTerminalWidget widget = getAndFocusTerminalWidget(false, project, buildFile, getActionCommandName());
         String stopCmd = "q";
         if (widget == null) {
             return;

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -162,7 +162,7 @@ public abstract class LibertyGeneralAction extends AnAction {
      * @param createWidget create Terminal widget if it does not already exist
      * @return ShellTerminalWidget
      */
-    protected ShellTerminalWidget getTerminalWidget(boolean createWidget, Project project, VirtualFile buildFile, String actionCmd) {
+    protected ShellTerminalWidget getAndFocusTerminalWidget(boolean createWidget, Project project, VirtualFile buildFile, String actionCmd) {
         LibertyModule libertyModule = LibertyModules.getInstance().getLibertyModule(buildFile);
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget);
         // Shows error for actions where terminal widget does not exist or action requires a terminal to already exist and expects "Start" to be running

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -32,13 +32,10 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class LibertyProjectUtil {
-    private static Logger LOGGER = Logger.getInstance(LibertyProjectUtil.class);;
+    private static Logger LOGGER = Logger.getInstance(LibertyProjectUtil.class);
 
     enum BuildFileFilter {
         ADDABLE {
@@ -155,20 +152,18 @@ public class LibertyProjectUtil {
         ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
         TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         ToolWindow toolWindow = manager.getToolWindow();
-        String widgetName = libertyModule.getName();
 
         ContentManager contentManager = toolWindow.getContentManager();
         Content[] contents = contentManager.getContents();
 
         int index = 0;
         for (int i = 0; i < contents.length; i++) {
-            String displayName = contents[i].getDisplayName();
-            if (widgetName.equals(displayName)) {
+            if (contents[i].getPreferredFocusableComponent().equals(widget)) {
                 index = i;
                 break;
             }
         }
-        if (contents.length > 0) {
+        if (contents.length > 0 && index > 0) {
             Content terminalContent = contents[index];
             contentManager.setSelectedContent(terminalContent);
             terminalContent.getComponent().requestFocus();

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -153,10 +153,22 @@ public class LibertyProjectUtil {
         TerminalView terminalView = TerminalView.getInstance(project);
         // look for existing terminal tab
         ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
+        setFocusToWidget(project, widget);
+
+        if (widget == null && createWidget) {
+            // create a new terminal tab
+            ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
+            libertyModule.setShellWidget(newTerminal);
+            return newTerminal;
+        }
+        return widget;
+    }
+
+    private static void setFocusToWidget(Project project, ShellTerminalWidget widget) {
         TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         ToolWindow toolWindow = manager.getToolWindow();
 
-        if (toolWindow != null) {
+        if (toolWindow != null && widget != null) {
             ContentManager contentManager = toolWindow.getContentManager();
             Content[] contents = contentManager.getContents();
 
@@ -167,20 +179,12 @@ public class LibertyProjectUtil {
                     break;
                 }
             }
-            if (contents.length > 0 && index > 0) {
+            if (contents.length > 0) {
                 Content terminalContent = contents[index];
                 contentManager.setSelectedContent(terminalContent);
                 terminalContent.getComponent().requestFocus();
             }
         }
-
-        if (widget == null && createWidget) {
-            // create a new terminal tab
-            ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
-            libertyModule.setShellWidget(newTerminal);
-            return newTerminal;
-        }
-        return widget;
     }
 
     // returns valid build files for the current project

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -32,7 +32,10 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.Collections;
+import java.util.HashSet;
 
 public class LibertyProjectUtil {
     private static Logger LOGGER = Logger.getInstance(LibertyProjectUtil.class);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -153,21 +153,24 @@ public class LibertyProjectUtil {
         TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         ToolWindow toolWindow = manager.getToolWindow();
 
-        ContentManager contentManager = toolWindow.getContentManager();
-        Content[] contents = contentManager.getContents();
+        if (toolWindow != null) {
+            ContentManager contentManager = toolWindow.getContentManager();
+            Content[] contents = contentManager.getContents();
 
-        int index = 0;
-        for (int i = 0; i < contents.length; i++) {
-            if (contents[i].getPreferredFocusableComponent().equals(widget)) {
-                index = i;
-                break;
+            int index = 0;
+            for (int i = 0; i < contents.length; i++) {
+                if (contents[i].getPreferredFocusableComponent().equals(widget)) {
+                    index = i;
+                    break;
+                }
+            }
+            if (contents.length > 0 && index > 0) {
+                Content terminalContent = contents[index];
+                contentManager.setSelectedContent(terminalContent);
+                terminalContent.getComponent().requestFocus();
             }
         }
-        if (contents.length > 0 && index > 0) {
-            Content terminalContent = contents[index];
-            contentManager.setSelectedContent(terminalContent);
-            terminalContent.getComponent().requestFocus();
-        }
+
         if (widget == null && createWidget) {
             // create a new terminal tab
             ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2023 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,15 +13,19 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.terminal.JBTerminalWidget;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
 import com.sun.istack.Nullable;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyProjectSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 import org.jetbrains.plugins.terminal.TerminalView;
 import org.xml.sax.SAXException;
 
@@ -149,6 +153,26 @@ public class LibertyProjectUtil {
         TerminalView terminalView = TerminalView.getInstance(project);
         // look for existing terminal tab
         ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
+        TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
+        ToolWindow toolWindow = manager.getToolWindow();
+        String widgetName = libertyModule.getName();
+
+        ContentManager contentManager = toolWindow.getContentManager();
+        Content[] contents = contentManager.getContents();
+
+        int index = 0;
+        for (int i = 0; i < contents.length; i++) {
+            String displayName = contents[i].getDisplayName();
+            if (widgetName.equals(displayName)) {
+                index = i;
+                break;
+            }
+        }
+        if (contents.length > 0) {
+            Content terminalContent = contents[index];
+            contentManager.setSelectedContent(terminalContent);
+            terminalContent.getComponent().requestFocus();
+        }
         if (widget == null && createWidget) {
             // create a new terminal tab
             ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -149,12 +149,7 @@ public class LibertyProjectUtil {
      * @param createWidget  true if a new widget should be created
      * @return ShellTerminalWidget or null if it does not exist
      */
-    public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget) {
-        TerminalView terminalView = TerminalView.getInstance(project);
-        // look for existing terminal tab
-        ShellTerminalWidget widget = getTerminalWidget(libertyModule, terminalView);
-        setFocusToWidget(project, widget);
-
+    public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget, TerminalView terminalView, ShellTerminalWidget widget) {
         if (widget == null && createWidget) {
             // create a new terminal tab
             ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
@@ -164,7 +159,7 @@ public class LibertyProjectUtil {
         return widget;
     }
 
-    private static void setFocusToWidget(Project project, ShellTerminalWidget widget) {
+    public static void setFocusToWidget(Project project, ShellTerminalWidget widget) {
         TerminalToolWindowManager manager = TerminalToolWindowManager.getInstance(project);
         ToolWindow toolWindow = manager.getToolWindow();
 
@@ -237,7 +232,7 @@ public class LibertyProjectUtil {
      * @param terminalView
      * @return ShellTerminalWidget or null if it does not exist
      */
-    private static ShellTerminalWidget getTerminalWidget(LibertyModule libertyModule, TerminalView terminalView) {
+    public static ShellTerminalWidget getTerminalWidget(LibertyModule libertyModule, TerminalView terminalView) {
         ShellTerminalWidget widget = libertyModule.getShellWidget();
         // check if widget exists in terminal view
         if (widget != null) {


### PR DESCRIPTION
Fixes #198 -->  Added code to make sure the focus shifts correctly for each terminal when we perform dev-actions, also tested that terminal renaming works properly.

We can close these dependent issues #505, #506, once the PR is merged.

