### PR TITLE
Enable GitHub action to be triggered manually.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: '**'
   pull_request:


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/628.