### PR TITLE
Use IntelilJ 2023.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.intellij.remoterobot:remote-robot:' + remoteRobotVersion
     testImplementation 'com.intellij.remoterobot:remote-fixtures:' + remoteRobotVersion
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:232.10072.27') {
+    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:233.11799.241') {
         transitive = false
     }
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
@@ -137,7 +137,7 @@ runIde {
 
 intellij {
     // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
-    version = '2023.2.3'
+    version = '2023.3'
 
     plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle']
     updateSinceUntilBuild = false

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'io.openliberty.tools'
-version '24.0.1-SNAPSHOT'
+version '24.0.3-SNAPSHOT'
 
 sourceCompatibility = 17
 targetCompatibility = 17
@@ -137,7 +137,7 @@ runIde {
 
 intellij {
     // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
-    version = '2023.3'
+    version = '2023.3.4'
 
     plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle']
     updateSinceUntilBuild = false

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -12,13 +12,11 @@ package io.openliberty.tools.intellij;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.DoubleClickListener;
@@ -51,8 +49,6 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
     public LibertyExplorer(@NotNull Project project) {
         super(true, true);
         // build tree
-        // Run the read action
-
         Tree tree = buildTree(project, getBackground());
 
         if (tree != null) {

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -52,24 +52,23 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
         super(true, true);
         // build tree
         // Run the read action
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            Tree tree = ApplicationManager.getApplication().runReadAction((Computable<Tree>) () -> buildTree(project, getBackground()));
 
-            if (tree != null) {
-                JBScrollPane scrollPane = new JBScrollPane(tree);
-                scrollPane.setName(Constants.LIBERTY_SCROLL_PANE);
-                this.setContent(scrollPane);
-            } else {
-                JBTextArea jbTextArea = new JBTextArea(LocalizedResourceUtil.getMessage("no.liberty.projects.detected"));
-                jbTextArea.setEditable(false);
-                jbTextArea.setBackground(getBackground());
-                jbTextArea.setLineWrap(true);
+        Tree tree = buildTree(project, getBackground());
 
-                this.setContent(jbTextArea);
-            }
-            ActionToolbar actionToolbar = buildActionToolbar(tree);
-            this.setToolbar(actionToolbar.getComponent());
-        });
+        if (tree != null) {
+            JBScrollPane scrollPane = new JBScrollPane(tree);
+            scrollPane.setName(Constants.LIBERTY_SCROLL_PANE);
+            this.setContent(scrollPane);
+        } else {
+            JBTextArea jbTextArea = new JBTextArea(LocalizedResourceUtil.getMessage("no.liberty.projects.detected"));
+            jbTextArea.setEditable(false);
+            jbTextArea.setBackground(getBackground());
+            jbTextArea.setLineWrap(true);
+
+            this.setContent(jbTextArea);
+        }
+        ActionToolbar actionToolbar = buildActionToolbar(tree);
+        this.setToolbar(actionToolbar.getComponent());
     }
 
     public static ActionToolbar buildActionToolbar(Tree tree) {

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -201,8 +201,8 @@ public class LibertyMavenUtil {
      * @return String command to execute in the terminal or an exception to display
      * @throws LibertyException
      */
+    final static String wrappedMaven = "Use Maven wrapper";
     public static String getMavenSettingsCmd(Project project, VirtualFile buildFile) throws LibertyException {
-        String wrappedMaven = "Use Maven wrapper";
         MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
         String mavenHome = mavenSettings.getMavenHome();
         if (wrappedMaven.equals(mavenHome)) {

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -202,9 +202,10 @@ public class LibertyMavenUtil {
      * @throws LibertyException
      */
     public static String getMavenSettingsCmd(Project project, VirtualFile buildFile) throws LibertyException {
+        String wrappedMaven = "Use Maven wrapper";
         MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
         String mavenHome = mavenSettings.getMavenHome();
-        if (MavenServerManager.WRAPPED_MAVEN.equals(mavenHome)) {
+        if (wrappedMaven.equals(mavenHome)) {
             // it is set to use the wrapper
             return getLocalMavenWrapper(buildFile);
         } else {

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
     <depends>com.intellij.properties</depends>
     <depends>org.jetbrains.idea.maven</depends>
     <depends>com.intellij.gradle</depends>
-    <idea-version since-build="231" until-build="232.*"/>
+    <idea-version since-build="231" until-build="233.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1513,7 +1513,7 @@ public class UIBotTestUtils {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
 
         // Click on the play button.
-        String xPath = "//div[@class='LibertyExplorer']//div[@class='ActionButton' and @tooltiptext.key='action.io.openliberty.tools.intellij.actions.RunLibertyDevTask.text']";
+        String xPath = "//div[@class='LibertyExplorer']//div[@class='ActionButton' and @accessiblename.key='action.io.openliberty.tools.intellij.actions.RunLibertyDevTask.text']";
         ComponentFixture actionButton = projectFrame.getActionButton(xPath, "10");
         actionButton.click();
     }
@@ -1801,7 +1801,7 @@ public class UIBotTestUtils {
         String exitButtonText = "Cancel";
         try {
             // Click on the Add Configuration action button (+) to open the Add New Configuration window.
-            Locator addButtonLocator = byXpath("//div[@tooltiptext.key='add.new.run.configuration.action2.name']");
+            Locator addButtonLocator = byXpath("//div[@accessiblename.key='add.new.run.configuration.action2.name']");
             ActionButtonFixture addCfgButton = addProjectDialog.actionButton(addButtonLocator);
             addCfgButton.click();
 
@@ -2121,7 +2121,7 @@ public class UIBotTestUtils {
                 // Find the Liberty tree node and delete all child configurations.
                 boolean processEntries = false;
                 boolean firstEntryClicked = false;
-                Locator locator = byXpath("//div[@tooltiptext.key='remove.run.configuration.action.name']");
+                Locator locator = byXpath("//div[@accessiblename.key='remove.run.configuration.action.name']");
                 ActionButtonFixture removeCfgButton = rdConfigDialog.actionButton(locator);
 
                 for (RemoteText treeEntry : treeEntries) {
@@ -2292,7 +2292,7 @@ public class UIBotTestUtils {
         ComponentFixture libertyTWBar = projectFrame.getBaseLabel("Liberty", "10");
         libertyTWBar.click();
 
-        String xPath = "//div[@class='LibertyExplorer']//div[@tooltiptext.key='action.io.openliberty.tools.intellij.actions.RefreshLibertyToolbar.text']";
+        String xPath = "//div[@class='LibertyExplorer']//div[@accessiblename.key='action.io.openliberty.tools.intellij.actions.RefreshLibertyToolbar.text']";
         ComponentFixture actionButton = projectFrame.getActionButton(xPath, "10");
         actionButton.click();
     }

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -155,7 +155,7 @@ main() {
 
     # Start the IDE.
     echo -e "\n$(${currentTime[@]}): INFO: Starting the IntelliJ IDE..."
-    ./gradlew runIdeForUiTests --info  > remoteServer.log  2>&1 &
+    ./gradlew -Dide.slow.operations.assertion=false runIdeForUiTests --info  > remoteServer.log  2>&1 &
 
     # Wait for the IDE to come up.
     echo -e "\n$(${currentTime[@]}): INFO: Waiting for the Intellij IDE to start..."

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ############################################################################
-# Copyright (c) 2023 IBM Corporation and others.
+# Copyright (c) 2023, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Pull in Vaisakh's changes.

One change, remove the code that runs LibertyExplorer on a background thread because it caused an exception involving the need to run the code on the event thread. Also when running the tests use an option not to generate an assertion (red warning dialog) when the slow operation on event thread exception is generated.