### PR TITLE
Fixes #611 LSP4Jakarta ambiguously matches the expected class names when checking diagnostics, applying quick fixes, etc

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation.
+ * Copyright (c) 2021, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -56,12 +56,9 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
             boolean isManagedBean = managedBeanAnnotations.size() > 0;
 
             if (managedBeanAnnotations.size() > 1) {
-                // convert to simple name
-                List<String> diagnosticData = managedBeanAnnotations.stream()
-                        .map(annotation -> getSimpleName(annotation)).collect(Collectors.toList());
                 diagnostics.add(createDiagnostic(type, unit,
                         Messages.getMessage("ScopeTypeAnnotationsManagedBean"),
-                        DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(diagnosticData)),
+                        DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(managedBeanAnnotations)),
                         DiagnosticSeverity.Error));
             }
 
@@ -108,12 +105,10 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                         isInjectField = true;
                 }
                 if (isProducerField && fieldScopes.size() > 1) {
-                    List<String> diagnosticData = fieldScopes.stream().map(annotation -> getSimpleName(annotation))
-                            .collect(Collectors.toList()); // convert to simple name
-                    diagnosticData.add(PRODUCES);
+                    fieldScopes.add(PRODUCES);
                     diagnostics.add(createDiagnostic(field, unit,
                             Messages.getMessage("ScopeTypeAnnotationsProducerField"),
-                            DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(diagnosticData)),
+                            DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(fieldScopes)),
                             DiagnosticSeverity.Error));
                 }
 
@@ -167,12 +162,10 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                 }
 
                 if (isProducerMethod && methodScopes.size() > 1) {
-                    List<String> diagnosticData = methodScopes.stream().map(annotation -> getSimpleName(annotation))
-                            .collect(Collectors.toList()); // convert to simple name
-                    diagnosticData.add(PRODUCES);
+                    methodScopes.add(PRODUCES);
                     diagnostics.add(createDiagnostic(method, unit,
                             Messages.getMessage("ScopeTypeAnnotationsProducerMethod"),
-                            DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(diagnosticData)),
+                            DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(methodScopes)),
                             DiagnosticSeverity.Error));
                 }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -105,7 +105,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                         isInjectField = true;
                 }
                 if (isProducerField && fieldScopes.size() > 1) {
-                    fieldScopes.add(PRODUCES);
+                    fieldScopes.add(PRODUCES_FQ_NAME);
                     diagnostics.add(createDiagnostic(field, unit,
                             Messages.getMessage("ScopeTypeAnnotationsProducerField"),
                             DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(fieldScopes)),
@@ -162,7 +162,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                 }
 
                 if (isProducerMethod && methodScopes.size() > 1) {
-                    methodScopes.add(PRODUCES);
+                    methodScopes.add(PRODUCES_FQ_NAME);
                     diagnostics.add(createDiagnostic(method, unit,
                             Messages.getMessage("ScopeTypeAnnotationsProducerMethod"),
                             DIAGNOSTIC_CODE_SCOPEDECL, (JsonArray) (new Gson().toJsonTree(methodScopes)),

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
@@ -50,19 +50,13 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
 
         if (parentType != null) {
 
-            // Convert the short annotation names to their fully qualified equivalents.
-            List<String> fqAnnotations = new ArrayList<>();
-            for (String annotation : annotations) {
-                fqAnnotations.addAll(getFQAnnotationNames(parentType.getProject(), annotation));
-            }
-
             List<CodeAction> codeActions = new ArrayList<>();
             /**
              * for each annotation, choose the current annotation to keep and remove the
              * rest since we can have at most one scope annotation.
              */
-            for (String annotation : fqAnnotations) {
-                List<String> resultingAnnotations = new ArrayList<>(fqAnnotations);
+            for (String annotation : annotations) {
+                List<String> resultingAnnotations = new ArrayList<>(annotations);
                 resultingAnnotations.remove(annotation);
                 removeAnnotation(diagnostic, context, codeActions,
                         resultingAnnotations.toArray(new String[] {}));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ScopeDeclarationQuickFix.java
@@ -46,7 +46,7 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
         List<String> annotations = IntStream.range(0, diagnosticData.size())
                 .mapToObj(idx -> diagnosticData.get(idx).getAsString()).collect(Collectors.toList());
 
-        annotations.remove(ManagedBeanConstants.PRODUCES);
+        annotations.remove(ManagedBeanConstants.PRODUCES_FQ_NAME);
 
         if (parentType != null) {
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbDiagnosticsCollector.java
@@ -137,11 +137,9 @@ public class JsonbDiagnosticsCollector extends AbstractDiagnosticsCollector {
             diagnosticErrorMessage = Messages.getMessage("ErrorMessageJsonbTransientOnField");
         else if (code.equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION_TRANSIENT_ACCESSOR))
             diagnosticErrorMessage = Messages.getMessage("ErrorMessageJsonbTransientOnAccessor");
-        // convert to simple name for current tests
-        List<String> diagnosticData = jsonbAnnotations.stream().map(annotation -> getSimpleName(annotation))
-                .collect(Collectors.toList());
+
         diagnostics.add(createDiagnostic(member, unit, diagnosticErrorMessage, code,
-                (JsonArray) (new Gson().toJsonTree(diagnosticData)), DiagnosticSeverity.Error));
+                (JsonArray) (new Gson().toJsonTree(jsonbAnnotations)), DiagnosticSeverity.Error));
         return true;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation, Matheus Cruz and others.
+ * Copyright (c) 2020, 2024 IBM Corporation, Matheus Cruz and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
@@ -17,6 +17,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quic
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,20 +36,15 @@ public class JsonbTransientAnnotationQuickFix extends RemoveMultipleAnnotations 
     protected List<List<String>> getMultipleRemoveAnnotations(Project project, List<String> annotations) {
         List<List<String>> annotationsListsToRemove = new ArrayList<List<String>>();
 
-        if (annotations.contains(JsonbConstants.JSONB_TRANSIENT)) {
+        if (annotations.contains(JsonbConstants.JSONB_TRANSIENT_FQ_NAME)) {
             // Provide as one option: Remove JsonbTransient
             annotationsListsToRemove.add(Arrays.asList(JsonbConstants.JSONB_TRANSIENT_FQ_NAME));
         }
 
         // Provide as another option: Remove all other JsonbAnnotations
-        annotations.remove(JsonbConstants.JSONB_TRANSIENT);
+        annotations.remove(JsonbConstants.JSONB_TRANSIENT_FQ_NAME);
         if (annotations.size() > 0) {
-            // Convert the short annotation names to their fully qualified equivalents.
-            List<String> fqAnnotations = new ArrayList<>();
-            for (String annotation : annotations) {
-                fqAnnotations.addAll(getFQAnnotationNames(project, annotation));
-            }
-            annotationsListsToRemove.add(fqAnnotations);
+            annotationsListsToRemove.addAll(Collections.singleton(annotations));
         }
 
         return annotationsListsToRemove;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonb/JsonbTransientAnnotationQuickFix.java
@@ -44,7 +44,7 @@ public class JsonbTransientAnnotationQuickFix extends RemoveMultipleAnnotations 
         // Provide as another option: Remove all other JsonbAnnotations
         annotations.remove(JsonbConstants.JSONB_TRANSIENT_FQ_NAME);
         if (annotations.size() > 0) {
-            annotationsListsToRemove.addAll(Collections.singleton(annotations));
+            annotationsListsToRemove.add(annotations);
         }
 
         return annotationsListsToRemove;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -380,6 +380,14 @@
                                    group="jakarta"
                                    targetDiagnostic="jakarta-di#RemoveInjectOrStatic"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveInjectAnnotationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-jsonb#NonmutualJsonbTransientAnnotation"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jsonb.JsonbTransientAnnotationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-cdi#InvalidScopeDecl"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ScopeDeclarationQuickFix"/>
 
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -105,13 +105,13 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 "Scope type annotations must be specified by a producer field at most once.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
         d1.setData(new Gson().toJsonTree(Arrays.asList("jakarta.enterprise.context.Dependent",
-                "jakarta.enterprise.context.ApplicationScoped", "Produces")));
+                "jakarta.enterprise.context.ApplicationScoped", "jakarta.enterprise.inject.Produces")));
 
         Diagnostic d2 = d(15, 25, 41, "Scope type annotations must be specified " +
                         "by a producer method at most once.", DiagnosticSeverity.Error, "jakarta-cdi",
                 "InvalidScopeDecl");
         d2.setData(new Gson().toJsonTree(Arrays.asList("jakarta.enterprise.context.ApplicationScoped",
-                "jakarta.enterprise.context.RequestScoped", "Produces")));
+                "jakarta.enterprise.context.RequestScoped", "jakarta.enterprise.inject.Produces")));
 
         Diagnostic d3 = d(10, 13, 29, "Scope type annotations must be " +
                         "specified by a managed bean class at most once.", DiagnosticSeverity.Error,

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -104,46 +104,92 @@ public class ManagedBeanTest extends BaseJakartaTest {
         Diagnostic d1 = d(12, 16, 17,
                 "Scope type annotations must be specified by a producer field at most once.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
-        d1.setData(new Gson().toJsonTree(Arrays.asList("Dependent", "ApplicationScoped", "Produces")));
+        d1.setData(new Gson().toJsonTree(Arrays.asList("jakarta.enterprise.context.Dependent",
+                "jakarta.enterprise.context.ApplicationScoped", "Produces")));
 
-        Diagnostic d2 = d(15, 25, 41, "Scope type annotations must be specified by a producer method at most once.",
-                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
-        d2.setData(new Gson().toJsonTree(Arrays.asList("ApplicationScoped", "RequestScoped", "Produces")));
-        
-        Diagnostic d3 = d(10, 13, 29, "Scope type annotations must be specified by a managed bean class at most once.",
-                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
-        d3.setData(new Gson().toJsonTree(Arrays.asList("ApplicationScoped", "RequestScoped")));
+        Diagnostic d2 = d(15, 25, 41, "Scope type annotations must be specified " +
+                        "by a producer method at most once.", DiagnosticSeverity.Error, "jakarta-cdi",
+                "InvalidScopeDecl");
+        d2.setData(new Gson().toJsonTree(Arrays.asList("jakarta.enterprise.context.ApplicationScoped",
+                "jakarta.enterprise.context.RequestScoped", "Produces")));
+
+        Diagnostic d3 = d(10, 13, 29, "Scope type annotations must be " +
+                        "specified by a managed bean class at most once.", DiagnosticSeverity.Error,
+                "jakarta-cdi", "InvalidScopeDecl");
+        d3.setData(new Gson().toJsonTree(Arrays.asList("jakarta.enterprise.context.ApplicationScoped",
+                "jakarta.enterprise.context.RequestScoped")));
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        if (CHECK_CODE_ACTIONS) {
-            // Assert for the diagnostic d1
-            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-            TextEdit te1 = te(11, 33, 12, 4, "");
-            TextEdit te2 = te(11, 14, 11, 33, "");
-            CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te2);
-            CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te1);
+        //TODO: Uncomment this line of code once all the quickfix changes are done.
+//        if (CHECK_CODE_ACTIONS) {
+        // Assert for the diagnostic d1
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        String newText = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;" +
+                "\nimport java.util.List;\n\nimport jakarta.enterprise.inject.Produces;\n\n" +
+                "import jakarta.enterprise.context.*;\n\n@ApplicationScoped @RequestScoped\n" +
+                "public class ScopeDeclaration {\n    @Produces  @Dependent\n    private int n;\n   " +
+                " \n    @Produces @ApplicationScoped @RequestScoped\n    public List<Integer> getAllProductIds() " +
+                "{\n        return Collections.emptyList();\n    }\n}";
 
-            assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
+        String newText1 = "package io.openliberty.sample.jakarta.cdi;\n\n" +
+                "import java.util.Collections;\nimport java.util.List;\n\n" +
+                "import jakarta.enterprise.inject.Produces;\n\nimport jakarta.enterprise.context.*;" +
+                "\n\n@ApplicationScoped @RequestScoped\npublic class ScopeDeclaration {\n   " +
+                " @Produces @ApplicationScoped\n    private int n;\n    \n    @Produces @ApplicationScoped" +
+                " @RequestScoped\n    public List<Integer> getAllProductIds() {\n        " +
+                "return Collections.emptyList();\n    }\n}";
 
-            // Assert for the diagnostic d2
-            JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-            TextEdit te3 = te(14, 33, 15, 4, "");
-            TextEdit te4 = te(14, 14, 14, 33, "");
-            CodeAction ca3 = ca(uri, "Remove @RequestScoped", d2, te3);
-            CodeAction ca4 = ca(uri, "Remove @ApplicationScoped", d2, te4);
+        TextEdit te1 = te(0, 0, 18, 1, newText);
+        TextEdit te2 = te(0, 0, 18, 1, newText1);
+        CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te1);
+        CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te2);
+        assertJavaCodeAction(codeActionParams1, utils, ca1,ca2);
 
-            assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        // Assert for the diagnostic d2
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        newText = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;\n" +
+                "import java.util.List;\n\nimport jakarta.enterprise.inject.Produces;\n\n" +
+                "import jakarta.enterprise.context.*;\n\n@ApplicationScoped @RequestScoped\n" +
+                "public class ScopeDeclaration {\n    @Produces @ApplicationScoped @Dependent\n   " +
+                " private int n;\n    \n    @Produces  @RequestScoped\n    public List<Integer> getAllProductIds()" +
+                " {\n        return Collections.emptyList();\n    }\n}";
 
-            // Assert for the diagnostic d3
-            JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
-            TextEdit te5 = te(9, 19, 10, 0, "");
-            TextEdit te6 = te(9, 0, 9, 19, "");
-            CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
-            CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
+        newText1 = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;\nimport " +
+                "java.util.List;\n\nimport jakarta.enterprise.inject.Produces;\n\nimport " +
+                "jakarta.enterprise.context.*;\n\n@ApplicationScoped @RequestScoped\npublic class ScopeDeclaration" +
+                " {\n    @Produces @ApplicationScoped @Dependent\n    private int n;\n    \n   " +
+                " @Produces @ApplicationScoped\n    public List<Integer> getAllProductIds() {\n      " +
+                "  return Collections.emptyList();\n    }\n}";
 
-            assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
-        }
+        TextEdit te3 = te(0, 0, 18, 1, newText1);
+        TextEdit te4 = te(0, 0, 18, 1, newText);
+        CodeAction ca3 = ca(uri, "Remove @RequestScoped", d2, te3);
+        CodeAction ca4 = ca(uri, "Remove @ApplicationScoped", d2, te4);
+        assertJavaCodeAction(codeActionParams2, utils, ca4, ca3);
+
+        // Assert for the diagnostic d3
+        JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
+        newText = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;\n" +
+                "import java.util.List;\n\nimport jakarta.enterprise.inject.Produces;\n\n" +
+                "import jakarta.enterprise.context.*;\n\n@RequestScoped\npublic class ScopeDeclaration {\n  " +
+                "  @Produces @ApplicationScoped @Dependent\n    private int n;\n    \n   " +
+                " @Produces @ApplicationScoped @RequestScoped\n    public List<Integer> getAllProductIds() {\n  " +
+                "      return Collections.emptyList();\n    }\n}";
+
+        newText1 = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;" +
+                "\nimport java.util.List;\n\nimport jakarta.enterprise.inject.Produces;\n\n" +
+                "import jakarta.enterprise.context.*;\n\n@ApplicationScoped\npublic class ScopeDeclaration {\n " +
+                "   @Produces @ApplicationScoped @Dependent\n    private int n;\n    \n    " +
+                "@Produces @ApplicationScoped @RequestScoped\n    public List<Integer> getAllProductIds() {\n   " +
+                "     return Collections.emptyList();\n    }\n}";
+
+        TextEdit te5 = te(0, 0, 18, 1, newText1);
+        TextEdit te6 = te(0, 0, 18, 1, newText);
+        CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
+        CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
+        assertJavaCodeAction(codeActionParams3, utils, ca6, ca5);
+//        }
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2024 IBM Corporation and others.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v. 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0.
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     IBM Corporation, Adit Rada, Yijia Jing - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Adit Rada, Yijia Jing - initial API and implementation
+ *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.it.jsonb;
 
 import com.google.gson.Gson;
@@ -122,87 +122,324 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
         Diagnostic d1 = JakartaForJavaAssert.d(21, 16, 18,
                 "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
-        d1.setData(new Gson().toJsonTree(Arrays.asList("JsonbTransient")));
+        d1.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbTransient")));
 
         // Diagnostic for the field "name"
         Diagnostic d2 = JakartaForJavaAssert.d(25, 19, 23,
                 "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
-        d2.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty",  "JsonbTransient")));
+        d2.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbProperty",  "jakarta.json.bind.annotation.JsonbTransient")));
 
         // Diagnostic for the field "favoriteLanguage"
         Diagnostic d3 = JakartaForJavaAssert.d(30, 19, 35,
                 "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
-        d3.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty", "JsonbAnnotation",  "JsonbTransient")));
         
+        d3.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbProperty", "jakarta.json.bind.annotation.JsonbAnnotation",  "jakarta.json.bind.annotation.JsonbTransient")));
+
         // Diagnostic for the field "favoriteEditor"
         Diagnostic d4 = JakartaForJavaAssert.d(39, 19, 33,
                 "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
-        d4.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty")));
         
+        d4.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbProperty")));
+
         // Diagnostic for the getter "getId"
         Diagnostic d5 = JakartaForJavaAssert.d(42, 16, 21,
                 "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
-        d5.setData(new Gson().toJsonTree(Arrays.asList("JsonbProperty")));
        
+        d5.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbProperty")));
+
         // Diagnostic for the setter "setId"
         Diagnostic d6 = JakartaForJavaAssert.d(49, 17, 22,
                 "When a class field is annotated with @JsonbTransient, this field, getter or setter must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotation");
-        d6.setData(new Gson().toJsonTree(Arrays.asList("JsonbAnnotation")));
         
+        d6.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbAnnotation")));
+
         // Diagnostic for the getter "getFavoriteEditor"
         Diagnostic d7 = JakartaForJavaAssert.d(67, 19, 36,
                 "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
-        d7.setData(new Gson().toJsonTree(Arrays.asList("JsonbTransient")));
        
+        d7.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbTransient")));
+
         // Diagnostic for the setter "setFavoriteEditor"
         Diagnostic d8 = JakartaForJavaAssert.d(74, 17, 34,
                 "When an accessor is annotated with @JsonbTransient, its field or the accessor must not be annotated with other JSON Binding annotations.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "NonmutualJsonbTransientAnnotationOnAccessor");
-        d8.setData(new Gson().toJsonTree(Arrays.asList("JsonbAnnotation", "JsonbTransient")));
   
+        d8.setData(new Gson().toJsonTree(Arrays.asList("jakarta.json.bind.annotation.JsonbAnnotation", "jakarta.json.bind.annotation.JsonbTransient")));
+
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
 
-        if (CHECK_CODE_ACTIONS) {
-            // Test code actions
-            // Quick fix for the field "id"
-            JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-            TextEdit te1 = JakartaForJavaAssert.te(20, 4, 21, 4, "");
-            CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d1, te1);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
+        //TODO: Uncomment this line of code once all the quickfix changes are done.
+//        if (CHECK_CODE_ACTIONS) {
+        // Test code actions
+        // Quick fix for the field "id"
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        String newText = "/******************************************************************************* \n" +
+                "* Copyright (c) 2022 IBM Corporation and others.\n *\n * This program and the accompanying " +
+                "materials are made available under the\n * terms of the Eclipse Public License v. 2.0 which " +
+                "is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier: " +
+                "EPL-2.0\n *\n * Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n" +
+                " *******************************************************************************/\n\n" +
+                "package io.openliberty.sample.jakarta.jsonb;\n\n" +
+                "import jakarta.json.bind.annotation.JsonbAnnotation;\n" +
+                "import jakarta.json.bind.annotation.JsonbProperty;\n" +
+                "import jakarta.json.bind.annotation.JsonbTransient;\n\n" +
+                "public class JsonbTransientDiagnostic {\n    private int id;\n\n    @JsonbProperty(\"name\")\n   " +
+                " @JsonbTransient\n    private String name;    // Diagnostic: JsonbTransient is mutually exclusive" +
+                " with other JsonB annotations\n\n    @JsonbProperty(\"fav_lang\")\n    @JsonbAnnotation\n   " +
+                " @JsonbTransient\n    private String favoriteLanguage;    // Diagnostic: JsonbTransient " +
+                "is mutually exclusive with other JsonB annotations\n    \n    // No diagnostic as field is not " +
+                "annotated with other Jsonb annotations,\n    // even though the accessors are annotated with " +
+                "@JsonbTransient\n    private String favoriteDatabase;\n    \n    // Diagnostic will appear as " +
+                "field accessors have @JsonbTransient,\n    // but field itself has annotation other than " +
+                "transient\n    @JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    \n    " +
+                "@JsonbProperty(\"person-id\")\n    private int getId() { \n        // A diagnostic is expected on" +
+                " getId because as a getter, it is annotated with other \n        // Jsonb annotations while its " +
+                "corresponding field id is annotated with JsonbTransient\n        return id;\n    }\n    \n   " +
+                " @JsonbAnnotation\n    private void setId(int id) {\n        // A diagnostic is expected on setId" +
+                " because as a setter, it is annotated with other \n        // Jsonb annotations while its " +
+                "corresponding field id is annotated with JsonbTransient\n        this.id = id;\n    }\n    \n   " +
+                " @JsonbTransient\n    private String getFavoriteDatabase() {\n        return favoriteDatabase;\n " +
+                "   }\n    \n    @JsonbTransient\n    private void setFavoriteDatabase(String favoriteDatabase) {\n" +
+                "        this.favoriteDatabase = favoriteDatabase;\n    }\n    \n    // A diagnostic will appear" +
+                " as field has conflicting annotation\n    @JsonbTransient\n    private String getFavoriteEditor()" +
+                " {\n        return favoriteEditor;\n    }\n    \n    // A diagnostic will appear as @JsonbTransient" +
+                " is not mutually exclusive on this accessor\n    @JsonbAnnotation\n    @JsonbTransient\n    " +
+                "private void setFavoriteEditor(String favoriteEditor) {\n        this.favoriteEditor = " +
+                "favoriteEditor;\n    }\n}";
+        TextEdit te1 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d1, te1);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca1);
 
-            // Quick fix for the field "name"
-            JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
-            TextEdit te3 = JakartaForJavaAssert.te(24, 4, 25, 4, "");
-            TextEdit te4 = JakartaForJavaAssert.te(23, 4, 24, 4, "");
-            CodeAction ca3 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d2, te3);
-            CodeAction ca4 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d2, te4);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca3, ca4);
+        // Quick fix for the field "name"
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d2);
+        newText = "/******************************************************************************* \n* Copyright " +
+                "(c) 2022 IBM Corporation and others.\n *\n * This program and the accompanying materials are" +
+                " made available under the\n * terms of the Eclipse Public License v. 2.0 which is available " +
+                "at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier: EPL-2.0\n *\n *" +
+                " Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n" +
+                " *******************************************************************************/\n\npackage " +
+                "io.openliberty.sample.jakarta.jsonb;\n\nimport jakarta.json.bind.annotation.JsonbAnnotation;\n" +
+                "import jakarta.json.bind.annotation.JsonbProperty;\nimport jakarta.json.bind.annotation." +
+                "JsonbTransient;\n\npublic class JsonbTransientDiagnostic {\n    @JsonbTransient\n    " +
+                "private int id;\n\n    @JsonbTransient\n    private String name;    // Diagnostic: " +
+                "JsonbTransient is mutually exclusive with other JsonB annotations\n\n    " +
+                "@JsonbProperty(\"fav_lang\")\n    @JsonbAnnotation\n    @JsonbTransient\n    " +
+                "private String favoriteLanguage;    // Diagnostic: JsonbTransient is mutually exclusive with other" +
+                " JsonB annotations\n    \n    // No diagnostic as field is not annotated with other Jsonb " +
+                "annotations,\n    // even though the accessors are annotated with @JsonbTransient\n    " +
+                "private String favoriteDatabase;\n    \n    // Diagnostic will appear as field accessors have" +
+                " @JsonbTransient,\n    // but field itself has annotation other than transient\n    " +
+                "@JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    \n    " +
+                "@JsonbProperty(\"person-id\")\n    private int getId() { \n       " +
+                " // A diagnostic is expected on getId because as a getter, it is annotated with other \n        " +
+                "// Jsonb annotations while its corresponding field id is annotated with JsonbTransient\n        " +
+                "return id;\n    }\n    \n    @JsonbAnnotation\n    private void setId(int id) {\n        " +
+                "// A diagnostic is expected on setId because as a setter, it is annotated with other \n        " +
+                "// Jsonb annotations while its corresponding field id is annotated with JsonbTransient\n        " +
+                "this.id = id;\n    }\n    \n    @JsonbTransient\n    private String getFavoriteDatabase() {\n     " +
+                "   return favoriteDatabase;\n    }\n    \n    @JsonbTransient\n    " +
+                "private void setFavoriteDatabase(String favoriteDatabase) {\n        " +
+                "this.favoriteDatabase = favoriteDatabase;\n    }\n    \n    // A diagnostic will appear as" +
+                " field has conflicting annotation\n    @JsonbTransient\n    private String getFavoriteEditor() " +
+                "{\n        return favoriteEditor;\n    }\n    \n    // A diagnostic will appear as @JsonbTransient" +
+                " is not mutually exclusive on this accessor\n    @JsonbAnnotation\n    @JsonbTransient\n   " +
+                " private void setFavoriteEditor(String favoriteEditor) {\n        this.favoriteEditor = " +
+                "favoriteEditor;\n    }\n}";
 
-            // Quick fix for the field "favoriteLanguage"
-            JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
-            TextEdit te5 = JakartaForJavaAssert.te(29, 4, 30, 4, "");
-            TextEdit te6 = JakartaForJavaAssert.te(27, 4, 29, 4, "");
-            CodeAction ca5 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d3, te5);
-            CodeAction ca6 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty, @JsonbAnnotation", d3, te6);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, ca5, ca6);
+        String newText1 = "/******************************************************************************* \n* " +
+                "Copyright (c) 2022 IBM Corporation and others.\n *\n * This program and the accompanying materials" +
+                " are made available under the\n * terms of the Eclipse Public License v. 2.0 which is available " +
+                "at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier: EPL-2.0\n *\n *" +
+                " Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n " +
+                "*******************************************************************************/\n\npackage " +
+                "io.openliberty.sample.jakarta.jsonb;\n\nimport jakarta.json.bind.annotation.JsonbAnnotation;\n" +
+                "import jakarta.json.bind.annotation.JsonbProperty;\nimport jakarta.json.bind.annotation." +
+                "JsonbTransient;\n\npublic class JsonbTransientDiagnostic {\n    @JsonbTransient\n    private int " +
+                "id;\n\n    @JsonbProperty(\"name\")\n    private String name;    // Diagnostic: JsonbTransient " +
+                "is mutually exclusive with other JsonB annotations\n\n    @JsonbProperty(\"fav_lang\")\n    " +
+                "@JsonbAnnotation\n    @JsonbTransient\n    private String favoriteLanguage;    // Diagnostic:" +
+                " JsonbTransient is mutually exclusive with other JsonB annotations\n    \n    // No diagnostic as " +
+                "field is not annotated with other Jsonb annotations,\n    // even though the accessors are " +
+                "annotated with @JsonbTransient\n    private String favoriteDatabase;\n    \n    // Diagnostic " +
+                "will appear as field accessors have @JsonbTransient,\n    // but field itself has annotation " +
+                "other than transient\n    @JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    " +
+                "\n    @JsonbProperty(\"person-id\")\n    private int getId() { \n        // A diagnostic is" +
+                " expected on getId because as a getter, it is annotated with other \n        // Jsonb annotations" +
+                " while its corresponding field id is annotated with JsonbTransient\n        return id;\n    }\n" +
+                "    \n    @JsonbAnnotation\n    private void setId(int id) {\n        // A diagnostic is expected" +
+                " on setId because as a setter, it is annotated with other \n        // Jsonb annotations while" +
+                " its corresponding field id is annotated with JsonbTransient\n        this.id = id;\n    }\n   " +
+                " \n    @JsonbTransient\n    private String getFavoriteDatabase() {\n        " +
+                "return favoriteDatabase;\n    }\n    \n    @JsonbTransient\n    private void " +
+                "setFavoriteDatabase(String favoriteDatabase) {\n        this.favoriteDatabase = favoriteDatabase;\n" +
+                "    }\n    \n    // A diagnostic will appear as field has conflicting annotation\n    " +
+                "@JsonbTransient\n    private String getFavoriteEditor() {\n        return favoriteEditor;\n    }\n " +
+                "   \n    // A diagnostic will appear as @JsonbTransient is not mutually exclusive on this " +
+                "accessor\n    @JsonbAnnotation\n    @JsonbTransient\n    private void setFavoriteEditor" +
+                "(String favoriteEditor) {\n        this.favoriteEditor = favoriteEditor;\n    }\n}";
 
-            // Quick fix for the accessor "getId"
-            JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, d5);
-            TextEdit te7 = JakartaForJavaAssert.te(41, 4, 42, 4, "");
-            CodeAction ca7 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d5, te7);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, ca7);
+        TextEdit te3 = JakartaForJavaAssert.te(0, 0, 77, 1, newText1);
+        TextEdit te4 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
+        CodeAction ca3 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d2, te3);
+        CodeAction ca4 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d2, te4);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca4, ca3);
 
-            // Quick fix for the accessor "setId"
-            JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, d6);
-            TextEdit te8 = JakartaForJavaAssert.te(48, 4, 49, 4, "");
-            CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
-        }
+        // Quick fix for the field "favoriteLanguage"
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+        newText1 = "/******************************************************************************* \n* Copyright" +
+                " (c) 2022 IBM Corporation and others.\n *\n * This program and the accompanying materials are made" +
+                " available under the\n * terms of the Eclipse Public License v. 2.0 which is available at\n" +
+                " * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier: EPL-2.0\n *\n * " +
+                "Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n ******************" +
+                "*************************************************************/\n\npackage io.openliberty.sample." +
+                "jakarta.jsonb;\n\nimport jakarta.json.bind.annotation.JsonbAnnotation;\nimport jakarta.json.bind." +
+                "annotation.JsonbProperty;\nimport jakarta.json.bind.annotation.JsonbTransient;\n\npublic class " +
+                "JsonbTransientDiagnostic {\n    @JsonbTransient\n    private int id;\n\n   " +
+                " @JsonbProperty(\"name\")\n    @JsonbTransient\n    private String name;    // Diagnostic: " +
+                "JsonbTransient is mutually exclusive with other JsonB annotations\n\n    @JsonbTransient\n    " +
+                "private String favoriteLanguage;    // Diagnostic: JsonbTransient is mutually exclusive with other" +
+                " JsonB annotations\n    \n    // No diagnostic as field is not annotated with other Jsonb " +
+                "annotations,\n    // even though the accessors are annotated with @JsonbTransient\n   " +
+                " private String favoriteDatabase;\n    \n    // Diagnostic will appear as field accessors have " +
+                "@JsonbTransient,\n    // but field itself has annotation other than transient\n   " +
+                " @JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    \n   " +
+                " @JsonbProperty(\"person-id\")\n    private int getId() { \n        // A diagnostic is expected " +
+                "on getId because as a getter, it is annotated with other \n        // Jsonb annotations while its" +
+                " corresponding field id is annotated with JsonbTransient\n        return id;\n    }\n    \n    " +
+                "@JsonbAnnotation\n    private void setId(int id) {\n        // A diagnostic is expected on setId" +
+                " because as a setter, it is annotated with other \n        // Jsonb annotations while its " +
+                "corresponding field id is annotated with JsonbTransient\n        this.id = id;\n    }\n    \n    " +
+                "@JsonbTransient\n    private String getFavoriteDatabase() {\n        return favoriteDatabase;\n   " +
+                " }\n    \n    @JsonbTransient\n    private void setFavoriteDatabase(String favoriteDatabase) {\n  " +
+                "      this.favoriteDatabase = favoriteDatabase;\n    }\n    \n    // A diagnostic will appear as " +
+                "field has conflicting annotation\n    @JsonbTransient\n    private String getFavoriteEditor() {\n " +
+                "       return favoriteEditor;\n    }\n    \n    // A diagnostic will appear as @JsonbTransient " +
+                "is not mutually exclusive on this accessor\n    @JsonbAnnotation\n    @JsonbTransient\n   " +
+                " private void setFavoriteEditor(String favoriteEditor) {\n        this.favoriteEditor = " +
+                "favoriteEditor;\n    }\n}";
+
+        newText = "/******************************************************************************* \n* " +
+                "Copyright (c) 2022 IBM Corporation and others.\n *\n * This program and the accompanying" +
+                " materials are made available under the\n * terms of the Eclipse Public License v. 2.0 " +
+                "which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier" +
+                ": EPL-2.0\n *\n * Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n" +
+                " *******************************************************************************/\n\n" +
+                "package io.openliberty.sample.jakarta.jsonb;\n\nimport jakarta.json.bind.annotation." +
+                "JsonbAnnotation;\nimport jakarta.json.bind.annotation.JsonbProperty;\nimport jakarta." +
+                "json.bind.annotation.JsonbTransient;\n\npublic class JsonbTransientDiagnostic {\n   " +
+                " @JsonbTransient\n    private int id;\n\n    @JsonbProperty(\"name\")\n    @JsonbTransient\n   " +
+                " private String name;    // Diagnostic: JsonbTransient is mutually exclusive with other JsonB " +
+                "annotations\n\n    @JsonbProperty(\"fav_lang\")\n    @JsonbAnnotation\n    private " +
+                "String favoriteLanguage;    // Diagnostic: JsonbTransient is mutually exclusive with other " +
+                "JsonB annotations\n    \n    // No diagnostic as field is not annotated with other Jsonb " +
+                "annotations,\n    // even though the accessors are annotated with @JsonbTransient\n    " +
+                "private String favoriteDatabase;\n    \n    // Diagnostic will appear as field accessors" +
+                " have @JsonbTransient,\n    // but field itself has annotation other than transient\n    " +
+                "@JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    \n    " +
+                "@JsonbProperty(\"person-id\")\n    private int getId() { \n        // A diagnostic is expected" +
+                " on getId because as a getter, it is annotated with other \n        // Jsonb annotations while " +
+                "its corresponding field id is annotated with JsonbTransient\n        return id;\n    }\n    \n" +
+                "    @JsonbAnnotation\n    private void setId(int id) {\n        // A diagnostic is expected on" +
+                " setId because as a setter, it is annotated with other \n        // Jsonb annotations while its" +
+                " corresponding field id is annotated with JsonbTransient\n        this.id = id;\n    }\n    \n" +
+                "    @JsonbTransient\n    private String getFavoriteDatabase() {\n        " +
+                "return favoriteDatabase;\n    }\n    \n    @JsonbTransient\n    private void setFavoriteDatabase" +
+                "(String favoriteDatabase) {\n        this.favoriteDatabase = favoriteDatabase;\n    }\n    \n  " +
+                "  // A diagnostic will appear as field has conflicting annotation\n    @JsonbTransient\n   " +
+                " private String getFavoriteEditor() {\n        return favoriteEditor;\n    }\n    \n    " +
+                "// A diagnostic will appear as @JsonbTransient is not mutually exclusive on this accessor\n  " +
+                "  @JsonbAnnotation\n    @JsonbTransient\n    private void setFavoriteEditor(String favoriteEditor)" +
+                " {\n        this.favoriteEditor = favoriteEditor;\n    }\n}";
+
+        TextEdit te5 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
+        TextEdit te6 = JakartaForJavaAssert.te(0, 0, 77, 1, newText1);
+        CodeAction ca5 = JakartaForJavaAssert.ca(uri, "Remove @JsonbTransient", d3, te5);
+        CodeAction ca6 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty, @JsonbAnnotation", d3, te6);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, ca6, ca5);
+
+        // Quick fix for the accessor "getId"
+        JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, d5);
+        newText = "/******************************************************************************* " +
+                "\n* Copyright (c) 2022 IBM Corporation and others.\n *\n * This program and the " +
+                "accompanying materials are made available under the\n * terms of the Eclipse Public License v. 2.0 " +
+                "which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-Identifier: " +
+                "EPL-2.0\n *\n * Contributors:\n *     Adit Rada, Yijia Jing - initial API and implementation\n " +
+                "*******************************************************************************/" +
+                "\n\npackage io.openliberty.sample.jakarta.jsonb;\n\nimport" +
+                " jakarta.json.bind.annotation.JsonbAnnotation;\nimport jakarta.json.bind.annotation.JsonbProperty;" +
+                "\nimport jakarta.json.bind.annotation.JsonbTransient;\n\npublic class JsonbTransientDiagnostic " +
+                "{\n    @JsonbTransient\n    private int id;\n\n    @JsonbProperty(\"name\")\n    @JsonbTransient\n" +
+                "    private String name;    // Diagnostic: JsonbTransient is mutually exclusive with other" +
+                " JsonB annotations\n\n    @JsonbProperty(\"fav_lang\")\n    @JsonbAnnotation\n   " +
+                " @JsonbTransient\n    private String favoriteLanguage;    // Diagnostic: JsonbTransient is" +
+                " mutually exclusive with other JsonB annotations\n    \n    // No diagnostic as field is not" +
+                " annotated with other Jsonb annotations,\n    // even though the accessors are annotated with" +
+                " @JsonbTransient\n    private String favoriteDatabase;\n    \n    // Diagnostic will appear as" +
+                " field accessors have @JsonbTransient,\n    // but field itself has annotation other than " +
+                "transient\n    @JsonbProperty(\"fav_editor\")\n    private String favoriteEditor;\n    \n  " +
+                "  private int getId() { \n        // A diagnostic is expected on getId because as a getter," +
+                " it is annotated with other \n        // Jsonb annotations while its corresponding field id " +
+                "is annotated with JsonbTransient\n        return id;\n    }\n    \n    @JsonbAnnotation\n   " +
+                " private void setId(int id) {\n        // A diagnostic is expected on setId because as a setter, " +
+                "it is annotated with other \n        // Jsonb annotations while its corresponding field id is " +
+                "annotated with JsonbTransient\n        this.id = id;\n    }\n    \n    @JsonbTransient\n  " +
+                "  private String getFavoriteDatabase() {\n        return favoriteDatabase;\n    }\n    \n " +
+                "   @JsonbTransient\n    private void setFavoriteDatabase(String favoriteDatabase) {\n       " +
+                " this.favoriteDatabase = favoriteDatabase;\n    }\n    \n    // A diagnostic will appear as " +
+                "field has conflicting annotation\n    @JsonbTransient\n    private String getFavoriteEditor() {\n " +
+                "       return favoriteEditor;\n    }\n    \n    // A diagnostic will appear as @JsonbTransient " +
+                "is not mutually exclusive on this accessor\n    @JsonbAnnotation\n    @JsonbTransient\n   " +
+                " private void setFavoriteEditor(String favoriteEditor) {\n        this.favoriteEditor =" +
+                " favoriteEditor;\n    }\n}";
+
+
+        TextEdit te7 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
+        CodeAction ca7 = JakartaForJavaAssert.ca(uri, "Remove @JsonbProperty", d5, te7);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, ca7);
+
+        // Quick fix for the accessor "setId"
+        JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, d6);
+        newText = "/*******************************************************************************" +
+                " \n* Copyright (c) 2022 IBM Corporation and others.\n *\n * This program and the" +
+                " accompanying materials are made available under the\n * terms of the Eclipse Public License " +
+                "v. 2.0 which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * SPDX-License-" +
+                "Identifier: EPL-2.0\n *\n * Contributors:\n *     Adit Rada, Yijia Jing - initial API and" +
+                " implementation\n *******************************************************************************/" +
+                "\n\npackage io.openliberty.sample.jakarta.jsonb;\n\nimport jakarta.json.bind.annotation." +
+                "JsonbAnnotation;\nimport jakarta.json.bind.annotation.JsonbProperty;\nimport jakarta.json.bind." +
+                "annotation.JsonbTransient;\n\npublic class JsonbTransientDiagnostic {\n    @JsonbTransient\n  " +
+                "  private int id;\n\n    @JsonbProperty(\"name\")\n    @JsonbTransient\n    private String name; " +
+                "   // Diagnostic: JsonbTransient is mutually exclusive with other JsonB annotations\n\n   " +
+                " @JsonbProperty(\"fav_lang\")\n    @JsonbAnnotation\n    @JsonbTransient\n    private String" +
+                " favoriteLanguage;    // Diagnostic: JsonbTransient is mutually exclusive with other JsonB " +
+                "annotations\n    \n    // No diagnostic as field is not annotated with other Jsonb annotations,\n" +
+                "    // even though the accessors are annotated with @JsonbTransient\n    private String " +
+                "favoriteDatabase;\n    \n    // Diagnostic will appear as field accessors have @JsonbTransient,\n " +
+                "   // but field itself has annotation other than transient\n    @JsonbProperty(\"fav_editor\")\n" +
+                "    private String favoriteEditor;\n    \n    @JsonbProperty(\"person-id\")\n   " +
+                " private int getId() { \n        // A diagnostic is expected on getId because as a getter," +
+                " it is annotated with other \n        // Jsonb annotations while its corresponding field id is " +
+                "annotated with JsonbTransient\n        return id;\n    }\n    \n    private void setId(int id) " +
+                "{\n        // A diagnostic is expected on setId because as a setter, it is annotated with other " +
+                "\n        // Jsonb annotations while its corresponding field id is annotated with JsonbTransient\n" +
+                "        this.id = id;\n    }\n    \n    @JsonbTransient\n    private String getFavoriteDatabase()" +
+                " {\n        return favoriteDatabase;\n    }\n    \n    @JsonbTransient\n    private void " +
+                "setFavoriteDatabase(String favoriteDatabase) {\n        this.favoriteDatabase = favoriteDatabase;\n" +
+                "    }\n    \n    // A diagnostic will appear as field has conflicting annotation\n   " +
+                " @JsonbTransient\n    private String getFavoriteEditor() {\n        return favoriteEditor;\n   " +
+                " }\n    \n    // A diagnostic will appear as @JsonbTransient is not mutually exclusive on this " +
+                "accessor\n    @JsonbAnnotation\n    @JsonbTransient\n    private void setFavoriteEditor(String" +
+                " favoriteEditor) {\n        this.favoriteEditor = favoriteEditor;\n    }\n}";
+
+        TextEdit te8 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
+        CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
+//        }
     }
 }


### PR DESCRIPTION
Fixes #611

LSP4Jakarta ambiguously matches the expected class names when checking diagnostics, applying quick fixes, etc

Updated all of the diagnostic collectors to include fully qualified class names in the diagnostic data that they produce. And fixed the quick fix  issue of JsonbTransientAnnotationQuickFix and ScopeDeclarationQuickFix.