### PR TITLE
Implementing a workaround for an issue with JavaCursorContextKind.forValue().

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -122,8 +122,19 @@ public final class PropertiesManagerForJakarta {
 
     private JavaCursorContextResult adapt(org.eclipse.lsp4mp.commons.JavaCursorContextResult contextResult) {
         if (contextResult != null) {
-            var kind = contextResult.getKind();
-            return new JavaCursorContextResult(JavaCursorContextKind.forValue(kind.getValue()), contextResult.getPrefix());
+            return new JavaCursorContextResult(adapt(contextResult.getKind()), contextResult.getPrefix());
+        }
+        return null;
+    }
+
+    private JavaCursorContextKind adapt(org.eclipse.lsp4mp.commons.JavaCursorContextKind kind) {
+        if (kind != null) {
+            // Workaround for an issue with JavaCursorContextKind.forValue().
+            // See https://github.com/OpenLiberty/liberty-tools-intellij/issues/681 for details.
+            if (kind == org.eclipse.lsp4mp.commons.JavaCursorContextKind.NONE) {
+                return JavaCursorContextKind.NONE;
+            }
+            return JavaCursorContextKind.forValue(kind.getValue());
         }
         return null;
     }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/681. This is achieved by treating `JavaCursorContextKind.NONE` as a special case, avoiding the issue with retrieving the enum value through the `forValue()` method.