### PR TITLE
Bump minimum supported IDE version to 2023.2

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
     <depends>com.intellij.properties</depends>
     <depends>org.jetbrains.idea.maven</depends>
     <depends>com.intellij.gradle</depends>
-    <idea-version since-build="231" until-build="233.*"/>
+    <idea-version since-build="232" until-build="233.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"


### PR DESCRIPTION
Did a quick smoke test on IntelliJ IDEA 2023.2 and 2023.3.6