### PR TITLE
Update github action to specify tag 0.0.4 for lsp4ij

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           repository: MicroShed/lsp4ij
           path: lsp4ij
+          ref: refs/tags/0.0.4
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Once we update lsp4ij we will need to specify the correct tag if we build 24.0.3.