### PR TITLE
Fixed to throw IllegalStateException

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -388,13 +388,12 @@ public class TestUtils {
                     Thread.sleep(retryIntervalSecs * 1000);
                 } catch (Exception e) {
                     e.printStackTrace(System.out);
-                    continue;
                 }
-                continue;
+            } else {
+                return;
             }
-
-            return;
         }
+        throw new IllegalStateException("Timed out waiting for test report: " + pathToTestReport + " file to be created.");
     }
 
     /**


### PR DESCRIPTION
Fixes #707 
I confirmed that each of the tests relying on the method **validateTestReportExists** (https://github.com/OpenLiberty/liberty-tools-intellij/blob/main/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java#L377)  failed when a test report was not created.