### PR TITLE
Enable pending quick fixes, which also extend RemoveAnnotationConflictQuickFix

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -347,11 +347,7 @@
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#RemoveProducesOrInject"
-                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveProduceAnnotationQuickFix"/>
-        <javaCodeActionParticipant kind="quickfix"
-                                   group="jakarta"
-                                   targetDiagnostic="jakarta-cdi#RemoveProducesOrInject"
-                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveInjectAnnotationQuickFix"/>
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ConflictProducesInjectQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#RemoveInjectOrConflictedAnnotations"
@@ -388,6 +384,10 @@
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#InvalidScopeDecl"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ScopeDeclarationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-di#RemoveInject"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.di.ConflictInjectMultipleConstructorQuickFix"/>
 
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/MultipleConstructorInjectTest.java
@@ -66,19 +66,42 @@ public class MultipleConstructorInjectTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-di", "RemoveInject");
         
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1,d2,d3);
-
-        if (CHECK_CODE_ACTIONS) {
+        
             // test expected quick-fix
-            JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
-            TextEdit te = JakartaForJavaAssert.te(21, 4, 22, 4, "");
-            CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca);
+        String newText = "/*******************************************************************************\n" +
+                "* Copyright (c) 2021 IBM Corporation.\n*\n* This program and the accompanying materials are made available under the\n" +
+                "* terms of the Eclipse Public License v. 2.0 which is available at\n* http://www.eclipse.org/legal/epl-2.0.\n*\n" +
+                "* SPDX-License-Identifier: EPL-2.0\n*\n* Contributors:\n*     Ananya Rao\n" +
+                "*******************************************************************************/\n\n" +
+                "package io.openliberty.sample.jakarta.di;\n\nimport jakarta.inject.Inject;\n\n" +
+                "public class MultipleConstructorWithInject{\n    private int productNum;\n    private String productDesc;\n	\n" +
+                "    public MultipleConstructorWithInject(int productNum) {\n        this.productNum = productNum;\n	}\n" +
+                "    @Inject\n    public MultipleConstructorWithInject(String productDesc) {\n" +
+                "        this.productDesc = productDesc;\n	}\n\n    @Inject\n" +
+                "    protected MultipleConstructorWithInject(int productNum, String productDesc) {\n" +
+                "        this.productNum = productNum;\n        this.productDesc = productDesc;\n	}\n}\n\n";
 
-            JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
-            TextEdit te2 = JakartaForJavaAssert.te(30, 4, 31, 4, "");
-            CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te2);
-            JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
-        }
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        TextEdit te = JakartaForJavaAssert.te(0, 0, 37, 0, newText);
+        CodeAction ca = JakartaForJavaAssert.ca(uri, "Remove @Inject", d1, te);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, ca);
+
+        String newText1 = "/*******************************************************************************\n" +
+                "* Copyright (c) 2021 IBM Corporation.\n*\n* This program and the accompanying materials are made available under the\n" +
+                "* terms of the Eclipse Public License v. 2.0 which is available at\n* http://www.eclipse.org/legal/epl-2.0.\n*\n" +
+                "* SPDX-License-Identifier: EPL-2.0\n*\n* Contributors:\n" +
+                "*     Ananya Rao\n*******************************************************************************/\n\n" +
+                "package io.openliberty.sample.jakarta.di;\n\nimport jakarta.inject.Inject;\n\n" +
+                "public class MultipleConstructorWithInject{\n    private int productNum;\n    private String productDesc;\n	\n" +
+                "    @Inject\n    public MultipleConstructorWithInject(int productNum) {\n        this.productNum = productNum;\n	}\n" +
+                "    @Inject\n    public MultipleConstructorWithInject(String productDesc) {\n        this.productDesc = productDesc;\n	}\n\n" +
+                "    protected MultipleConstructorWithInject(int productNum, String productDesc) {\n        this.productNum = productNum;\n" +
+                "        this.productDesc = productDesc;\n	}\n}\n\n";
+
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, d3);
+        TextEdit te2 = JakartaForJavaAssert.te(0, 0, 37, 0, newText1);
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove @Inject", d3, te2);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, ca2);
     }
 
 }


### PR DESCRIPTION
Fixes #593 

This PR will complete issue #593
There are two more quickfix classes, `ConflictInjectMultipleConstructorQuickFix` and `ConflictProducesInjectQuickFix` both of which extend the **RemoveAnnotationConflictQuickFix** class.
Initially I  couldn't find the relevant test. However, I have now found it. And I found that **ConflictProducesInjectQuickFix** can be utilized to resolve diagnostic when both `the @Produces and @Inject annotations are used on the same field or property.
`
