### PR TITLE
Override AnAction.getActionUpdateThread() as required by IntelliJ.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -13,6 +13,7 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -32,6 +33,13 @@ import java.util.List;
 
 public abstract class LibertyGeneralAction extends AnAction {
     protected static final Logger LOGGER = Logger.getInstance(LibertyGeneralAction.class);
+
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        // Schedule actions on the event dispatching thread.
+        // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
+        return ActionUpdateThread.EDT;
+    }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -35,7 +35,7 @@ public abstract class LibertyGeneralAction extends AnAction {
     protected static final Logger LOGGER = Logger.getInstance(LibertyGeneralAction.class);
 
     @Override
-    public ActionUpdateThread getActionUpdateThread() {
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
         // Schedule actions on the event dispatching thread.
         // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
         return ActionUpdateThread.EDT;

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -11,6 +11,7 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.projectView.ProjectView;
 import com.intellij.openapi.actionSystem.ActionToolbar;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -33,6 +34,13 @@ import java.awt.*;
 
 public class RefreshLibertyToolbar extends AnAction {
     private static final Logger LOGGER = Logger.getInstance(RefreshLibertyToolbar.class);
+
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        // Schedule actions on the event dispatching thread.
+        // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
+        return ActionUpdateThread.EDT;
+    }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -36,7 +36,7 @@ public class RefreshLibertyToolbar extends AnAction {
     private static final Logger LOGGER = Logger.getInstance(RefreshLibertyToolbar.class);
 
     @Override
-    public ActionUpdateThread getActionUpdateThread() {
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
         // Schedule actions on the event dispatching thread.
         // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
         return ActionUpdateThread.EDT;

--- a/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
@@ -36,7 +36,7 @@ public class RunLibertyDevTask extends AnAction {
     private static final Logger LOGGER = Logger.getInstance(RunLibertyDevTask.class);
 
     @Override
-    public ActionUpdateThread getActionUpdateThread() {
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
         // Schedule actions on the event dispatching thread.
         // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
         return ActionUpdateThread.EDT;

--- a/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
@@ -11,6 +11,7 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -33,6 +34,13 @@ import java.awt.*;
 
 public class RunLibertyDevTask extends AnAction {
     private static final Logger LOGGER = Logger.getInstance(RunLibertyDevTask.class);
+
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        // Schedule actions on the event dispatching thread.
+        // See: https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides.
+        return ActionUpdateThread.EDT;
+    }
 
     /**
      * Enables/disables the play/action button for the Liberty projects and action options in the Liberty Tool Window tree


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/720. Schedule Liberty actions to run on the `EDT`. This is effectively the same as the default `OLD_EDT` which is deprecated.