### PR TITLE
Add GraphQL support for diagnostics for MicroProfile

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -294,6 +294,7 @@
             <attribute name="jitter" range="0"/> <!-- x >=0 -->
             <attribute name="maxRetries" range="-1"/> <!-- x >=0 -->
         </javaASTValidator.annotationValidator>
+        <javaASTValidator.validator implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.graphql.java.MicroProfileGraphQLASTValidator"/>
     </extensions>
 
     <projectListeners>


### PR DESCRIPTION
Fixes #699 

You can test with a project created at microprofile.io that includes graphql (check the appropriate box).

One diagnostic is generated when you add @Query to a field in a class.