### PR TITLE
Wait 60s when starting server in the test Run Tests and wait 1s for search for Liberty:Start

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -439,6 +439,7 @@ public abstract class SingleModMPProjectTestCommon {
 
         // Start dev mode.
         UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Liberty: Start", 3);
+        TestUtils.sleepAndIgnoreException(60); // Leave plenty of time for the server to start
 
         try {
             // Validate that the application started.

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1596,6 +1596,7 @@ public class UIBotTestUtils {
                 JTextFieldFixture searchField = projectFrame.textField(JTextFieldFixture.Companion.byType(), Duration.ofSeconds(10));
                 searchField.click();
                 searchField.setText(action);
+                TestUtils.sleepAndIgnoreException(1); // allow the search for 'action' to complete
 
                 // Wait for the desired action to show in the search output frame and click on it.
                 RepeatUtilsKt.waitFor(Duration.ofSeconds(20),


### PR DESCRIPTION
Three "green" runs in a row hopefully demonstrates this fix works. The first run had the quick fix error so technicaslly not green but it did not have tis error. 

![image](https://github.com/OpenLiberty/liberty-tools-intellij/assets/24705144/f25988e7-7e3e-43d0-b7a6-57107e224b23)

This fix works the same as that for #768 

Fixes #769 