### PR TITLE
Include RemoveStaticModifierQuickFix for resolving a @PreDestroy diagnostic and update unit tests.

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -258,6 +258,10 @@
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations.RemovePreDestroyAnnotationQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"
+                                   targetDiagnostic="jakarta-annotations#PreDestroyStatic"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveStaticModifierQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
                                    targetDiagnostic="jakarta-annotations#PostConstructParams"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveMethodParametersQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PreDestroyAnnotationTest.java
@@ -24,9 +24,8 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -64,13 +63,6 @@ public class PreDestroyAnnotationTest extends BaseJakartaTest {
                 DiagnosticSeverity.Warning, "jakarta-annotations", "PreDestroyException");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d2, d1, d3);
-        
-        if (CHECK_CODE_ACTIONS) {
-            JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-            TextEdit te3 = te(26, 7, 26, 14, "");
-            CodeAction ca3 = ca(uri, "Remove the 'static' modifier from this method", d2, te3);
-            assertJavaCodeAction(codeActionParams1, utils, ca3);
-        }
 
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
         String newText = "package io.openliberty.sample.jakarta.annotations;\n\n" +
@@ -137,10 +129,29 @@ public class PreDestroyAnnotationTest extends BaseJakartaTest {
                 "		System.out.println(\"I'm sad\");\n	}\n\n\n" +
                 "    private String emailAddress;\n\n\n}\n\n\n\n";
 
+        String newText2 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.annotation.Resource;\n\n" +
+                "@Resource(type = Object.class, name = \"aa\") \n" +
+                "public class PreDestroyAnnotation { \n\n" +
+                "    private Integer studentId;\n	\n    private boolean isHappy;\n\n" +
+                "    private boolean isSad;\n	\n	@PreDestroy()\n" +
+                "	public Integer getStudentId() {\n		return this.studentId;\n" +
+                "	}\n	\n	@PreDestroy()\n	public boolean getHappiness(String type) {\n" +
+                "		if (type.equals(\"happy\")) return this.isHappy;\n" +
+                "		return this.isSad;\n	}\n	\n" +
+                "	@PreDestroy()\n	public void makeUnhappy() {\n" +
+                "		System.out.println(\"I'm sad\");\n	}\n	\n	@PreDestroy()\n" +
+                "	public void throwTantrum() throws Exception {\n" +
+                "		System.out.println(\"I'm sad\");\n	}\n\n\n" +
+                "    private String emailAddress;\n\n\n}\n\n\n\n";
+
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
         TextEdit te2 = te(0, 0, 43, 0, newText1);
         CodeAction ca2 = ca(uri, "Remove @PreDestroy", d2, te2);
-        assertJavaCodeAction(codeActionParams1, utils, ca2);
+        TextEdit te3 = te(0, 0, 43, 0, newText2);
+        CodeAction ca3 = ca(uri, "Remove the 'static' modifier from this method", d2, te3);
+        assertJavaCodeAction(codeActionParams1, utils, ca2, ca3);
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -44,8 +44,6 @@ import java.util.stream.Collectors;
  */
 public abstract class BaseJakartaTest extends MavenImportingTestCase {
 
-    protected static final boolean CHECK_CODE_ACTIONS = false;
-
     protected TestFixtureBuilder<IdeaProjectTestFixture> myProjectBuilder;
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/766 by including the missing quick fix for removing the `static` modifier from a method annotated with `@PreDestroy` and completing enablement of the relevant unit test.

This PR also resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/476 by enabling the last of the Jakarta EE quick fix tests.

![image](https://github.com/OpenLiberty/liberty-tools-intellij/assets/890521/fdd27a13-a189-4b4e-985e-eaa92ccc4c57)
![image](https://github.com/OpenLiberty/liberty-tools-intellij/assets/890521/d01b04a5-0c9d-4625-a737-969bfbe0a835)
