### PR TITLE
Fix  Diagnostic missing for @PositiveOrZero and enabled test

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation, Reza Akhavan and others.
+ * Copyright (c) 2020, 2024 IBM Corporation, Reza Akhavan and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,7 +34,7 @@ public class BeanValidationConstants {
     public static final String MIN = "jakarta.validation.constraints.Min";
     public static final String MAX = "jakarta.validation.constraints.Max";
     public static final String NEGATIVE_OR_ZERO = "jakarta.validation.constraints.NegativeOrZero";
-    public static final String POSTIVE_OR_ZERO = "jakarta.validation.constraints.PositiveOrZero";
+    public static final String POSITIVE_OR_ZERO = "jakarta.validation.constraints.PositiveOrZero";
     public static final String NEGATIVE = "jakarta.validation.constraints.Negative";
     public static final String POSITIVE = "jakarta.validation.constraints.Positive";
     public static final String NOT_BLANK = "jakarta.validation.constraints.NotBlank";
@@ -78,7 +78,7 @@ public class BeanValidationConstants {
     public final static Set<String> SET_OF_ANNOTATIONS = Collections
             .unmodifiableSet(new HashSet<String>(Arrays.asList(ASSERT_TRUE, ASSERT_FALSE, DIGITS, DECIMAL_MAX,
                     DECIMAL_MIN, EMAIL, PAST_OR_PRESENT, FUTURE_OR_PRESENT, PAST, FUTURE, MIN, MAX, NEGATIVE_OR_ZERO,
-                    POSTIVE_OR_ZERO, NEGATIVE, POSITIVE, NOT_BLANK, PATTERN, SIZE, NOT_EMPTY)));
+                    POSITIVE_OR_ZERO, NEGATIVE, POSITIVE, NOT_BLANK, PATTERN, SIZE, NOT_EMPTY)));
     public final static Set<String> SET_OF_DATE_TYPES = Collections
             .unmodifiableSet(new HashSet<String>(Arrays.asList(THAI_BUDDHIST_DATE, MINGUO_DATE, JAPANESE_DATE,
                     HIJRAH_DATE, ZONED_DATE_TIME, YEAR_MONTH, YEAR, OFFSET_TIME, OFFSET_DATE_TIME, MONTH_DAY,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
@@ -34,7 +34,7 @@ public class BeanValidationConstants {
     public static final String MIN = "jakarta.validation.constraints.Min";
     public static final String MAX = "jakarta.validation.constraints.Max";
     public static final String NEGATIVE_OR_ZERO = "jakarta.validation.constraints.NegativeOrZero";
-    public static final String POSTIVE_OR_ZERO = "jakarta.validation.constraints.PostiveOrZero";
+    public static final String POSTIVE_OR_ZERO = "jakarta.validation.constraints.PositiveOrZero";
     public static final String NEGATIVE = "jakarta.validation.constraints.Negative";
     public static final String POSITIVE = "jakarta.validation.constraints.Positive";
     public static final String NOT_BLANK = "jakarta.validation.constraints.NotBlank";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation, Reza Akhavan and others.
+ * Copyright (c) 2020, 2024 IBM Corporation, Reza Akhavan and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -149,7 +149,7 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
                 } else if (matchedAnnotation.equals(NEGATIVE) || matchedAnnotation.equals(NEGATIVE_OR_ZERO)
-                        || matchedAnnotation.equals(POSITIVE) || matchedAnnotation.equals(POSTIVE_OR_ZERO)) {
+                        || matchedAnnotation.equals(POSITIVE) || matchedAnnotation.equals(POSITIVE_OR_ZERO)) {
                     if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
                             && !type.getCanonicalText().endsWith(BIG_INTEGER)
                             && !type.equals(PsiType.BYTE)

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -153,10 +153,9 @@ public class BeanValidationTest extends BaseJakartaTest {
                         + "- byte, short, int, long, float, double (and their respective wrappers) \n"
                         + " type fields.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Positive");
-        // not yet implemented
-//        Diagnostic d18 = d(11, 17, 24,
-//                "The @PositiveOrZero annotation can only be used on boolean and Boolean type fields.",
-//                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "PositiveOrZero");
+        Diagnostic d18 = d(57, 25, 34,
+                "The @PositiveOrZero annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long, float, double (and their respective wrappers) \n type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.PositiveOrZero");
         Diagnostic d19 = d(60, 27, 36,
                 "Constraint annotations are not allowed on static fields.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.AssertTrue");
@@ -165,7 +164,7 @@ public class BeanValidationTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.Past");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8,
-                d9, d10, d11, d12, d13, d14, d15, d16, d17, d19, d20);
+                d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20);
 
         // Test quickfix codeActions - type (1-17), static, static+type (should only display static)
         String newText = "package io.openliberty.sample.jakarta.beanvalidation;\n\nimport java.util.Calendar;\n" +
@@ -255,6 +254,26 @@ public class BeanValidationTest extends BaseJakartaTest {
         CodeAction ca4 = ca(uri, "Remove static modifier from element", d20, te4);
 
         assertJavaCodeAction(codeActionParams3, utils, ca3, ca4);
+
+        String newText10 = "package io.openliberty.sample.jakarta.beanvalidation;\n\nimport java.util.Calendar;\n" +
+                "import java.util.List;\n\nimport jakarta.validation.constraints.*;\n\n" +
+                "public class FieldConstraintValidation {\n\n    @AssertTrue\n    private int isHappy;                    // invalid types\n\n" +
+                "    @AssertFalse\n    private Double isSad;\n\n    @DecimalMax(\"30.0\")\n    @DecimalMin(\"10.0\")\n" +
+                "    private String bigDecimal;\n\n    @Digits(fraction = 0, integer = 0)\n    private boolean digits;\n\n" +
+                "    @Email\n    private Integer emailAddress;\n\n    @FutureOrPresent\n    private boolean graduationDate;\n\n" +
+                "    @Future\n    private double fergiesYear;\n\n    @Min(value = 50)\n    @Max(value = 100)\n    private boolean gpa;\n\n" +
+                "    @Negative\n    private boolean subZero;\n\n    @NegativeOrZero\n    private String notPos;\n\n    @NotBlank\n" +
+                "    private boolean saysomething;\n\n    @Pattern(regexp = \"\")\n    private Calendar thisIsUsed;\n\n    @Past\n" +
+                "    private double theGoodOldDays;\n\n    @PastOrPresent\n    private char[] aGoodFieldName;\n\n    @Positive\n" +
+                "    private String[] area;\n\n    private List<String> maybeZero;\n\n" +
+                "    @AssertTrue\n    private static boolean typeValid;       // static\n\n    @Past\n" +
+                "    private static boolean doubleBad;      // static and invalid type\n}";
+
+        JakartaJavaCodeActionParams codeActionParams4 = createCodeActionParams(uri, d18);
+        TextEdit te5 = te(0, 0, 64, 1, newText10);
+        CodeAction ca5 = ca(uri, "Remove constraint annotation jakarta.validation.constraints.PositiveOrZero from element", d1, te5);
+
+        assertJavaCodeAction(codeActionParams4, utils, ca5);
     }
 
     @Test


### PR DESCRIPTION
Fixes #781
I just enabled the test for diagnostics (d18) and added a test for the corresponding quick fix.