### PR TITLE
FVT: Execute cd and mvn in the same command for Liberty Actions

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -31,11 +31,11 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        String runTestsCommand = " ";
         ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }
+        String runTestsCommand = " ";
         LibertyActionUtil.executeCommand(widget, runTestsCommand);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -82,7 +82,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         }
 
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
-        LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
+        startCmd = cdToProjectCmd + "; " + startCmd; // IntelliJ Windows uses Power Shell so ; is ok
         LibertyActionUtil.executeCommand(widget, startCmd);
         if (libertyModule.isDebugMode() && debugPort != -1) {
             // Create remote configuration to attach debugger

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -51,7 +51,7 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
             return;
         }
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
-        LibertyActionUtil.executeCommand(widget, cdToProjectCmd);
+        startCmd = cdToProjectCmd + "; " + startCmd; // IntelliJ Windows uses Power Shell so ; is ok
         LibertyActionUtil.executeCommand(widget, startCmd);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -32,10 +32,10 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
         ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
-        String stopCmd = "q";
         if (widget == null) {
             return;
         }
+        String stopCmd = "q";
         LibertyActionUtil.executeCommand(widget, stopCmd);
     }
 }


### PR DESCRIPTION
I hope you don't mind but I included a bit of fix up on LibertyRunTestsAction and LibertyStopAction to clarify and simplify the code. These are all the places where `LibertyActionUtil.executeCommand()` are called.

Fixes #797