### PR TITLE
Fixed using Deprecated Maven Methods which are Marked for Removal

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -209,13 +209,13 @@ public class LibertyMavenUtil {
     final static String wrappedMaven = "Use Maven wrapper";
     public static String getMavenSettingsCmd(Project project, VirtualFile buildFile) throws LibertyException {
         MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
-        @NotNull MavenHomeType mavenHome = mavenSettings.getMavenHomeType();
-        if (wrappedMaven.equals(mavenHome.getTitle())) {
+        @NotNull MavenHomeType mavenHomeType = mavenSettings.getMavenHomeType();
+        if (wrappedMaven.equals(mavenHomeType.getTitle())) {
             // it is set to use the wrapper
             return getLocalMavenWrapper(buildFile);
         } else {
             // try to use maven home path defined in the settings
-            return getCustomMavenPath(project, mavenHome.getTitle());
+            return getCustomMavenPath(project, mavenHomeType.getTitle());
         }
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -252,7 +252,8 @@ public class LibertyMavenUtil {
      * @throws LibertyException
      */
     private static String getCustomMavenPath(Project project, @NotNull MavenHomeType customMavenHome) throws LibertyException {
-        StaticResolvedMavenHomeType resolvedMavenHomeType = getResolvedMavenHomeType(customMavenHome);
+        // If 'customMavenHome' is not an instance of 'StaticResolvedMavenHomeType',it using a fallback method (staticOrBundled) to return default 'BundledMaven3.INSTANCE'.
+        StaticResolvedMavenHomeType resolvedMavenHomeType = staticOrBundled(customMavenHome);
         File mavenHomeFile = MavenUtil.getMavenHomeFile(resolvedMavenHomeType);
         // when customMavenHome path is invalid it returns null
         if (mavenHomeFile == null) {
@@ -294,20 +295,6 @@ public class LibertyMavenUtil {
             throw new LibertyException(String.format("Could not execute the Maven executable %s. Make sure a valid path is configured " +
                     "inside IntelliJ Maven preferences.", mavenExecutable.getAbsolutePath()), translatedMessage);
         }
-    }
-
-    /**
-     * This method checks if the provided 'MavenHomeType' is an instance of 'StaticResolvedMavenHomeType'.
-     * If it is, it returns the casted object. Otherwise, it uses a fallback method (staticOrBundled) to return default 'BundledMaven3.INSTANCE'
-     * @param customMavenHome the custom MavenHomeType to be resolved
-     * @return the resolved StaticResolvedMavenHomeType
-     */
-    private static StaticResolvedMavenHomeType getResolvedMavenHomeType(MavenHomeType customMavenHome) {
-        if (customMavenHome instanceof StaticResolvedMavenHomeType) {
-            return (StaticResolvedMavenHomeType) customMavenHome;
-        }
-        // If 'customMavenHome' is not an instance of 'StaticResolvedMavenHomeType', return default 'BundledMaven3.INSTANCE'.
-        return staticOrBundled(customMavenHome);
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -14,9 +14,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.execution.MavenExternalParameters;
 import org.jetbrains.idea.maven.project.MavenGeneralSettings;
+import org.jetbrains.idea.maven.project.MavenHomeType;
 import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
+import org.jetbrains.idea.maven.project.StaticResolvedMavenHomeType;
 import org.jetbrains.idea.maven.server.MavenServerConnector;
 import org.jetbrains.idea.maven.server.MavenServerManager;
 import org.jetbrains.idea.maven.utils.MavenUtil;
@@ -204,13 +207,13 @@ public class LibertyMavenUtil {
     final static String wrappedMaven = "Use Maven wrapper";
     public static String getMavenSettingsCmd(Project project, VirtualFile buildFile) throws LibertyException {
         MavenGeneralSettings mavenSettings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings().getGeneralSettings();
-        String mavenHome = mavenSettings.getMavenHome();
-        if (wrappedMaven.equals(mavenHome)) {
+        @NotNull MavenHomeType mavenHome = mavenSettings.getMavenHomeType();
+        if (wrappedMaven.equals(mavenHome.getTitle())) {
             // it is set to use the wrapper
             return getLocalMavenWrapper(buildFile);
         } else {
             // try to use maven home path defined in the settings
-            return getCustomMavenPath(project, mavenHome);
+            return getCustomMavenPath(project, (StaticResolvedMavenHomeType) mavenHome);
         }
     }
 
@@ -246,8 +249,8 @@ public class LibertyMavenUtil {
      * @return Maven path to be executed or an exception to display
      * @throws LibertyException
      */
-    private static String getCustomMavenPath(Project project, String customMavenHome) throws LibertyException {
-        File mavenHomeFile = MavenUtil.resolveMavenHomeDirectory(customMavenHome); // when customMavenHome path is invalid it returns null
+    private static String getCustomMavenPath(Project project, StaticResolvedMavenHomeType customMavenHome) throws LibertyException {
+        File mavenHomeFile = MavenUtil.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
         if (mavenHomeFile == null) {
             String translatedMessage = LocalizedResourceUtil.getMessage("maven.invalid.build.preference");
             throw new LibertyException("Make sure to configure a valid path for Maven home path inside IntelliJ Maven preferences.", translatedMessage);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -38,7 +38,6 @@ import java.util.Iterator;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
-import static org.jetbrains.idea.maven.project.MavenHomeKt.resolveMavenHomeType;
 import static org.jetbrains.idea.maven.project.MavenHomeKt.staticOrBundled;
 
 public class LibertyMavenUtil {
@@ -297,11 +296,18 @@ public class LibertyMavenUtil {
         }
     }
 
+    /**
+     * This method checks if the provided 'MavenHomeType' is an instance of 'StaticResolvedMavenHomeType'.
+     * If it is, it returns the casted object. Otherwise, it uses a fallback method (staticOrBundled) to return default 'BundledMaven3.INSTANCE'
+     * @param customMavenHome the custom MavenHomeType to be resolved
+     * @return the resolved StaticResolvedMavenHomeType
+     */
     private static StaticResolvedMavenHomeType getResolvedMavenHomeType(MavenHomeType customMavenHome) {
         if (customMavenHome instanceof StaticResolvedMavenHomeType) {
             return (StaticResolvedMavenHomeType) customMavenHome;
         }
-        return null;
+        // If 'customMavenHome' is not an instance of 'StaticResolvedMavenHomeType', return default 'BundledMaven3.INSTANCE'.
+        return staticOrBundled(customMavenHome);
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -19,6 +19,7 @@ import org.jetbrains.idea.maven.execution.MavenExternalParameters;
 import org.jetbrains.idea.maven.project.MavenGeneralSettings;
 import org.jetbrains.idea.maven.project.MavenHomeType;
 import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
+import org.jetbrains.idea.maven.project.StaticResolvedMavenHomeType;
 import org.jetbrains.idea.maven.server.MavenServerConnector;
 import org.jetbrains.idea.maven.server.MavenServerManager;
 import org.jetbrains.idea.maven.utils.MavenUtil;
@@ -215,7 +216,7 @@ public class LibertyMavenUtil {
             return getLocalMavenWrapper(buildFile);
         } else {
             // try to use maven home path defined in the settings
-            return getCustomMavenPath(project, mavenHomeType.getTitle());
+            return getCustomMavenPath(project, mavenHomeType);
         }
     }
 
@@ -251,8 +252,10 @@ public class LibertyMavenUtil {
      * @return Maven path to be executed or an exception to display
      * @throws LibertyException
      */
-    private static String getCustomMavenPath(Project project, String customMavenHome) throws LibertyException {
-        File mavenHomeFile = MavenUtil.getMavenHomeFile(staticOrBundled(resolveMavenHomeType(customMavenHome))); // when customMavenHome path is invalid it returns null
+    private static String getCustomMavenPath(Project project, @NotNull MavenHomeType customMavenHome) throws LibertyException {
+        StaticResolvedMavenHomeType resolvedMavenHomeType = getResolvedMavenHomeType(customMavenHome);
+        File mavenHomeFile = MavenUtil.getMavenHomeFile(resolvedMavenHomeType);
+        // when customMavenHome path is invalid it returns null
         if (mavenHomeFile == null) {
             String translatedMessage = LocalizedResourceUtil.getMessage("maven.invalid.build.preference");
             throw new LibertyException("Make sure to configure a valid path for Maven home path inside IntelliJ Maven preferences.", translatedMessage);
@@ -292,6 +295,13 @@ public class LibertyMavenUtil {
             throw new LibertyException(String.format("Could not execute the Maven executable %s. Make sure a valid path is configured " +
                     "inside IntelliJ Maven preferences.", mavenExecutable.getAbsolutePath()), translatedMessage);
         }
+    }
+
+    private static StaticResolvedMavenHomeType getResolvedMavenHomeType(MavenHomeType customMavenHome) {
+        if (customMavenHome instanceof StaticResolvedMavenHomeType) {
+            return (StaticResolvedMavenHomeType) customMavenHome;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -19,7 +19,6 @@ import org.jetbrains.idea.maven.execution.MavenExternalParameters;
 import org.jetbrains.idea.maven.project.MavenGeneralSettings;
 import org.jetbrains.idea.maven.project.MavenHomeType;
 import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
-import org.jetbrains.idea.maven.project.StaticResolvedMavenHomeType;
 import org.jetbrains.idea.maven.server.MavenServerConnector;
 import org.jetbrains.idea.maven.server.MavenServerManager;
 import org.jetbrains.idea.maven.utils.MavenUtil;
@@ -37,6 +36,9 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
+
+import static org.jetbrains.idea.maven.project.MavenHomeKt.resolveMavenHomeType;
+import static org.jetbrains.idea.maven.project.MavenHomeKt.staticOrBundled;
 
 public class LibertyMavenUtil {
     private static Logger LOGGER = Logger.getInstance(LibertyMavenUtil.class);
@@ -213,7 +215,7 @@ public class LibertyMavenUtil {
             return getLocalMavenWrapper(buildFile);
         } else {
             // try to use maven home path defined in the settings
-            return getCustomMavenPath(project, (StaticResolvedMavenHomeType) mavenHome);
+            return getCustomMavenPath(project, mavenHome.getTitle());
         }
     }
 
@@ -249,8 +251,8 @@ public class LibertyMavenUtil {
      * @return Maven path to be executed or an exception to display
      * @throws LibertyException
      */
-    private static String getCustomMavenPath(Project project, StaticResolvedMavenHomeType customMavenHome) throws LibertyException {
-        File mavenHomeFile = MavenUtil.getMavenHomeFile(customMavenHome); // when customMavenHome path is invalid it returns null
+    private static String getCustomMavenPath(Project project, String customMavenHome) throws LibertyException {
+        File mavenHomeFile = MavenUtil.getMavenHomeFile(staticOrBundled(resolveMavenHomeType(customMavenHome))); // when customMavenHome path is invalid it returns null
         if (mavenHomeFile == null) {
             String translatedMessage = LocalizedResourceUtil.getMessage("maven.invalid.build.preference");
             throw new LibertyException("Make sure to configure a valid path for Maven home path inside IntelliJ Maven preferences.", translatedMessage);


### PR DESCRIPTION
Fixes #823 
Updated `getMavenHome()` method to `getMavenHomeType()` method and
Updated `resolveMavenHomeDirectory()` method to `getMavenHomeFile()` method