### PR TITLE
Continuous integration of the Red Hat LSP4iJ plug-in

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,18 +63,18 @@ jobs:
 
       # Checkout and build lsp4ij only if USE_LOCAL_PLUGIN is true
       - name: 'Checkout lsp4ij'
-        if: env.USE_LOCAL_PLUGIN == true
+        if: ${{ inputs.useLocalPlugin == true }}
         uses: actions/checkout@v3
         with:
           repository: redhat-developer/lsp4ij
           path: lsp4ij
           ref: ${{ env.REF_LSP4IJ }}
       - name: 'Build Lsp4ij'
-        if: env.USE_LOCAL_PLUGIN == true
+        if: ${{ inputs.useLocalPlugin == true }}
         working-directory: ./lsp4ij
         run: bash ./gradlew buildPlugin
       - name: 'Unzip lsp4ij file'
-        if: env.USE_LOCAL_PLUGIN == true
+        if: ${{ inputs.useLocalPlugin == true }}
         working-directory: ./lsp4ij/build/distributions
         run: |
           unzip -o '*.zip' -d .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             os: windows-latest
             reportName: windows-test-report
     env:
-      USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || 'false' }}
+      USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || false }}
       REF_LSP4IJ: ${{ inputs.refLsp4ij }}
     steps:
       - name: Configure pagefile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,25 @@
 name: Build
 
 on:
+  workflow_call:
+    inputs:
+      refLsp4ij:
+        description: 'Lsp4ij ref'
+        type: string
+        required: true
+        default: main
+      useLocalPlugin:
+        description: 'Use lsp4ij locally'
+        required: true
+        type: boolean
+        default: false
   workflow_dispatch:
+    inputs:
+      useLocalPlugin:
+        description: 'Use lsp4ij locally'
+        required: true
+        type: boolean
+        default: false
   push:
     branches: '**'
   pull_request:
@@ -24,6 +42,9 @@ jobs:
           - runtime: windows
             os: windows-latest
             reportName: windows-test-report
+    env:
+      USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || 'false' }}
+      REF_LSP4IJ: ${{ inputs.refLsp4ij }}
     steps:
       - name: Configure pagefile
         if: contains(matrix.os, 'windows')
@@ -39,9 +60,28 @@ jobs:
       - name: 'Install required integration test software'
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/setup.sh
+
+      # Checkout and build lsp4ij only if USE_LOCAL_PLUGIN is true
+      - name: 'Checkout lsp4ij'
+        if: env.USE_LOCAL_PLUGIN == 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: redhat-developer/lsp4ij
+          path: lsp4ij
+          ref: ${{ env.REF_LSP4IJ }}
+      - name: 'Build Lsp4ij'
+        if: env.USE_LOCAL_PLUGIN == 'true'
+        working-directory: ./lsp4ij
+        run: bash ./gradlew buildPlugin
+      - name: 'Unzip lsp4ij file'
+        if: env.USE_LOCAL_PLUGIN == 'true'
+        working-directory: ./lsp4ij/build/distributions
+        run: |
+          unzip -o '*.zip' -d .
+
       - name: 'Build Liberty-Tools-Intellij'
         working-directory: ./liberty-tools-intellij
-        run: bash ./gradlew buildPlugin
+        run: bash ./gradlew buildPlugin -PuseLocal=${{ env.USE_LOCAL_PLUGIN }}
       - name: 'Archive artifacts'
         if: ${{ runner.os == 'Linux' && !failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ on:
         required: true
         type: boolean
         default: false
+      refLsp4ij:
+        description: 'Reference/branch for Lsp4ij checkout'
+        type: string
+        required: true
+        default: main
   push:
     branches: '**'
   pull_request:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       refLsp4ij:
-        description: 'Lsp4ij ref'
+        description: 'Reference/branch for Lsp4ij checkout'
         type: string
         required: true
         default: main
@@ -63,18 +63,18 @@ jobs:
 
       # Checkout and build lsp4ij only if USE_LOCAL_PLUGIN is true
       - name: 'Checkout lsp4ij'
-        if: env.USE_LOCAL_PLUGIN == 'true'
+        if: env.USE_LOCAL_PLUGIN == true
         uses: actions/checkout@v3
         with:
           repository: redhat-developer/lsp4ij
           path: lsp4ij
           ref: ${{ env.REF_LSP4IJ }}
       - name: 'Build Lsp4ij'
-        if: env.USE_LOCAL_PLUGIN == 'true'
+        if: env.USE_LOCAL_PLUGIN == true
         working-directory: ./lsp4ij
         run: bash ./gradlew buildPlugin
       - name: 'Unzip lsp4ij file'
-        if: env.USE_LOCAL_PLUGIN == 'true'
+        if: env.USE_LOCAL_PLUGIN == true
         working-directory: ./lsp4ij/build/distributions
         run: |
           unzip -o '*.zip' -d .

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -32,7 +32,7 @@ jobs:
           pr_details=$(echo "$pr_details" | jq -nc '[inputs | {number: .number, sha: .sha}]')
           echo "pr_details=$pr_details" >> $GITHUB_OUTPUT
 
-  # Run the LTI Tests against each open lsp4ij PR
+  # Run the LTI Tests against each open lsp4ij PRs
   call-build-workflow-for-each-merge-commit-sha:
     needs: fetch_all_pull_request_shas
     uses: ./.github/workflows/build.yaml

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,0 +1,45 @@
+name: Cron Job
+
+on:
+  workflow_dispatch:
+  schedule:
+    # The job runs every midnight (UTC time). Ref - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: '0 0 * * *'
+
+jobs:
+  fetch_all_pull_request_shas:
+    runs-on: ubuntu-latest
+    outputs:
+      shas: ${{ steps.extract.outputs.shas }}
+    steps:
+      - name: Extract merge_commit_shas
+        shell: bash
+        id: extract
+        run: |
+          pr_infos=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/redhat-developer/lsp4ij/pulls?&state=open&sort=created&direction=desc&per_page=100")
+
+          # Extract PR numbers and merge_commit_sha values, excluding draft pull requests
+          pr_details=$(echo "$pr_infos" | jq -r '.[] | select(.draft == false) | {number: .number, sha: .merge_commit_sha}')
+
+          # Print the PR number and corresponding merge commit sha
+          echo "PR number and merge commit sha:"
+          echo "$pr_details" | jq -r '. | "PR #\(.number): \(.sha)"'
+
+          # Extract merge_commit_sha values into an array
+          merge_commit_shas=($(echo "$pr_details" | jq -r '.sha'))
+
+          # Create a JSON array string
+          shas=$(jq -nc --arg shas "${merge_commit_shas[*]}" '$shas | split(" ")')
+          echo "shas=$shas" >> $GITHUB_OUTPUT
+
+  call-build-workflow:
+    needs: fetch_all_pull_request_shas
+    uses: ./.github/workflows/build.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        sha: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.shas) }}
+    with:
+      useLocalPlugin: true
+      refLsp4ij: ${{ matrix.sha }}

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -33,7 +33,8 @@ jobs:
           shas=$(jq -nc --arg shas "${merge_commit_shas[*]}" '$shas | split(" ")')
           echo "shas=$shas" >> $GITHUB_OUTPUT
 
-  call-build-workflow:
+  # Run the LTI Tests against each open lsp4ij PR
+  call-build-workflow-for-each-merge-commit-sha:
     needs: fetch_all_pull_request_shas
     uses: ./.github/workflows/build.yaml
     strategy:
@@ -43,3 +44,10 @@ jobs:
     with:
       useLocalPlugin: true
       refLsp4ij: ${{ matrix.sha }}
+
+  # Run the LTI Tests against lsp4ij main branch
+  call-build-workflow-for-lsp4ij-main-branch:
+    uses: ./.github/workflows/build.yaml
+    with:
+      useLocalPlugin: true
+      refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       shas: ${{ steps.extract.outputs.shas }}
+    env:
+      API_URL: https://api.github.com/repos/redhat-developer/lsp4ij/pulls
     steps:
       - name: Extract merge_commit_shas
         shell: bash
         id: extract
         run: |
           pr_infos=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/redhat-developer/lsp4ij/pulls?&state=open&sort=created&direction=desc&per_page=100")
+          "${{ env.API_URL }}")
 
           # Extract PR numbers and merge_commit_sha values, excluding draft pull requests
           pr_details=$(echo "$pr_infos" | jq -r '.[] | select(.draft == false) | {number: .number, sha: .merge_commit_sha}')

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -10,11 +10,11 @@ jobs:
   fetch_all_pull_request_shas:
     runs-on: ubuntu-latest
     outputs:
-      shas: ${{ steps.extract.outputs.shas }}
+      pr_details: ${{ steps.extract.outputs.pr_details }}
     env:
       API_URL: https://api.github.com/repos/redhat-developer/lsp4ij/pulls
     steps:
-      - name: Extract merge_commit_shas
+      - name: Extract PR numbers and merge_commit_shas
         shell: bash
         id: extract
         run: |
@@ -28,12 +28,9 @@ jobs:
           echo "PR number and merge commit sha:"
           echo "$pr_details" | jq -r '. | "PR #\(.number): \(.sha)"'
 
-          # Extract merge_commit_sha values into an array
-          merge_commit_shas=($(echo "$pr_details" | jq -r '.sha'))
-
-          # Create a JSON array string
-          shas=$(jq -nc --arg shas "${merge_commit_shas[*]}" '$shas | split(" ")')
-          echo "shas=$shas" >> $GITHUB_OUTPUT
+          # Create a JSON array string of PR numbers and SHAs
+          pr_details=$(echo "$pr_details" | jq -nc '[inputs | {number: .number, sha: .sha}]')
+          echo "pr_details=$pr_details" >> $GITHUB_OUTPUT
 
   # Run the LTI Tests against each open lsp4ij PR
   call-build-workflow-for-each-merge-commit-sha:
@@ -42,10 +39,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sha: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.shas) }}
+        pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
-      refLsp4ij: ${{ matrix.sha }}
+      refLsp4ij: ${{ matrix.pr_details.sha }}
+    name: Run LTI tests for PR #${{ matrix.pr_details.number }}
 
   # Run the LTI Tests against lsp4ij main branch
   call-build-workflow-for-lsp4ij-main-branch:
@@ -53,3 +51,4 @@ jobs:
     with:
       useLocalPlugin: true
       refLsp4ij: main
+    name: Run LTI tests for Lsp4ij Main branch

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 def remoteRobotVersion = "0.11.18"
+// To switch to stable version, remove that @nightly and just specify the stable version number alone.
 def lsp4ijVersion = '0.0.2-20240615-013020@nightly'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 def remoteRobotVersion = "0.11.18"
-def lsp4ijVersion = '0.0.2-20240615-013020'
+def lsp4ijVersion = '0.0.2-20240615-013020@nightly'
 
 repositories {
     mavenCentral()
@@ -140,7 +140,10 @@ intellij {
     // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     version = '2024.1.3'
 
-    plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle', 'com.redhat.devtools.lsp4ij:' + lsp4ijVersion + '@nightly']
+    def lsp4ij = project.hasProperty('useLocal') && project.property('useLocal') == 'true' ?
+            file("../lsp4ij/build/distributions/LSP4IJ/") :
+            'com.redhat.devtools.lsp4ij:' + lsp4ijVersion
+    plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle', lsp4ij]
     updateSinceUntilBuild = false
 }
 

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -155,7 +155,7 @@ main() {
 
     # Start the IDE.
     echo -e "\n$(${currentTime[@]}): INFO: Starting the IntelliJ IDE..."
-    ./gradlew runIdeForUiTests --info  > remoteServer.log  2>&1 &
+    ./gradlew runIdeForUiTests -PuseLocal=$USE_LOCAL_PLUGIN --info  > remoteServer.log  2>&1 &
 
     # Wait for the IDE to come up.
     echo -e "\n$(${currentTime[@]}): INFO: Waiting for the Intellij IDE to start..."
@@ -172,7 +172,7 @@ main() {
 
     # Run the tests
     echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
-    ./gradlew test
+    ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN
 
     # If there were any errors, gather some debug data before exiting.
     rc=$?


### PR DESCRIPTION
Part of #666 

- Fixes #758 - Build lsp4ij plugin from a branch to use in the LTI automated tests
Checkout any branch of `lsp4ij` (main or any merge commit SHA) and use the `buildPlugin` command to create a ZIP file from it. Unzip the file and specify the path to the `lib` folder as a plugin dependency in `build.gradle`.

- Fixes #756 - Set up a cron job to run every midnight
Created a new YAML file named `cronJob.yaml` with the `useLocalPlugin` value set to `true`. This configuration ensures that the cron job will execute the LTI build with `useLocalPlugin=true`.

- Fixes #783 -  Parameterize LTI Build.
Build and run tests using lsp4ij either (1) from the marketplace or (2) locally. Added a `workflow_dispatch` event so that we can check the `useLocalPlugin` as true or false. 

- Fixes #757 - Fetch and checkout sha of each opened PR in lsp4ij and run LTI builds.
Added a job in the cronJob.yaml file to Extract merge_commit_shas of all the opened PRs in lsp4ij which are not in draft state. Created an array of sha values. 
Run the LTI Tests for each extracted SHA in parallel, using a matrix strategy to handle multiple SHAs concurrently.
Also Run the LTI Tests against lsp4ij main branch