### PR TITLE
Fixes issue 846 - usage of APIs scheduled for removal #855

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyPluginIcons;
@@ -27,6 +28,7 @@ import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 import org.jetbrains.plugins.terminal.TerminalView;
 
 import java.util.Arrays;
@@ -173,11 +175,11 @@ public abstract class LibertyGeneralAction extends AnAction {
      */
     protected ShellTerminalWidget getTerminalWidgetWithFocus(boolean createWidget, Project project, VirtualFile buildFile, String actionCmd) {
         LibertyModule libertyModule = LibertyModules.getInstance().getLibertyModule(buildFile);
-        TerminalView terminalView = TerminalView.getInstance(project);
+        TerminalToolWindowManager terminalToolWindowManager = TerminalToolWindowManager.getInstance(project);
         // look for existing terminal tab
-        ShellTerminalWidget existingWidget = LibertyProjectUtil.getTerminalWidget(libertyModule, terminalView);
+        ShellTerminalWidget existingWidget = LibertyProjectUtil.getTerminalWidget(libertyModule, terminalToolWindowManager);
         // look for creating new terminal tab
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget, terminalView, existingWidget);
+        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget, terminalToolWindowManager, existingWidget);
         // Set Focus to existing terminal widget
         LibertyProjectUtil.setFocusToWidget(project, existingWidget);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -19,7 +19,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyPluginIcons;
@@ -29,7 +28,6 @@ import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
-import org.jetbrains.plugins.terminal.TerminalView;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -176,7 +176,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                                     DiagnosticSeverity.Error));
                         }
 
-                        if (!method.getReturnType().equals(PsiType.VOID)) {
+                        if (!method.getReturnType().equals(PsiTypes.voidType())) {
                             String diagnosticMessage = Messages.getMessage("MethodMustBeVoid",
                                     "@PostConstruct");
                             diagnostics.add(createDiagnostic(method, unit, diagnosticMessage,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiPrimitiveType;
+import com.intellij.psi.PsiTypes;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
@@ -72,7 +73,7 @@ public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipa
 
         assert parentType != null;
         ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
-                context.getASTRoot(), parentType, 0, PsiPrimitiveType.VOID);
+                context.getASTRoot(), parentType, 0, PsiTypes.voidType());
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -97,7 +97,7 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                     String source = isMethod ?
                             Messages.getMessage("AnnotationBooleanMethods", "@" + getSimpleName(annotationName)) :
                             Messages.getMessage("AnnotationBooleanFields", "@" + getSimpleName(annotationName));
-                    if (!type.equals(PsiType.BOOLEAN)) {
+                    if (!type.equals(PsiTypes.booleanType())) {
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -106,10 +106,10 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                     if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
                             && !type.getCanonicalText().endsWith(BIG_INTEGER)
                             && !type.getCanonicalText().endsWith(CHAR_SEQUENCE)
-                            && !type.equals(PsiType.BYTE)
-                            && !type.equals(PsiType.SHORT)
-                            && !type.equals(PsiType.INT)
-                            && !type.equals(PsiType.LONG)) {
+                            && !type.equals(PsiTypes.byteType())
+                            && !type.equals(PsiTypes.shortType())
+                            && !type.equals(PsiTypes.intType())
+                            && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
                                 Messages.getMessage("AnnotationBigDecimalMethods", "@" + getSimpleName(annotationName)) :
                                 Messages.getMessage("AnnotationBigDecimalFields", "@" + getSimpleName(annotationName));
@@ -138,10 +138,10 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                 } else if (matchedAnnotation.equals(MIN) || matchedAnnotation.equals(MAX)) {
                     if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
                             && !type.getCanonicalText().endsWith(BIG_INTEGER)
-                            && !type.equals(PsiType.BYTE)
-                            && !type.equals(PsiType.SHORT)
-                            && !type.equals(PsiType.INT)
-                            && !type.equals(PsiType.LONG)) {
+                            && !type.equals(PsiTypes.byteType())
+                            && !type.equals(PsiTypes.shortType())
+                            && !type.equals(PsiTypes.intType())
+                            && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
                                 Messages.getMessage("AnnotationMinMaxMethods", "@" + getSimpleName(annotationName)) :
                                 Messages.getMessage("AnnotationMinMaxFields", "@" + getSimpleName(annotationName));
@@ -152,12 +152,12 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                         || matchedAnnotation.equals(POSITIVE) || matchedAnnotation.equals(POSITIVE_OR_ZERO)) {
                     if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
                             && !type.getCanonicalText().endsWith(BIG_INTEGER)
-                            && !type.equals(PsiType.BYTE)
-                            && !type.equals(PsiType.SHORT)
-                            && !type.equals(PsiType.INT)
-                            && !type.equals(PsiType.LONG)
-                            && !type.equals(PsiType.FLOAT)
-                            && !type.equals(PsiType.DOUBLE)) {
+                            && !type.equals(PsiTypes.byteType())
+                            && !type.equals(PsiTypes.shortType())
+                            && !type.equals(PsiTypes.intType())
+                            && !type.equals(PsiTypes.longType())
+                            && !type.equals(PsiTypes.floatType())
+                            && !type.equals(PsiTypes.doubleType())) {
                         String source = isMethod ?
                                 Messages.getMessage("AnnotationPositiveMethods", "@" + getSimpleName(annotationName)) :
                                 Messages.getMessage("AnnotationPositiveFields", "@" + getSimpleName(annotationName));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020, 2024 Red Hat, Inc.
+ * Copyright (c) 2019, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2020, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -328,6 +328,6 @@ public class PsiTypeUtils {
      * @return
      */
     public static boolean isVoidReturnType(PsiMethod method) {
-        return PsiType.VOID.equals(method.getReturnType());
+        return PsiTypes.voidType().equals(method.getReturnType());
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,6 @@ package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.graphql.java;
 
 import java.text.MessageFormat;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.psi.PsiAnnotation;
@@ -37,6 +36,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.graphql.MicroProfileGraphQLConstants;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.graphql.TypeSystemDirectiveLocation;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import com.intellij.psi.PsiTypes;
 
 import static io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotation;
 import static io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.isMatchAnnotation;
@@ -195,7 +195,7 @@ public class MicroProfileGraphQLASTValidator extends JavaASTValidator {
     private void validateNoVoidReturnedFromOperations(PsiMethod node) {
         // ignore constructors, and non-void methods for now, it's faster than iterating through all annotations
         if (node.getReturnTypeElement() == null ||
-                !PsiType.VOID.equals(node.getReturnType())) {
+                !PsiTypes.voidType().equals(node.getReturnType())) {
             return;
         }
         for (PsiAnnotation annotation : node.getAnnotations()) {

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -27,7 +27,6 @@ import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyProjectSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
-import org.jetbrains.plugins.terminal.TerminalView;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.terminal.JBTerminalWidget;
+import com.intellij.terminal.ui.TerminalWidget;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.sun.istack.Nullable;
@@ -149,10 +150,13 @@ public class LibertyProjectUtil {
      * @param createWidget  true if a new widget should be created
      * @return ShellTerminalWidget or null if it does not exist
      */
-    public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget, TerminalView terminalView, ShellTerminalWidget widget) {
+    public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget,
+                                                        TerminalToolWindowManager terminalToolWindowManager, ShellTerminalWidget widget) {
         if (widget == null && createWidget) {
             // create a new terminal tab
-            ShellTerminalWidget newTerminal = terminalView.createLocalShellWidget(project.getBasePath(), libertyModule.getName(), true);
+            ShellTerminalWidget newTerminal = ShellTerminalWidget.toShellJediTermWidgetOrThrow(
+                    terminalToolWindowManager.createShellWidget(project.getBasePath(), libertyModule.getName(),
+                            true, true));
             libertyModule.setShellWidget(newTerminal);
             return newTerminal;
         }
@@ -229,15 +233,16 @@ public class LibertyProjectUtil {
      * exists in the Terminal view.
      *
      * @param libertyModule
-     * @param terminalView
+     * @param terminalToolWindowManager
      * @return ShellTerminalWidget or null if it does not exist
      */
-    public static ShellTerminalWidget getTerminalWidget(LibertyModule libertyModule, TerminalView terminalView) {
+    public static ShellTerminalWidget getTerminalWidget(LibertyModule libertyModule, TerminalToolWindowManager terminalToolWindowManager) {
         ShellTerminalWidget widget = libertyModule.getShellWidget();
         // check if widget exists in terminal view
         if (widget != null) {
-            for (JBTerminalWidget terminalWidget : terminalView.getWidgets()) {
-                if (widget.equals(terminalWidget)) {
+            for (TerminalWidget terminalWidget : terminalToolWindowManager.getTerminalWidgets()) {
+                JBTerminalWidget jbTerminalWidget = JBTerminalWidget.asJediTermWidget(terminalWidget);
+                if (widget.equals(jbTerminalWidget)) {
                     return widget;
                 }
             }


### PR DESCRIPTION
Fixes #846 
There are 20 usages of scheduled for removal API.

- Scheduled for removal fields usages (11)
- Scheduled for removal classes usages (4)
- Scheduled for removal methods usages (4)
- Scheduled for removal enum usage (1)