### PR TITLE
Fix running LSP4iJ continuous integration builds with existing LTI releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,6 @@ jobs:
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v3
         with:
-          repository: OpenLiberty/Liberty-tools-intellij
           path: liberty-tools-intellij
           ref: ${{ env.REF_LTI_TAG }}
       - name: 'Install required integration test software'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,11 @@ on:
         required: true
         type: boolean
         default: false
+      refLTITag:
+        description: 'Reference LTI Tag'
+        type: string
+        required: true
+        default: main
   workflow_dispatch:
     inputs:
       useLocalPlugin:
@@ -26,6 +31,11 @@ on:
         default: false
       refLsp4ij:
         description: 'Reference/branch for Lsp4ij checkout'
+        type: string
+        required: true
+        default: main
+      refLTITag:
+        description: 'Reference LTI Tag'
         type: string
         required: true
         default: main
@@ -55,6 +65,7 @@ jobs:
       USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || false }}
       REF_LSP4IJ: ${{ inputs.refLsp4ij }}
       LSP4IJ_BRANCH: ${{ inputs.lsp4ijBranch || 'latest' }}
+      REF_LTI_TAG: ${{ inputs.refLTITag }}
     steps:
       - name: Configure pagefile
         if: contains(matrix.os, 'windows')
@@ -66,7 +77,9 @@ jobs:
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v3
         with:
+          repository: OpenLiberty/Liberty-tools-intellij
           path: liberty-tools-intellij
+          ref: ${{ env.REF_LTI_TAG }}
       - name: 'Install required integration test software'
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/setup.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && !failure() }}
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
+          name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG != '' && env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             ./**/*liberty-tools-intellij*.zip
             ./**/libs/*liberty-tools-intellij*.jar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && !failure() }}
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG != '' && env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
+          name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             ./**/*liberty-tools-intellij*.zip
             ./**/libs/*liberty-tools-intellij*.jar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ on:
       refLTITag:
         description: 'Reference LTI Tag'
         type: string
-        required: true
+        required: false
         default: main
   push:
     branches: '**'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
     env:
       USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || false }}
       REF_LSP4IJ: ${{ inputs.refLsp4ij }}
-      LSP4IJ_BRANCH: ${{ inputs.lsp4ijBranch || 'latest' }}
+      LSP4IJ_BRANCH: ${{ inputs.lsp4ijBranch || 'default' }}
       REF_LTI_TAG: ${{ inputs.refLTITag }}
     steps:
       - name: Configure pagefile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,6 +121,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.reportName }}
+          name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             liberty-tools-intellij/build/reports/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,6 +121,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
+          name: ${{ matrix.reportName }}
           path: |
             liberty-tools-intellij/build/reports/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: false
       refLTITag:
-        description: 'Reference LTI Tag'
+        description: 'Reference LTI Tag/Branch'
         type: string
         required: true
         default: main
@@ -35,7 +35,7 @@ on:
         required: true
         default: main
       refLTITag:
-        description: 'Reference LTI Tag'
+        description: 'Reference LTI Tag/Branch'
         type: string
         required: false
         default: main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && !failure() }}
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: liberty-tools-intellij-LTI-main-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
+          name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             ./**/*liberty-tools-intellij*.zip
             ./**/libs/*liberty-tools-intellij*.jar

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -139,5 +140,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.3', 'v0.0.0.1' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.3', 'v0.0.0.1' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -94,16 +95,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Existing LTI release tags can be added to obtain build results.
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
       refLsp4ij: ${{ matrix.pr_details.sha }}
       lsp4ijBranch: PR-${{ matrix.pr_details.number }}
+      refLTITag: ${{ matrix.tag }}
     name: Running PR
 
   # Run the LTI Tests against lsp4ij main branch
   call-build-workflow-for-lsp4ij-main-branch:
     uses: ./.github/workflows/build.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        # Existing LTI release tags can be added to obtain build results.
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -96,8 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        # tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
-        tag: [ 'main' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -113,8 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        # tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
-        tag: [ 'main' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -117,6 +117,7 @@ jobs:
       useLocalPlugin: true
       refLsp4ij: main
       lsp4ijBranch: main
+      refLTITag: ${{ matrix.tag }}
     name: Run LTI tests for Lsp4ij Main branch
 
   # Send slack notification for build results

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -95,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Existing LTI release tags can be added to obtain build results.
+        # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
         tag: [ '' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
@@ -112,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Existing LTI release tags can be added to obtain build results.
+        # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
         tag: ['']
     with:
       useLocalPlugin: true

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.3', 'v0.0.0.1' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration', , 'main', 'v0.0.0.3', 'v0.0.0.1' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: []
+        tag: ['']
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -103,7 +103,8 @@ jobs:
       refLsp4ij: ${{ matrix.pr_details.sha }}
       lsp4ijBranch: PR-${{ matrix.pr_details.number }}
       refLTITag: ${{ matrix.tag }}
-    name: Running PR
+    name: Run PR
+
 
   # Run the LTI Tests against lsp4ij main branch
   call-build-workflow-for-lsp4ij-main-branch:
@@ -112,13 +113,13 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main
       lsp4ijBranch: main
       refLTITag: ${{ matrix.tag }}
-    name: Run LTI tests for Lsp4ij Main branch
+    name: Run Lsp4ij Main
 
   # Send slack notification for build results
   call-build-workflow-slack-notification:

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -140,5 +139,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ '' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -104,7 +104,6 @@ jobs:
       refLTITag: ${{ matrix.tag }}
     name: Run PR
 
-
   # Run the LTI Tests against lsp4ij main branch
   call-build-workflow-for-lsp4ij-main-branch:
     uses: ./.github/workflows/build.yaml
@@ -112,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: ['']
+        tag: [ 'lsp4ij-market-0.0.2-integration' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ '' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ]
+        tag: []
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration', , 'main', 'v0.0.0.3', 'v0.0.0.1' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.3', 'v0.0.0.1' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -96,7 +96,8 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        # tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'main' ]
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -112,7 +113,8 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags can be added to obtain build results.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        # tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'main' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main


### PR DESCRIPTION
Fixes #815 

A part of the fix for - [#868](https://github.com/OpenLiberty/liberty-tools-intellij/issues/868)
Implementation of running LSP4iJ continuous integration builds with existing LTI releases

Currently, the fix is running against the branch `lsp4ij-market-0.0.2-integration`. We can add the `main` and other existing `LTI release tags`, but those will fail because of the `microshed:lsp4ij` dependency. Once we have an LTI release that uses the `redhat:lsp4ij` plugin, we will be able to easily add the version in the `tag` specified in the code.