### PR TITLE
Deprecated the method FilenameIndex.getFilesByName() 

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import com.intellij.ui.DoubleClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBScrollPane;

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -130,11 +130,10 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
 
         for (BuildFile buildFile : mavenBuildFiles) {
             // create a new Liberty project
-            PsiFile psiFile = buildFile.getBuildFile();
+            VirtualFile virtualFile = buildFile.getBuildFile();
             String projectName = null;
-            VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
-                LOGGER.error(String.format("Could not resolve current Maven project %s", psiFile));
+                LOGGER.error(String.format("Could not resolve current Maven project %s", virtualFile));
                 break;
             }
             LibertyModuleNode node;
@@ -152,7 +151,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             }
 
             boolean validContainerVersion = buildFile.isValidContainerVersion();
-            LibertyModule module = libertyModules.addLibertyModule(new LibertyModule(project, psiFile.getVirtualFile(), projectName, Constants.LIBERTY_MAVEN_PROJECT, validContainerVersion));
+            LibertyModule module = libertyModules.addLibertyModule(new LibertyModule(project, virtualFile, projectName, Constants.LIBERTY_MAVEN_PROJECT, validContainerVersion));
             node = new LibertyModuleNode(module);
 
             top.add(node);
@@ -176,9 +175,8 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
         }
 
         for (BuildFile buildFile : gradleBuildFiles) {
-            PsiFile psiFile = buildFile.getBuildFile();
+            VirtualFile virtualFile = buildFile.getBuildFile();
             String projectName = null;
-            VirtualFile virtualFile = psiFile.getVirtualFile();
             if (virtualFile == null) {
                 LOGGER.error(String.format("Could not resolve current Gradle project %s", buildFile));
                 break;

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -51,7 +51,7 @@ public class LibertyModule {
 
     public LibertyModule(Project project, BuildFile buildFile) {
         this(project);
-        this.buildFile = buildFile.getBuildFile().getVirtualFile();
+        this.buildFile = buildFile.getBuildFile();
         this.name = buildFile.getProjectName();
         this.projectType = buildFile.getProjectType();
         this.validContainerVersion = buildFile.isValidContainerVersion();

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation.
+ * Copyright (c) 2022,2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2023 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
@@ -88,7 +88,7 @@ public abstract class LibertyProjectAction extends LibertyGeneralAction {
         // Resolve project names and add to list
         mavenBuildFiles.forEach(mavenBuildFile -> {
             // resolve project name
-            VirtualFile virtualFile = mavenBuildFile.getBuildFile().getVirtualFile();
+            VirtualFile virtualFile = mavenBuildFile.getBuildFile();
             if (virtualFile == null) {
                 LOGGER.error(String.format("Could not resolve Maven project for build file: %s", mavenBuildFile.getBuildFile()));
             } else {
@@ -103,7 +103,7 @@ public abstract class LibertyProjectAction extends LibertyGeneralAction {
 
         });
         gradleBuildFiles.forEach(gradleBuildFile -> {
-            VirtualFile virtualFile = gradleBuildFile.getBuildFile().getVirtualFile();
+            VirtualFile virtualFile = gradleBuildFile.getBuildFile();
             if (virtualFile == null) {
                 LOGGER.error(String.format("Could not resolve Gradle project for build file: %s", gradleBuildFile.getBuildFile()));
             } else {

--- a/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,6 @@
 package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 
 /**
  * Defines a BuildFile object

--- a/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
@@ -9,13 +9,14 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.util;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 
 /**
  * Defines a BuildFile object
  */
 public class BuildFile {
-    public PsiFile buildFile;
+    public VirtualFile buildFile;
     public boolean validBuildFile;
     public boolean validContainerVersion;
 
@@ -37,9 +38,9 @@ public class BuildFile {
         this.buildFile = null;
     }
 
-    public PsiFile getBuildFile() { return this.buildFile; }
+    public VirtualFile getBuildFile() { return this.buildFile; }
 
-    public void setBuildFile(PsiFile buildFile) {
+    public void setBuildFile(VirtualFile buildFile) {
         this.buildFile = buildFile;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 
 import java.io.*;
 import java.nio.file.Path;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -91,8 +91,8 @@ public class LibertyGradleUtil {
      * validContainerVersion true if plugin version is valid for dev mode in containers
      * @throws IOException
      */
-    public static BuildFile validBuildGradle(PsiFile file) throws IOException {
-            String buildFile = fileToString(file.getVirtualFile().getPath());
+    public static BuildFile validBuildGradle(VirtualFile file) throws IOException {
+            String buildFile = fileToString(file.getPath());
             if (buildFile.isEmpty()) { return (new BuildFile(false, false)); }
 
             // instead of iterating over capture groups in a plugin{}, search directly

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.execution.MavenExternalParameters;
 import org.jetbrains.idea.maven.project.MavenGeneralSettings;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -84,12 +84,12 @@ public class LibertyMavenUtil {
      * @throws IOException
      * @throws SAXException
      */
-    public static BuildFile validPom(PsiFile file) throws ParserConfigurationException, IOException, SAXException {
+    public static BuildFile validPom(VirtualFile file) throws ParserConfigurationException, IOException, SAXException {
         BuildFile buildFile = new BuildFile(false, false);
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
 
-        File inputFile = new File(file.getVirtualFile().getPath());
+        File inputFile = new File(file.getPath());
         Document doc = builder.parse(inputFile);
 
         doc.getDocumentElement().normalize();


### PR DESCRIPTION
part of #847 
Replaced Psi file with Virtual file. Because intellij deprecated FilenameIndex.getFilesByName(...) method and instead of this method they suggested to use FilenameIndex.getVirtualFilesByName(). The 'getFilesByName' method was returning array of PsiFile objects, the new method 'getVirtualFilesByName' is returning Collection<VirtualFile>. So replaced 'PsiFile' object with 'VirtualFile'.