### PR TITLE
Issue 847 deprecated api usage 

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -10,7 +10,6 @@
 package io.openliberty.tools.intellij.actions;
 
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
@@ -157,11 +156,9 @@ public abstract class LibertyGeneralAction extends AnAction {
      * @param errMsg
      */
     protected void notifyError(String errMsg, Project project) {
-        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID, errMsg, NotificationType.WARNING)
-                .setTitle(LocalizedResourceUtil.getMessage("liberty.action.cannot.start"))
-                .setIcon(LibertyPluginIcons.libertyIcon)
-                .setSubtitle("")
-                .setListener(NotificationListener.URL_OPENING_LISTENER);
+        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                LocalizedResourceUtil.getMessage("liberty.action.cannot.start"), errMsg, NotificationType.WARNING);
+        notif.setIcon(LibertyPluginIcons.libertyIcon);
         Notifications.Bus.notify(notif, project);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,6 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
@@ -54,13 +53,12 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
 
 
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
-            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID
-                    , LibertyPluginIcons.libertyIcon
-                    , LocalizedResourceUtil.getMessage("integration.test.report.does.not.exist.notification.title")
-                    , ""
-                    , LocalizedResourceUtil.getMessage("test.report.does.not.exist", failsafeReportFile.getAbsolutePath())
-                    , NotificationType.ERROR
-                    , NotificationListener.URL_OPENING_LISTENER);
+            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                    LocalizedResourceUtil.getMessage("integration.test.report.does.not.exist.notification.title"),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", failsafeReportFile.getAbsolutePath()),
+                    NotificationType.ERROR);
+            notif.setIcon(LibertyPluginIcons.libertyIcon);
+
             Notifications.Bus.notify(notif, project);
             LOGGER.debug("Integration test report does not exist at : " + failsafeReportFile.getAbsolutePath());
             return;

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,6 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
@@ -86,13 +85,12 @@ public class ViewTestReport extends LibertyGeneralAction {
 
         VirtualFile testReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(testReportFile);
         if (testReportVirtualFile == null || !testReportVirtualFile.exists()) {
-            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID
-                    , LibertyPluginIcons.libertyIcon
-                    , LocalizedResourceUtil.getMessage("gradle.test.report.does.not.exist")
-                    , ""
-                    , LocalizedResourceUtil.getMessage("test.report.does.not.exist", testReportFile.getAbsolutePath())
-                    , NotificationType.ERROR
-                    , NotificationListener.URL_OPENING_LISTENER);
+            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                    LocalizedResourceUtil.getMessage("gradle.test.report.does.not.exist"),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", testReportFile.getAbsolutePath()),
+                    NotificationType.ERROR);
+            notif.setIcon(LibertyPluginIcons.libertyIcon);
+
             Notifications.Bus.notify(notif, project);
             LOGGER.debug("Gradle test report does not exist at : " + testReportFile.getAbsolutePath());
             return;

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,6 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
@@ -53,13 +52,12 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
         VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
 
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
-            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID
-                    , LibertyPluginIcons.libertyIcon
-                    , LocalizedResourceUtil.getMessage("unit.test.report.does.not.exist")
-                    , ""
-                    , LocalizedResourceUtil.getMessage("test.report.does.not.exist", surefireReportFile.getAbsolutePath())
-                    , NotificationType.ERROR
-                    , NotificationListener.URL_OPENING_LISTENER);
+            Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                    LocalizedResourceUtil.getMessage("unit.test.report.does.not.exist"),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", surefireReportFile.getAbsolutePath()),
+                    NotificationType.ERROR);
+            notif.setIcon(LibertyPluginIcons.libertyIcon);
+
             Notifications.Bus.notify(notif, project);
             LOGGER.debug("Unit test report does not exist at : " + surefireReportFile.getAbsolutePath());
             return;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileDeploymentSupport.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileDeploymentSupport.java
@@ -11,6 +11,7 @@
 package io.openliberty.tools.intellij.lsp4mp;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
@@ -38,7 +39,7 @@ public class MicroProfileDeploymentSupport implements ClasspathResourceChangedMa
     private final Project project;
 
     public static MicroProfileDeploymentSupport getInstance(Project project) {
-        return ServiceManager.getService(project, MicroProfileDeploymentSupport.class);
+        return project.getService(MicroProfileDeploymentSupport.class);
     }
 
     public MicroProfileDeploymentSupport(Project project) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileDeploymentSupport.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileDeploymentSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Red Hat, Inc.
+ * Copyright (c) 2023, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,8 +11,6 @@
 package io.openliberty.tools.intellij.lsp4mp;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileProjectService.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileProjectService.java
@@ -90,7 +90,7 @@ public class MicroProfileProjectService implements LibraryTable.Listener, BulkFi
         LibraryTablesRegistrar.getInstance().getLibraryTable(project).addListener(this, project);
         connection = ApplicationManager.getApplication().getMessageBus().connect(project);
         connection.subscribe(VirtualFileManager.VFS_CHANGES, this);
-        project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, this);
+        project.getMessageBus().connect().subscribe(ModuleListener.TOPIC, this);
     }
 
     private void handleLibraryUpdate(Library library) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileProjectService.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/MicroProfileProjectService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp;
 
-import com.intellij.ProjectTopics;
 import com.intellij.json.JsonFileType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Red Hat Inc. and others.
+ * Copyright (c) 2023, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,10 +13,8 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.classpath;
 
-import com.intellij.ProjectTopics;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
@@ -28,8 +26,6 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Pair;
@@ -80,7 +81,7 @@ public class ClasspathResourceChangedManager implements Disposable {
 		// Track update of Psi Java, properties files
 		PsiManager.getInstance(project).addPsiTreeChangeListener(listener, project);
 		// Track modules changes
-		projectConnection.subscribe(ProjectTopics.MODULES, listener);
+		projectConnection.subscribe(ModuleListener.TOPIC, listener);
 		// Track delete, create, update of file
 		appConnection = ApplicationManager.getApplication().getMessageBus().connect(project);
 		appConnection.subscribe(VirtualFileManager.VFS_CHANGES, listener);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/classpath/ClasspathResourceChangedManager.java
@@ -57,7 +57,7 @@ public class ClasspathResourceChangedManager implements Disposable {
 	private final ClasspathResourceChangedListener listener;
 
 	public static ClasspathResourceChangedManager getInstance(Project project) {
-		return ServiceManager.getService(project, ClasspathResourceChangedManager.class);
+		return project.getService(ClasspathResourceChangedManager.class);
 	}
 
 	public interface Listener {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -192,7 +192,7 @@ public final class PropertiesManagerForJava {
                     // Collect all adapted definition participant
                     JavaDefinitionContext context = new JavaDefinitionContext(uri, typeRoot, utils, module,
                             hyperlinkedElement, hyperlinkedPosition);
-                    List<IJavaDefinitionParticipant> definitions = IJavaDefinitionParticipant.EP_NAME.extensions()
+                    List<IJavaDefinitionParticipant> definitions = IJavaDefinitionParticipant.EP_NAME.getExtensionList().stream()
                             .filter(definition -> definition.isAdaptedForDefinition(context))
                             .collect(Collectors.toList());
                     if (definitions.isEmpty()) {
@@ -326,7 +326,7 @@ public final class PropertiesManagerForJava {
                     // Collect all adapted hover participant
                     JavaHoverContext context = new JavaHoverContext(uri, typeRoot, utils, module, hoverElement, hoverPosition,
                             documentFormat, surroundEqualsWithSpaces);
-                    List<IJavaHoverParticipant> definitions = IJavaHoverParticipant.EP_NAME.extensions()
+                    List<IJavaHoverParticipant> definitions = IJavaHoverParticipant.EP_NAME.getExtensionList().stream()
                             .filter(definition -> definition.isAdaptedForHover(context)).collect(Collectors.toList());
                     if (definitions.isEmpty()) {
                         return;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
@@ -72,7 +72,7 @@ public final class CompletionHandler {
                 List<CompletionItem> completionItems = new ArrayList<>();
                 JavaCompletionContext completionContext = new JavaCompletionContext(uri, typeRoot, utils, module, completionOffset);
 
-                List<JavaCompletionDefinition> completions = JavaCompletionDefinition.EP_NAME.extensions()
+                List<JavaCompletionDefinition> completions = JavaCompletionDefinition.EP_NAME.getExtensionList().stream()
                         .filter(definition -> group.equals(definition.getGroup()))
                         .filter(completion -> completion.isAdaptedForCompletion(completionContext))
                         .collect(Collectors.toList());

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -72,7 +72,7 @@ public final class DiagnosticsHandler {
             DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
                 // Collect all adapted diagnostic definitions
                 JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, module, documentFormat, settings);
-                List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.extensions()
+                List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.getExtensionList().stream()
                         .filter(definition -> group.equals(definition.getGroup()))
                         .filter(definition -> definition.isAdaptedForDiagnostics(context))
                         .collect(Collectors.toList());

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProjectManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProjectManager.java
@@ -86,7 +86,7 @@ public final class PsiMicroProfileProjectManager implements Disposable {
 		microprofileProjectListener = new MicroProfileProjectListener();
 		connection = project.getMessageBus().connect(project);
 		connection.subscribe(ClasspathResourceChangedManager.TOPIC, microprofileProjectListener);
-		connection.subscribe(ProjectTopics.MODULES, microprofileProjectListener);
+		connection.subscribe(ModuleListener.TOPIC, microprofileProjectListener);
 	}
 
 	public PsiMicroProfileProject getMicroProfileProject(Module project) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProjectManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProjectManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html
@@ -9,7 +9,6 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.project;
 
-import com.intellij.ProjectTopics;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
@@ -98,7 +98,7 @@ public final class CodeActionHandler {
 			// Loop for each code action kinds to process the proper code actions
 			for (String codeActionKind : codeActionKinds) {
 				// Get list of code action definition for the given kind
-				List<JavaCodeActionDefinition> codeActionDefinitions = JavaCodeActionDefinition.EP.extensions()
+				List<JavaCodeActionDefinition> codeActionDefinitions = JavaCodeActionDefinition.EP.getExtensionList().stream()
 						.filter(definition -> group.equals(definition.getGroup()))
 						.filter(definition -> definition.isAdaptedForCodeAction(context))
 						.filter(definition -> codeActionKind.equals(definition.getKind()))
@@ -204,7 +204,7 @@ public final class CodeActionHandler {
 					start, end - start, utils, params, unresolved);
 			context.setASTRoot(getASTRoot(unit));
 
-			IJavaCodeActionParticipant participant = JavaCodeActionDefinition.EP.extensions()
+			IJavaCodeActionParticipant participant = JavaCodeActionDefinition.EP.getExtensionList().stream()
 					.filter(definition -> unresolved.getKind().startsWith(definition.getKind()))
 					.filter(definition -> group.equals(definition.getGroup()))
 					.filter(definition -> participantId.equals(definition.getParticipantId()))

--- a/src/main/java/io/openliberty/tools/intellij/util/JavaVersionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/JavaVersionUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,6 @@
 package io.openliberty.tools.intellij.util;
 
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
@@ -55,11 +54,11 @@ public class JavaVersionUtil {
     }
 
     private static void notifyError(String errMsg, Project project) {
-        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID, errMsg, NotificationType.WARNING)
-                .setTitle(LocalizedResourceUtil.getMessage("java.runtime.error.message"))
-                .setIcon(LibertyPluginIcons.libertyIcon)
-                .setSubtitle("")
-                .setListener(NotificationListener.URL_OPENING_LISTENER);
+
+        Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
+                LocalizedResourceUtil.getMessage("java.runtime.error.message"),
+                errMsg, NotificationType.WARNING);
+        notif.setIcon(LibertyPluginIcons.libertyIcon);
         Notifications.Bus.notify(notif, project);
     }
 


### PR DESCRIPTION
Part of #847 
1. Replaced 'ExtensionPointName.extensions()' with 'getExtensionList().stream()
2. Replaced ServiceManager.getService with project.getService.
3. Replaced deprecated field ProjectTopics.MODULES with ModuleListener.TOPICS.
4. Updated deprecated Notification constructor and removed deprecated setListener method.