### PR TITLE
Fix sending LSP4IJ integration build results to Slack channel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,21 @@ on:
       refLsp4ij:
         description: 'Reference/branch for Lsp4ij checkout'
         type: string
-        required: true
+        required: false
         default: main
       lsp4ijBranch:
         description: 'PR number or branch name for Artifact upload'
         type: string
-        required: true
+        required: false
       useLocalPlugin:
         description: 'Use lsp4ij locally'
-        required: true
+        required: false
         type: boolean
         default: false
+    outputs:
+      status:
+        description: "Build Status"
+        value: ${{ jobs.build-status.outputs.status }}
   workflow_dispatch:
     inputs:
       useLocalPlugin:
@@ -112,3 +116,19 @@ jobs:
           name: ${{ matrix.reportName }}
           path: |
             liberty-tools-intellij/build/reports/
+
+  build-status:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.status.outputs.status }}
+    needs: build
+    if: always()
+    steps:
+      - id: status
+        run: |
+          if [ ${{ needs.build.result }} != "success" ]; then
+               echo "status=failed" >> $GITHUB_OUTPUT
+          else
+               echo "status=succeeded" >> $GITHUB_OUTPUT
+          fi
+        shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,15 +6,15 @@ on:
       refLsp4ij:
         description: 'Reference/branch for Lsp4ij checkout'
         type: string
-        required: false
+        required: true
         default: main
       lsp4ijBranch:
         description: 'PR number or branch name for Artifact upload'
         type: string
-        required: false
+        required: true
       useLocalPlugin:
         description: 'Use lsp4ij locally'
-        required: false
+        required: true
         type: boolean
         default: false
     outputs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,8 @@ jobs:
     needs: build
     if: always()
     steps:
-      - id: status
+      - name: Fetch Build Status
+        id: status
         run: |
           if [ ${{ needs.build.result }} != "success" ]; then
                echo "status=failed" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,10 +17,6 @@ on:
         required: true
         type: boolean
         default: false
-    outputs:
-      status:
-        description: "Build Status"
-        value: ${{ jobs.build-status.outputs.status }}
   workflow_dispatch:
     inputs:
       useLocalPlugin:
@@ -116,20 +112,3 @@ jobs:
           name: ${{ matrix.reportName }}
           path: |
             liberty-tools-intellij/build/reports/
-
-  build-status:
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.status.outputs.status }}
-    needs: build
-    if: always()
-    steps:
-      - name: Fetch Build Status
-        id: status
-        run: |
-          if [ ${{ needs.build.result }} != "success" ]; then
-               echo "status=failed" >> $GITHUB_OUTPUT
-          else
-               echo "status=succeeded" >> $GITHUB_OUTPUT
-          fi
-        shell: bash

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs every midnight (UTC time). Ref - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
@@ -89,3 +90,27 @@ jobs:
       refLsp4ij: main
       lsp4ijBranch: main
     name: Run LTI tests for Lsp4ij Main branch
+
+  call-build-workflow-slack-notification:
+    runs-on: ubuntu-latest
+    needs: [ call-build-workflow-for-lsp4ij-main-branch, call-build-workflow-for-each-merge-commit-sha ]
+    if: always()
+    steps:
+      - run: |
+          STATUS="succeeded"
+          JOB2_STATUS="${{ needs.call-build-workflow-for-lsp4ij-main-branch.outputs.status }}"
+          JOB3_STATUS="${{ needs.call-build-workflow-for-each-merge-commit-sha.outputs.status }}"
+          
+          echo "Job2 status: $JOB2_STATUS"
+          echo "Job3 status: $JOB3_STATUS"
+          
+          if [ "$JOB3_STATUS" = "failed" ] || [ "$JOB2_STATUS" = "failed" ]; then
+            STATUS="failed"
+          fi
+          
+          echo "Final status: $STATUS"
+          
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch ${{ github.ref }}. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: $STATUS\"}" $SLACK_WEBHOOK_URL
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
+    name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs every midnight (UTC time). Ref - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
@@ -91,6 +90,7 @@ jobs:
       lsp4ijBranch: main
     name: Run LTI tests for Lsp4ij Main branch
 
+  # Send slack notification for build results
   call-build-workflow-slack-notification:
     runs-on: ubuntu-latest
     needs: [ call-build-workflow-for-lsp4ij-main-branch, call-build-workflow-for-each-merge-commit-sha ]
@@ -101,9 +101,6 @@ jobs:
           JOB2_STATUS="${{ needs.call-build-workflow-for-lsp4ij-main-branch.outputs.status }}"
           JOB3_STATUS="${{ needs.call-build-workflow-for-each-merge-commit-sha.outputs.status }}"
           
-          echo "Job2 status: $JOB2_STATUS"
-          echo "Job3 status: $JOB3_STATUS"
-          
           if [ "$JOB3_STATUS" = "failed" ] || [ "$JOB2_STATUS" = "failed" ]; then
             STATUS="failed"
           fi
@@ -112,5 +109,5 @@ jobs:
           
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch ${{ github.ref }}. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: $STATUS\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -96,7 +96,8 @@ jobs:
     needs: [ call-build-workflow-for-lsp4ij-main-branch, call-build-workflow-for-each-merge-commit-sha ]
     if: always()
     steps:
-      - run: |
+      - name: Send Slack Notification
+        run: |
           STATUS="succeeded"
           JOB2_STATUS="${{ needs.call-build-workflow-for-lsp4ij-main-branch.outputs.status }}"
           JOB3_STATUS="${{ needs.call-build-workflow-for-each-merge-commit-sha.outputs.status }}"

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -98,17 +98,17 @@ jobs:
     steps:
       - name: Send Slack Notification
         run: |
-          STATUS="succeeded"
-          JOB2_STATUS="${{ needs.call-build-workflow-for-lsp4ij-main-branch.outputs.status }}"
-          JOB3_STATUS="${{ needs.call-build-workflow-for-each-merge-commit-sha.outputs.status }}"
-          
-          if [ "$JOB3_STATUS" = "failed" ] || [ "$JOB2_STATUS" = "failed" ]; then
-            STATUS="failed"
+          STATUS="failure"
+          JOB_STATUS_MAIN="${{ needs.call-build-workflow-for-lsp4ij-main-branch.result }}"
+          JOB_STATUS_PR="${{ needs.call-build-workflow-for-each-merge-commit-sha.result }}"
+
+          if [[ "$JOB_STATUS_MAIN" == "success" ]] && [[ "$JOB_STATUS_PR" = "success" ]]; then
+            STATUS="success"
           fi
-          
+
           echo "Final status: $STATUS"
-          
-          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch ${{ github.ref }}. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: $STATUS\"}" $SLACK_WEBHOOK_URL
+
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     name: Run Slack Notification


### PR DESCRIPTION
Fixes #759 

I have added code for sending LSP4IJ integration build results to Slack channel. Currently I am using the same channel `lsp4ij-monitoring` and using the same secret variable `SLACK_WEBHOOK_URL`

I have tested with the changes in the PR https://github.com/OpenLiberty/liberty-tools-intellij/pull/864 which is opened against the issue #815 