### PR TITLE
issue 847 Replaced deprecated methods in jediTermWidget class

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation.
+ * Copyright (c) 2020, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,7 +69,7 @@ public class LibertyActionUtil {
                 return;
             }
             // existing terminal, add a new line character and send command through connector
-            String enterCode = new String(widget.getTerminalStarter().getCode(KeyEvent.VK_ENTER, 0), StandardCharsets.UTF_8);
+            String enterCode = new String(widget.getTerminal().getCodeForKey(KeyEvent.VK_ENTER, 0), StandardCharsets.UTF_8);
             StringBuilder result = new StringBuilder();
             result.append(cmd).append(enterCode);
             connector.write(result.toString());


### PR DESCRIPTION
Part of #847 
1. getTerminalStarter() replaced with getTerminal()
2. used getCodeForKey() method to add new line character after command