### PR TITLE
Enabled UI Tests in Windows 

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModJakartaLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModJakartaLSTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
 
-@DisabledOnOs({OS.WINDOWS})
+
 public class GradleSingleModJakartaLSTest extends SingleModJakartaLSTestCommon {
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModLSTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
 
-@DisabledOnOs({OS.WINDOWS})
+
 public class GradleSingleModLSTest extends SingleModLibertyLSTestCommon {
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPLSTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
 
-@DisabledOnOs({OS.WINDOWS})
+
 public class GradleSingleModMPLSTest extends SingleModMPLSTestCommon {
 
     /**


### PR DESCRIPTION
Fixes #655 . Removed @DisabledOnOs({OS.WINDOWS}) 

Observations - https://github.com/OpenLiberty/liberty-tools-intellij/issues/655#issuecomment-2247569020