### PR TITLE
Fix usage of ProcessCanceledException and CancellationException in catch block

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -38,7 +38,11 @@ public class AnnotationUtil {
             // recognised annotations found in scopes.
             return Arrays.stream(type.getAnnotations()).map(annotation -> annotation.getNameReferenceElement().getQualifiedName())
                     .filter(scopes::contains).distinct().collect(Collectors.toList());
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             return Collections.<String>emptyList();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 IBM Corporation, Lidia Ataupillco Ramos and others.
+/* Copyright (c) 2022, 2024 IBM Corporation, Lidia Ataupillco Ramos and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -77,7 +77,11 @@ public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipa
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to change return type to void", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -114,7 +114,11 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 try {
                     WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                     toResolve.setEdit(we);
-                } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+                } catch (ProcessCanceledException e) {
+                    //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                    //TODO delete block when minimum required version is 2024.2
+                    throw e;
+                } catch (IndexNotReadyException | CancellationException e) {
                     throw e;
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove constraint annotation", e);
@@ -137,7 +141,11 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove static modifier", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -77,7 +77,11 @@ public class ManagedBeanNoArgConstructorQuickFix implements IJavaCodeActionParti
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
@@ -77,7 +77,11 @@ public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -93,7 +93,11 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -96,7 +96,11 @@ public abstract class InsertAnnotationQuickFix implements IJavaCodeActionPartici
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -120,7 +120,11 @@ public abstract class RemoveAnnotationConflictQuickFix implements IJavaCodeActio
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
@@ -78,7 +78,11 @@ public class RemoveMethodParametersQuickFix implements IJavaCodeActionParticipan
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -111,7 +111,11 @@ public abstract class RemoveModifierConflictQuickFix implements IJavaCodeActionP
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -124,7 +124,11 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
          try {
              WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
              toResolve.setEdit(we);
-         } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+         } catch (ProcessCanceledException e) {
+             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+             //TODO delete block when minimum required version is 2024.2
+             throw e;
+         } catch (IndexNotReadyException | CancellationException e) {
              throw e;
          } catch (Exception e) {
              LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -106,7 +106,11 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             context.getUnresolved().setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, warningMessage, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -80,7 +80,11 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -132,7 +132,11 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
@@ -78,7 +78,11 @@ public class PersistenceAnnotationQuickFix extends InsertAnnotationMissingQuickF
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -96,7 +96,11 @@ public class PersistenceEntityQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
@@ -105,7 +105,11 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
@@ -125,7 +129,11 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -104,7 +104,11 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
@@ -123,7 +127,11 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
@@ -81,7 +81,11 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to filter implementation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
@@ -98,7 +98,11 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
@@ -102,7 +102,11 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to listener implementation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
@@ -83,7 +83,11 @@ public abstract class InsertAnnotationAttributeQuickFix implements IJavaCodeActi
 				annotation, 0, context.getSource().getCompilationUnit(), attributeName);
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Unable to resolve code action edit for inserting an attribute value", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2021, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -105,7 +105,11 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
 		try {
 			WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
 			toResolve.setEdit(we);
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to insert missing annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -93,7 +93,11 @@ public class AnnotationValidator {
 				return null;
 			}
 			return rule.validate(value);
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2021, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -52,8 +52,11 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public boolean isAdaptedForCompletion(JavaCompletionContext context) {
         try {
             return getInstance().isAdaptedForCompletion(context);
-        }
-        catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         }
         catch (Exception e) {
@@ -66,8 +69,11 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public List<? extends CompletionItem> collectCompletionItems(JavaCompletionContext context) {
         try {
             return getInstance().collectCompletionItems(context);
-        }
-        catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         }
         catch (Exception e) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -52,7 +52,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
         try {
             return getInstance().isAdaptedForDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e);
@@ -64,7 +68,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public void beginDiagnostics(JavaDiagnosticsContext context) {
         try {
             getInstance().beginDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
@@ -76,7 +84,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
         try {
             List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
             return diagnostics != null ? diagnostics : Collections.emptyList();
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e);
@@ -88,7 +100,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public void endDiagnostics(JavaDiagnosticsContext context) {
         try {
             getInstance().endDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -156,7 +156,11 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 		String methodReturnTypeString;
 		try {
 			methodReturnTypeString = methodReturnType.getCanonicalText();
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			throw e;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -87,7 +87,11 @@ public class ImplementHealthCheckQuickFix implements IJavaCodeActionParticipant 
 					context.getSource().getCompilationUnit());
 			try {
 				toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-			} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+			} catch (ProcessCanceledException e) {
+				//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+				//TODO delete block when minimum required version is 2024.2
+				throw e;
+			} catch (IndexNotReadyException | CancellationException e) {
 				throw e;
 			} catch (Exception e) {
 				LOGGER.log(Level.WARNING, "Unable to create workspace edit to make the class implement @HealthCheck", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -103,7 +103,11 @@ public class ApplicationScopedAnnotationMissingQuickFix implements IJavaCodeActi
 				REMOVE_ANNOTATION_NAMES);
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Failed to create workspace edit to replace bean scope annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 IBM Corporation and others.
+* Copyright (c) 2020, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -125,7 +125,11 @@ public class MicroProfileGenerateOpenAPIOperation implements IJavaCodeActionPart
 
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 		}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
Fixes #767 

I found many usages of the following 
`catch (IndexNotReadyException | ProcessCanceledException | CancellationException e)`

I have changed the code as suggested by IntelliJ.

I haven't found the exact usage of the following in our code.
`catch (CancellationException | ProcessCanceledException e)`