### PR TITLE
Fix to Update Versions of Checkout Actions and Upload Artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,13 +69,13 @@ jobs:
     steps:
       - name: Configure pagefile
         if: contains(matrix.os, 'windows')
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 10GB
           disk-root: "C:"
       - name: 'Checkout liberty-tools-intellij'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: liberty-tools-intellij
           ref: ${{ env.REF_LTI_TAG }}
@@ -86,7 +86,7 @@ jobs:
       # Checkout and build lsp4ij only if USE_LOCAL_PLUGIN is true
       - name: 'Checkout lsp4ij'
         if: ${{ inputs.useLocalPlugin == true }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: redhat-developer/lsp4ij
           path: lsp4ij
@@ -115,12 +115,13 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
       - name: 'Run UI integration tests'
+        id: run_tests
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/run.sh
       - name: 'Archive Test logs and reports'
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v4.3.4
         with:
-          name: ${{ matrix.reportName }}
+          name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG != '' && env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             liberty-tools-intellij/build/reports/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,6 +122,6 @@ jobs:
         if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG != '' && env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
+          name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
           path: |
             liberty-tools-intellij/build/reports/

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -95,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.1' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -111,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.1' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main
@@ -139,5 +140,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,6 +1,7 @@
 name: Cron Job
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -139,5 +140,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -96,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.1' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -112,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration', 'main', 'v0.0.0.1' ]
+        tag: [ 'lsp4ij-market-0.0.2-integration' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main
@@ -140,5 +139,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     name: Run Slack Notification

--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -1,7 +1,6 @@
 name: Cron Job
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     # The job runs at 15:45 UTC every Monday through Friday, which is 9:15 PM IST and 11:45 AM EST.
@@ -140,5 +139,5 @@ jobs:
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"Workflow ${{ github.workflow }} triggered by branch *${{ github.ref }}*. Build results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Status: *$STATUS*\"}" $SLACK_WEBHOOK_URL
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_COPY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     name: Run Slack Notification


### PR DESCRIPTION
Fixes #856 

I have updated the versions of `Checkout Actions` and `Upload Artifacts`. We changed `actions/upload-artifact` to `v4.3.4`, and I have given unique names to the `test reports.` This is necessary because we are running builds for different PRs, different LTI Tags, and the main branch, so we need to uniquely identify the test reports.


I am using the environment variable `env.REF_LTI_TAG` to name the `test reports`. Since the value is currently empty, it defaults to `'default'`. After merging this PR https://github.com/OpenLiberty/liberty-tools-intellij/pull/864, the value will take the exact value of `env.REF_LTI_TAG`. There is no issue with merging this PR first or merging the above-mentioned PR first.

I have added an extra condition to the step `Archive Test logs and reports` because the test report is generated only in the previous step, `Run UI integration tests`. We need to execute the `Archive Test logs and reports` step only if the previous step (`Run UI integration tests`) fails. So that we can avoid this below warning,

![Screenshot 2024-08-02 at 1 32 03 PM](https://github.com/user-attachments/assets/a625030d-0b88-49b5-bbaa-37fe0accbc99)

Resolves #892 

I have tried to reproduce the issue #892 with the changes in this PR. So that issue is not reproducible now.
