### PR TITLE
Fix warnings in Workflows on macOS 14.6 for curl 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, lsp4ij-market-0.0.2-integration ]
+    branches: [ main, lsp4ij-market-0.3.0-integration ]
 
 jobs:
   build:

--- a/src/test/resources/ci/scripts/setup.sh
+++ b/src/test/resources/ci/scripts/setup.sh
@@ -93,7 +93,7 @@ installBaseSoftware() {
         installDockerOnLinux
     elif [[ $OS == "Darwin" ]]; then
         brew update
-        brew install curl unzip || true
+        # brew install curl unzip || true
         # installDockerOnMAC
     else
         # Note: Docker is already installed on the windows VMs provisioned by GHA.

--- a/src/test/resources/ci/scripts/setup.sh
+++ b/src/test/resources/ci/scripts/setup.sh
@@ -93,7 +93,7 @@ installBaseSoftware() {
         installDockerOnLinux
     elif [[ $OS == "Darwin" ]]; then
         brew update
-        # brew install curl unzip || true
+        brew install --quiet curl unzip || true
         # installDockerOnMAC
     else
         # Note: Docker is already installed on the windows VMs provisioned by GHA.


### PR DESCRIPTION
Fixes #902 

Since we are using `macOS-latest`, which refers to `macOS 14 Arm64`,we can check [here](https://github.com/actions/runner-images?tab=readme-ov-file#about)

Upon reviewing the [readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md), I found that they are using `macOS version 14.6.1` now, and this update is reflected in the `documentation`. Therefore, we can confirm that they won't revert to `macOS version` 14.5. 

I have suppressed the warning for the command `brew install curl unzip || true` by using the` --quiet` option. 
The `--quiet` option in Homebrew's `brew install` command is used to minimize the output by suppressing some of the usual messages that appear during installation.


I have updated the branch to` lsp4ij-market-0.3.0-integration` in [this line](https://github.com/OpenLiberty/liberty-tools-intellij/blob/8287c40a55a83c8dc0a6d2081fbacd7a8a59a971/.github/workflows/build.yaml#L45) to enable tests on the feature branch.
