### PR TITLE
Add a 5s delay after clicking on a quick fix

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1382,6 +1382,8 @@ public class UIBotTestUtils {
 
         // get the text from the quickfix popup
         quickFixPopup.findText(contains(quickfixChooserString)).click();
+        // After you click IntelliJ can chug for a while before the edit is rendered
+        TestUtils.sleepAndIgnoreException(5);
 
         // Save the file.
         if (remoteRobot.isMac()) {


### PR DESCRIPTION
Fixes #916

This affects four test cases that have quick fixes.