### PR TITLE
Upgrade to LSP4iJ 0.4.0, IntelliJ 2024.1.6 and LSP4MP 0.12.0-SNAPSHOT.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, lsp4ij-market-0.3.0-integration ]
+    branches: [ main, lsp4ij-market-0.4.0-integration ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 17
 
 def remoteRobotVersion = "0.11.18"
 // To switch to nightly version, add @nightly to the version number.
-def lsp4ijVersion = '0.3.0'
+def lsp4ijVersion = '0.4.0'
 
 repositories {
     mavenCentral()
@@ -111,7 +111,7 @@ dependencies {
     testImplementation 'com.automation-remarks:video-recorder-junit5:2.0'
 
     // define jars to grab locally (if falling back to mavenLocal() repo)
-    lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.10.0:uber') {
+    lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.12.0-SNAPSHOT:uber') {
         transitive = false
     }
     lsp('org.eclipse.lemminx:org.eclipse.lemminx:0.26.1:uber') {
@@ -143,7 +143,7 @@ runIde {
 
 intellij {
     // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
-    version = '2024.1.3'
+    version = '2024.1.6'
 
     def lsp4ij = project.hasProperty('useLocal') && project.property('useLocal') == 'true' ?
             file("../lsp4ij/build/distributions/LSP4IJ/") :


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/914.

The upgrade to LSP4MP 0.12.0-SNAPSHOT is required to resolve a problem exposed by the introduction of `workspace/symbols` support in LSP4iJ 0.4.0. See the discussion here for more information: https://github.com/redhat-developer/lsp4ij/discussions/452#discussioncomment-10329922.

IntelliJ 2024.1.6 is now the current 2024.1.x release and we should be using it for our automated testing.