### PR TITLE
Align the implementation of resolveCodeAction() with the MicroProfileLanguageClient to resolve a GSON compatibility issue.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageClient.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.lsp4ij.JSONUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PropertiesManagerForJakarta;
 import io.openliberty.tools.intellij.lsp4mp.MicroProfileProjectService;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.ProjectLabelManager;
@@ -34,7 +35,6 @@ import org.eclipse.lsp4mp.commons.JavaFileInfo;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaFileInfoParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
-import org.eclipse.lsp4mp.commons.utils.JSONUtility;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +74,7 @@ public final class JakartaLanguageClient extends IndexAwareLanguageClient implem
     final IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
     final var coalesceBy = new CoalesceByKey("jakarta/java/resolveCodeAction");
     return runAsBackground("Computing Java resolve code actions", monitor -> {
-      final CodeActionResolveData data = JSONUtility.toModel(codeAction.getData(), CodeActionResolveData.class);
+      final CodeActionResolveData data = JSONUtils.toModel(codeAction.getData(), CodeActionResolveData.class);
       codeAction.setData(data);
       return PropertiesManagerForJakarta.getInstance().resolveCodeAction(codeAction, utils);
     }, coalesceBy);


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/922

This addresses an issue that we will immediately encounter when upgrading to LSP4Jakarta 0.2.2. Fixing this now to make the future upgrade go more smoother.