### PR TITLE
Cast the value to a Number in order to tolerate type conversion from Integer to Double.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -98,7 +98,7 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
          int paramIndex;
 
          if (data.getExtendedDataEntry(ANNOTATION_TO_REMOVE) instanceof List &&
-                 data.getExtendedDataEntry(INDEX_KEY) instanceof Integer) {
+                 data.getExtendedDataEntry(INDEX_KEY) instanceof Number) {
              annotationsToRemove = (List<String>) data.getExtendedDataEntry(ANNOTATION_TO_REMOVE);
              paramIndex = ((Number) data.getExtendedDataEntry(INDEX_KEY)).intValue();
          } else {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -100,7 +100,7 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
          if (data.getExtendedDataEntry(ANNOTATION_TO_REMOVE) instanceof List &&
                  data.getExtendedDataEntry(INDEX_KEY) instanceof Integer) {
              annotationsToRemove = (List<String>) data.getExtendedDataEntry(ANNOTATION_TO_REMOVE);
-             paramIndex = (Integer) data.getExtendedDataEntry(INDEX_KEY);
+             paramIndex = ((Number) data.getExtendedDataEntry(INDEX_KEY)).intValue();
          } else {
              LOGGER.log(Level.WARNING, "The CodeActionResolveData was corrupted somewhere in the LSP layer. Unable to resolve code action.");
              return null;


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/924

This addresses an issue that we will immediately encounter when upgrading to LSP4Jakarta 0.2.2. Fixing this now to make the future upgrade go more smoother.