### PR TITLE
Update existing LTI Tag as main branch 

### DIFF
--- a/.github/workflows/cronJob.yaml
+++ b/.github/workflows/cronJob.yaml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ] # Can specify tags or branches such as '24.0.6' and 'main'
+        tag: [ 'main' ] # Can specify tags or branches such as '24.0.6' and 'main'
         pr_details: ${{ fromJson(needs.fetch_all_pull_request_shas.outputs.pr_details) }}
     with:
       useLocalPlugin: true
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         # Existing LTI release tags and branches can be added to obtain build results.If the tag array is empty, it will default to 'main'. However, if there is at least one tag or branch in the tag array and you need to run on 'main' as well, make sure to add 'main' to the array.
-        tag: [ 'lsp4ij-market-0.0.2-integration' ]
+        tag: [ 'main' ]
     with:
       useLocalPlugin: true
       refLsp4ij: main


### PR DESCRIPTION
Part of #895 

Updated existing LTI Tag as `main`. 
Since there is no existing LTI tag that are currently using LSP4IJ plugin, we specifying just LTI `main` branch only.