### PR TITLE
Update lsp4mp4ij component to align with Quarkus Tools for IntelliJ release 2.0.0 & Update LSP4MP to 0.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ configurations {
 
 dependencies {
 
-    implementation ('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.12.0-SNAPSHOT') {
+    implementation ('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.12.0') {
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     testImplementation 'com.automation-remarks:video-recorder-junit5:2.0'
 
     // define jars to grab locally (if falling back to mavenLocal() repo)
-    lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.12.0-SNAPSHOT:uber') {
+    lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.12.0:uber') {
         transitive = false
     }
     lsp('org.eclipse.lemminx:org.eclipse.lemminx:0.26.1:uber') {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -126,7 +126,8 @@ public final class PropertiesManagerForJava {
             }
             JavaCodeLensContext context = new JavaCodeLensContext(uri, typeRoot, utils, module, params);
             List<IJavaCodeLensParticipant> definitions = IJavaCodeLensParticipant.EP_NAME.getExtensionList()
-                    .stream().filter(definition -> definition.isAdaptedForCodeLens(context, monitor))
+                    .stream()
+                    .filter(definition -> definition.isAdaptedForCodeLens(context, monitor))
                     .collect(Collectors.toList());
             if (definitions.isEmpty()) {
                 return;
@@ -194,7 +195,8 @@ public final class PropertiesManagerForJava {
                     // Collect all adapted definition participant
                     JavaDefinitionContext context = new JavaDefinitionContext(uri, typeRoot, utils, module,
                             hyperlinkedElement, hyperlinkedPosition);
-                    List<IJavaDefinitionParticipant> definitions = IJavaDefinitionParticipant.EP_NAME.extensions()
+                    List<IJavaDefinitionParticipant> definitions = IJavaDefinitionParticipant.EP_NAME.getExtensionList()
+                            .stream()
                             .filter(definition -> definition.isAdaptedForDefinition(context))
                             .toList();
                     if (definitions.isEmpty()) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -14,6 +14,7 @@ import com.intellij.lang.jvm.JvmParameter;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -24,6 +25,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codelens.JavaCodeLe
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.CompletionHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.definition.IJavaDefinitionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.definition.JavaDefinitionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.DiagnosticsHandler;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.hover.IJavaHoverParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.hover.JavaHoverContext;
@@ -385,5 +387,45 @@ public final class PropertiesManagerForJava {
         return ApplicationManager.getApplication().runReadAction((Computable<CodeAction>) () -> {
             return codeActionHandler.resolveCodeAction(unresolved, utils);
         });
+    }
+
+    /**
+     * Returns the workspace symbols for the given java project.
+     *
+     * @param projectUri the uri of the java project
+     * @param utils      the JDT utils
+     * @param monitor    the progress monitor
+     * @return the workspace symbols for the given java project
+     */
+    public List<SymbolInformation> workspaceSymbols(String projectUri, IPsiUtils utils, ProgressIndicator monitor) {
+        List<SymbolInformation> symbols = new ArrayList<>();
+        Module module = getModule(projectUri, utils);
+        if (module != null) {
+            collectWorkspaceSymbols(module, utils, symbols, monitor);
+        }
+        return symbols;
+    }
+
+    private static @Nullable Module getModule(String uri, IPsiUtils utils) {
+        Module[] modules = ModuleManager.getInstance(utils.getProject()).getModules();
+        for (Module module : modules) {
+            if (uri.equals(module.getName())) {
+                return module;
+            }
+        }
+        return null;
+    }
+
+    private void collectWorkspaceSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols,
+                                         ProgressIndicator monitor) {
+        if (monitor.isCanceled()) {
+            return;
+        }
+
+        List<IJavaWorkspaceSymbolsParticipant> definitions = IJavaWorkspaceSymbolsParticipant.EP_NAME.getExtensionList();
+        if (definitions.isEmpty()) {
+            return;
+        }
+        definitions.forEach(definition -> definition.collectSymbols(project, utils, symbols, monitor));
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codelens/IJavaCodeLensParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codelens/IJavaCodeLensParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@ import java.util.List;
  *
  */
 public interface IJavaCodeLensParticipant {
-	public static final ExtensionPointName<IJavaCodeLensParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaCodeLensParticipant");
+	ExtensionPointName<IJavaCodeLensParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaCodeLensParticipant");
 
 
 	/**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/CompletionHandler.java
@@ -72,7 +72,8 @@ public final class CompletionHandler {
                 List<CompletionItem> completionItems = new ArrayList<>();
                 JavaCompletionContext completionContext = new JavaCompletionContext(uri, typeRoot, utils, module, completionOffset);
 
-                List<JavaCompletionDefinition> completions = JavaCompletionDefinition.EP_NAME.extensions()
+                List<JavaCompletionDefinition> completions = JavaCompletionDefinition.EP_NAME.getExtensionList()
+                        .stream()
                         .filter(definition -> group.equals(definition.getGroup()))
                         .filter(completion -> completion.isAdaptedForCompletion(completionContext))
                         .collect(Collectors.toList());

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.CompletionItem;
  * @author datho7561
  */
 public interface IJavaCompletionParticipant {
-	public static final ExtensionPointName<IJavaCompletionParticipant> EP_NAME =
+	 ExtensionPointName<IJavaCompletionParticipant> EP_NAME =
 			ExtensionPointName.create("open-liberty.intellij.javaCompletionParticipant");
 
 	/**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/definition/IJavaDefinitionParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/definition/IJavaDefinitionParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,7 @@ import java.util.List;
  *
  */
 public interface IJavaDefinitionParticipant {
-	public static final ExtensionPointName<IJavaDefinitionParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaDefinitionParticipant");
+	ExtensionPointName<IJavaDefinitionParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaDefinitionParticipant");
 
 	/**
 	 * Returns true if definition must be collected for the given context and false

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -72,7 +72,8 @@ public final class DiagnosticsHandler {
             DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
                 // Collect all adapted diagnostic definitions
                 JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, module, documentFormat, settings);
-                List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.extensions()
+                List<JavaDiagnosticsDefinition> definitions = JavaDiagnosticsDefinition.EP_NAME.getExtensionList()
+                        .stream()
                         .filter(definition -> group.equals(definition.getGroup()))
                         .filter(definition -> definition.isAdaptedForDiagnostics(context))
                         .toList();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  */
 public interface IJavaDiagnosticsParticipant {
-	public static final ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME =
+	ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME =
 			ExtensionPointName.create("open-liberty.intellij.javaDiagnosticsParticipant");
 	/**
 	 * Returns true if diagnostics must be collected for the given context and false

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/hover/IJavaHoverParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/hover/IJavaHoverParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html
@@ -23,7 +23,7 @@ import org.eclipse.lsp4j.Hover;
  */
 public interface IJavaHoverParticipant {
 
-	public static final ExtensionPointName<IJavaHoverParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaHoverParticipant");
+	ExtensionPointName<IJavaHoverParticipant> EP_NAME = ExtensionPointName.create("open-liberty.intellij.javaHoverParticipant");
 
 	/**
 	 * Returns true if hover must be collected for the given context and false

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.symbols;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.SymbolInformation;
+
+import java.util.List;
+
+/**
+ * Represents an object that can collect workspace symbols for java projects.
+ */
+public interface IJavaWorkspaceSymbolsParticipant {
+
+    ExtensionPointName<IJavaWorkspaceSymbolsParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaWorkspaceSymbolsParticipant");
+
+    /**
+     * Fill in <code>symbols</code> with workspace symbols of the given project.
+     *
+     * @param project the project to collect workspace symbols from
+     * @param utils   the JDT utils
+     * @param symbols the list of symbols to add to
+     * @param monitor the progress monitor
+     */
+    void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols,
+                        ProgressIndicator monitor);
+
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/jaxrs/IJaxRsInfoProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/jaxrs/IJaxRsInfoProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -42,15 +42,17 @@ public interface IJaxRsInfoProvider {
 	 * Returns a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for.
 	 *
 	 * @param javaProject the project to check for JAX-RS method information
+	 * @param utils the Psi utilities.
 	 * @param monitor the progress monitor
 	 * @return a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for
 	 */
-	@NotNull Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject, @NotNull ProgressIndicator monitor);
+	@NotNull Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject, @NotNull IPsiUtils utils, @NotNull ProgressIndicator monitor);
 
 	/**
 	 * Returns a list of all the JAX-RS methods in the given type.
 	 *
 	 * @param type    the type to check for JAX-RS methods
+	 * @param jaxrsContext the JAX-RS context.
 	 * @param monitor the progress monitor
 	 * @return a list of all the JAX-RS methods in the given type
 	 */

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/utils/PsiTypeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,8 +11,6 @@
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils;
 
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VfsUtilCore;
@@ -266,35 +264,13 @@ public class PsiTypeUtils {
         return getRootDirectory(PsiTreeUtil.getParentOfType(element, PsiFile.class));
     }
 
-    public static VirtualFile getRootDirectory(PsiFile file) {
+    public static @Nullable VirtualFile getRootDirectory(PsiFile file) {
         ProjectFileIndex index = ProjectFileIndex.getInstance(file.getProject());
         VirtualFile directory = index.getSourceRootForFile(file.getVirtualFile());
         if (directory == null) {
             directory = index.getClassRootForFile(file.getVirtualFile());
         }
         return directory;
-    }
-
-    public static String getLocation(Project project, VirtualFile directory) {
-        String location = null;
-        Module module = ProjectFileIndex.getInstance(project).getModuleForFile(directory);
-        if (module != null) {
-            VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
-            if (roots.length > 0) {
-                VirtualFile moduleRoot = roots[0]; // choose any
-                String path = VfsUtilCore.getRelativePath(directory, moduleRoot);
-                if (path != null) {
-                    location = '/' + module.getName() + '/' + path;
-                }
-            }
-        }
-        if (location == null) {
-            location = directory.getPath();
-        }
-        if (location.endsWith("!/")) {
-            location = location.substring(0, location.length() - 2);
-        }
-        return location;
     }
 
     public static boolean overlaps(TextRange typeRange, TextRange methodRange) {
@@ -328,6 +304,6 @@ public class PsiTypeUtils {
      * @return
      */
     public static boolean isVoidReturnType(PsiMethod method) {
-        return PsiType.VOID.equals(method.getReturnType());
+        return PsiTypes.voidType().equals(method.getReturnType());
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/codeaction/CodeActionHandler.java
@@ -98,7 +98,8 @@ public final class CodeActionHandler {
 			// Loop for each code action kinds to process the proper code actions
 			for (String codeActionKind : codeActionKinds) {
 				// Get list of code action definition for the given kind
-				List<JavaCodeActionDefinition> codeActionDefinitions = JavaCodeActionDefinition.EP.extensions()
+				List<JavaCodeActionDefinition> codeActionDefinitions = JavaCodeActionDefinition.EP.getExtensionList()
+						.stream()
 						.filter(definition -> group.equals(definition.getGroup()))
 						.filter(definition -> definition.isAdaptedForCodeAction(context))
 						.filter(definition -> codeActionKind.equals(definition.getKind()))
@@ -204,7 +205,8 @@ public final class CodeActionHandler {
 					start, end - start, utils, params, unresolved);
 			context.setASTRoot(getASTRoot(unit));
 
-			IJavaCodeActionParticipant participant = JavaCodeActionDefinition.EP.extensions()
+			IJavaCodeActionParticipant participant = JavaCodeActionDefinition.EP.getExtensionList()
+					.stream()
 					.filter(definition -> unresolved.getKind().startsWith(definition.getKind()))
 					.filter(definition -> group.equals(definition.getGroup()))
 					.filter(definition -> participantId.equals(definition.getParticipantId()))

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/DefaultJaxRsInfoProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/DefaultJaxRsInfoProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,19 +18,20 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.*;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.psi.search.searches.AnnotatedElementsSearch;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.MergeQuery;
+import com.intellij.util.Query;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.*;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CancellationException;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -49,15 +50,58 @@ public class DefaultJaxRsInfoProvider implements IJaxRsInfoProvider {
 	private static final Logger LOGGER = Logger.getLogger(DefaultJaxRsInfoProvider.class.getName());
 
 	@Override
-	public boolean canProvideJaxRsMethodInfoForClass(PsiFile typeRoot, Module javaProject, ProgressIndicator monitor) {
+	public boolean canProvideJaxRsMethodInfoForClass(@NotNull PsiFile typeRoot, Module javaProject, ProgressIndicator monitor) {
 		return PsiTypeUtils.findType(javaProject, JAVAX_WS_RS_PATH_ANNOTATION) != null
 				|| PsiTypeUtils.findType(javaProject, JAKARTA_WS_RS_PATH_ANNOTATION) != null;
 	}
 
 	@Override
-	public Set<PsiClass> getAllJaxRsClasses(Module javaProject, ProgressIndicator monitor) {
-		// TODO: implement when LSP4IJ will support workspace symbols
-		return Collections.emptySet();
+	public Set<PsiClass> getAllJaxRsClasses(Module javaProject, IPsiUtils utils, ProgressIndicator monitor) {
+		if (monitor.isCanceled()) {
+			return Collections.emptySet();
+		}
+
+		try {
+			SearchScope scope = javaProject.getModuleScope(false);
+
+			Query<PsiModifierListOwner> query = null;
+			for (var httpAnnotation : JaxRsConstants.HTTP_METHOD_ANNOTATIONS) {
+				PsiClass annotationClass = utils.findClass(javaProject, httpAnnotation);
+				if (annotationClass != null) {
+					Query<PsiModifierListOwner> annotationQuery = AnnotatedElementsSearch.searchElements(annotationClass, scope, PsiModifierListOwner.class);
+					if (query == null) {
+						query = annotationQuery;
+					} else {
+						query = new MergeQuery<>(query, annotationQuery);
+					}
+				}
+			}
+			if (query == null) {
+				return Collections.emptySet();
+			}
+
+			Set<PsiClass> jaxRsClasses = new HashSet<>();
+			query.forEach((Consumer<? super PsiModifierListOwner>) item -> {
+				if (item instanceof PsiMember) {
+					PsiClass cl = ((PsiMember) item).getContainingClass();
+					if (cl != null) {
+						jaxRsClasses.add(cl);
+					}
+				}
+			});
+			if (monitor.isCanceled()) {
+				return Collections.emptySet();
+			}
+			return jaxRsClasses;
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
+			throw e;
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "While collecting JAX-RS method information for project " + javaProject.getName(), e);
+		}		return Collections.emptySet();
 	}
 
 	@Override

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsInfoProviderRegistry.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsInfoProviderRegistry.java
@@ -62,7 +62,7 @@ public class JaxRsInfoProviderRegistry {
         return null;
     }
 
-    private List<IJaxRsInfoProvider> getProviders() {
+    public List<IJaxRsInfoProvider> getProviders() {
         if (!initialized) {
             providers = loadProviders();
             return providers;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.jaxrs.java;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiClass;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsMethodInfo;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Collects workspace symbols for JAX-RS REST endpoints.
+ */
+public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(JaxRsWorkspaceSymbolParticipant.class.getName());
+
+	@Override
+	public void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols, ProgressIndicator monitor) {
+		if (monitor.isCanceled()) {
+			return;
+		}
+
+		JaxRsContext jaxrsContext = new JaxRsContext(project);
+		Set<PsiClass> jaxrsTypes = getAllJaxRsTypes(project, utils, monitor);
+		if (jaxrsTypes == null || monitor.isCanceled()) {
+			return;
+		}
+		List<JaxRsMethodInfo> methodsInfo = new ArrayList<>();
+		for (PsiClass typeRoot : jaxrsTypes) {
+			IJaxRsInfoProvider provider = getProviderForType(typeRoot, project, monitor);
+			if (provider != null) {
+				methodsInfo.addAll(provider.getJaxRsMethodInfo(typeRoot.getContainingFile(), jaxrsContext, utils, monitor));
+			}
+			if (monitor.isCanceled()) {
+				return;
+			}
+		}
+
+		methodsInfo.forEach(methodInfo -> {
+			try {
+				symbols.add(createSymbol(methodInfo, utils));
+			} catch (Exception e) {
+				LOGGER.log(Level.WARNING, "failed to create workspace symbol for jax-rs method", e);
+			}
+		});
+	}
+
+	/**
+	 * Returns the provider that can provide JAX-RS method info for the given class,
+	 * or null if no provider can provide info.
+	 *
+	 * @param typeRoot the class to collect JAX-RS method info for
+	 * @param project the Module project
+	 * @param monitor the progress monitor
+	 * @return the provider that can provide JAX-RS method info for the given class,
+	 *         or null if no provider can provide info
+	 */
+	private static IJaxRsInfoProvider getProviderForType(PsiClass typeRoot, Module project,  ProgressIndicator monitor) {
+		for (IJaxRsInfoProvider provider : JaxRsInfoProviderRegistry.getInstance().getProviders()) {
+			if (provider.canProvideJaxRsMethodInfoForClass(typeRoot.getContainingFile(), project, monitor)) {
+				return provider;
+			}
+		}
+		LOGGER.severe("Attempted to collect JAX-RS info for " + typeRoot.getQualifiedName()
+				+ ", but no participant was suitable, despite the fact that an earlier check found a suitable participant");
+		return null;
+	}
+
+	private static Set<PsiClass> getAllJaxRsTypes(Module javaProject, IPsiUtils utils, ProgressIndicator monitor) {
+		Set<PsiClass> jaxrsTypes = new HashSet<>();
+		for (IJaxRsInfoProvider provider : JaxRsInfoProviderRegistry.getInstance().getProviders()) {
+			jaxrsTypes.addAll(provider.getAllJaxRsClasses(javaProject, utils,monitor));
+			if (monitor.isCanceled()) {
+				return null;
+			}
+		}
+		return jaxrsTypes;
+	}
+
+	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException {
+		TextRange sourceRange = methodInfo.getJavaMethod().getNameIdentifier().getTextRange();
+		Range r = utils.toRange(methodInfo.getJavaMethod(), sourceRange.getStartOffset(), sourceRange.getLength());
+		Location location = new Location(methodInfo.getDocumentUri(), r);
+
+		StringBuilder nameBuilder = new StringBuilder("@");
+		URL url = new URL(methodInfo.getUrl());
+		String path = url.getPath();
+		nameBuilder.append(path);
+		nameBuilder.append(": ");
+		nameBuilder.append(methodInfo.getHttpMethod());
+
+		SymbolInformation symbol = new SymbolInformation();
+		symbol.setName(nameBuilder.toString());
+		symbol.setKind(SymbolKind.Method);
+		symbol.setLocation(location);
+		return symbol;
+	}
+
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Red Hat Inc. and others.
+* Copyright (c) 2019, 2024 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
@@ -93,11 +93,11 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 	private static final String[] ANNOTATION_NAMES = { CONNECTOR_ANNOTATION, INCOMING_ANNOTATION, OUTGOING_ANNOTATION,
 	CHANNEL_ANNOTATION};
 
-	private static enum Direction {
+	private enum Direction {
 		INCOMING, OUTGOING, INCOMING_AND_OUTGOING;
 	}
 
-	private static enum MessageType {
+	private enum MessageType {
 		INCOMING, OUTGOING, CONNECTOR;
 	}
 
@@ -132,11 +132,12 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 				// public double process(int priceInUsd) {
 				processIncomingChannel(psiElement, mprmAnnotation, context);
 				break;
-			case CHANNEL_ANNOTATION:
+			case CHANNEL_ANNOTATION: //Used for both incoming and outgoing channels
 				// @Inject
 				// @Channel("prices")
 				// Emitter<double> pricesEmitter;
-				if (isAnnotatingEmitterObject(psiElement)) {
+				if (isChannelField(psiElement)) {
+					processIncomingChannel(psiElement, mprmAnnotation, context);
 					processOutgoingChannel(psiElement, mprmAnnotation, context);
 				}
 				break;
@@ -151,16 +152,8 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 		}
 	}
 
-	private static boolean isAnnotatingEmitterObject(PsiElement element) {
-		if (!(element instanceof PsiField)) {
-			return false;
-		}
-		PsiField field = (PsiField) element;
-		String typeSignature = PsiTypeUtils.getResolvedTypeName(field);
-		if (typeSignature == null) {
-			return false;
-		}
-		return typeSignature.startsWith(EMITTER_CLASS);
+	private static boolean isChannelField(PsiElement element) {
+		return element instanceof PsiField;
 	}
 
 	/**
@@ -210,11 +203,9 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 		String sourceType = getSourceType(javaElement);
 		String sourceMethod = null;
 		String sourceField = null;
-		if (javaElement instanceof PsiMethod) {
-			PsiMethod method = (PsiMethod) javaElement;
+		if (javaElement instanceof PsiMethod method) {
 			sourceMethod = getSourceMethod(method);
-		} else if (javaElement instanceof PsiField) {
-			PsiField field = (PsiField) javaElement;
+		} else if (javaElement instanceof PsiField field) {
 			sourceField = getSourceField(field);
 		}
 		boolean binary = isBinary(javaElement);
@@ -252,11 +243,10 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 				processConnectorAttribute(connectorName, connectorAttributeAnnotation, sourceType, binary, context);
 			} else if (isMatchAnnotation(connectorAttributeAnnotation, CONNECTOR_ATTRIBUTES_ANNOTATION)) {
 				for (PsiNameValuePair pair : connectorAttributeAnnotation.getParameterList().getAttributes()) {
-					if (pair.getValue() instanceof PsiArrayInitializerMemberValue) {
-						PsiArrayInitializerMemberValue connectorAttributeAnnotations = (PsiArrayInitializerMemberValue) pair.getValue();
+					if (pair.getValue() instanceof PsiArrayInitializerMemberValue connectorAttributeAnnotations) {
 						for (Object annotation : connectorAttributeAnnotations.getInitializers()) {
-							if (annotation instanceof PsiAnnotation) {
-								processConnectorAttribute(connectorName, (PsiAnnotation) annotation, sourceType, binary,
+							if (annotation instanceof PsiAnnotation psiAnnotation) {
+								processConnectorAttribute(connectorName, psiAnnotation, sourceType, binary,
 										context);
 							}
 						}
@@ -354,12 +344,10 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 		if (StringUtils.isEmpty(connectorAttributeType)) {
 			return null;
 		}
-		switch (connectorAttributeType) {
-			case "string":
-				return "java.lang.String";
-			default:
-				return connectorAttributeType;
+		if (connectorAttributeType.equals("string")) {
+			return "java.lang.String";
 		}
+		return connectorAttributeType;
 	}
 
 	private static String getMPMessagingName(MessageType messageType, boolean dynamic, String connectorOrChannelName,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
@@ -18,7 +18,6 @@ import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiNameValuePair;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.AbstractAnnotationTypeReferencePropertiesProvider;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.SearchContext;
-import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4mp.commons.metadata.ItemHint;
 import org.eclipse.lsp4mp.commons.metadata.ValueHint;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,6 +55,8 @@
         <extensionPoint name="javaCodeActionParticipant"
                         beanClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.codeaction.JavaCodeActionDefinition"/>
         <extensionPoint name="jaxRsInfoProvider" interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider"/>
+        <extensionPoint name="javaWorkspaceSymbolsParticipant"
+                        interface="io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant"/>
     </extensionPoints>
 
     <extensions defaultExtensionNs="open-liberty.intellij">
@@ -216,6 +218,7 @@
         <javaCodeActionParticipant kind="source"
                                    group="mp"
                                    implementationClass="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.openapi.java.MicroProfileGenerateOpenAPIOperation"/>
+        <javaWorkspaceSymbolsParticipant implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.jaxrs.java.JaxRsWorkspaceSymbolParticipant" />
 
         <!-- Jakarta Code Action Participants -->
 


### PR DESCRIPTION
Fixes #841 
- Update lsp4mp4ij component to align with Quarkus Tools for IntelliJ release 2.0.0: https://github.com/redhat-developer/intellij-quarkus/releases/tag/2.0.0
-  Update LSP4MP to 0.12.0: https://github.com/eclipse/lsp4mp/releases/tag/0.12.0