### PR TITLE
issue 955 - clear run in container module setting on run config deletion

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -27,7 +27,6 @@ public class LibertyModule {
     private boolean validContainerVersion;
 
     private String customStartParams;
-    // FIXME not currently being used, need to enable runInContainer checkbox in LibertyRunConfiguration see https://github.com/OpenLiberty/liberty-tools-intellij/issues/160
     private boolean runInContainer;
 
     private boolean debugMode;

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -42,7 +42,7 @@ public class LibertyRunManagerListener implements RunManagerListener {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
                 if (libertyModule != null) {
-                    libertyModule.setRunInContainer(false); // clear the run in configuration checkbox
+                    libertyModule.setRunInContainer(false); // clear the run in container checkbox
                     if (libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
                         libertyModule.setCustomStartParams(""); // clear the custom params
                     }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -43,6 +43,7 @@ public class LibertyRunManagerListener implements RunManagerListener {
                 if (libertyModule != null && libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
                     libertyModule.setCustomStartParams(""); // clear the custom params
                 }
+                libertyModule.setRunInContainer(false);
             } catch (Exception e) {
                 LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
             }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -28,7 +28,8 @@ public class LibertyRunManagerListener implements RunManagerListener {
     protected static Logger LOGGER = Logger.getInstance(LibertyRunManagerListener.class);
 
     /**
-     * When a Liberty run configuration is removed, clear custom start parameters from Liberty module
+     * When a Liberty run configuration is removed, clear custom start parameters and run in container
+     * from Liberty module
      *
      * @param settings
      */

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -41,11 +41,9 @@ public class LibertyRunManagerListener implements RunManagerListener {
             try {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
-                if (libertyModule != null) {
-                    libertyModule.setRunInContainer(false); // clear the run in container setting for the Liberty module.
-                    if (libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
+                if (libertyModule != null && libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
+                        libertyModule.setRunInContainer(false); // clear the run in container setting for the Liberty module.
                         libertyModule.setCustomStartParams(""); // clear the custom params
-                    }
                 }
             } catch (Exception e) {
                 LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -42,7 +42,7 @@ public class LibertyRunManagerListener implements RunManagerListener {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
                 if (libertyModule != null) {
-                    libertyModule.setRunInContainer(false); // clear the run in container checkbox
+                    libertyModule.setRunInContainer(false); // clear the run in container setting for the Liberty module.
                     if (libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
                         libertyModule.setCustomStartParams(""); // clear the custom params
                     }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -41,10 +41,12 @@ public class LibertyRunManagerListener implements RunManagerListener {
             try {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
-                if (libertyModule != null && libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
-                    libertyModule.setCustomStartParams(""); // clear the custom params
+                if (libertyModule != null) {
+                    libertyModule.setRunInContainer(false); // clear the run in configuration checkbox
+                    if (libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
+                        libertyModule.setCustomStartParams(""); // clear the custom params
+                    }
                 }
-                libertyModule.setRunInContainer(false);
             } catch (Exception e) {
                 LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
             }


### PR DESCRIPTION
Fixes #955 - Deletion of configuration does not remove 'Start in Container' Setting when enabled