### PR TITLE
Check test reports when Maven report generator 3.4 and 3.5 is used

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPProjectTest.java
@@ -200,6 +200,6 @@ public class GradleSingleModMPProjectTest extends SingleModMPProjectTestCommon {
     @Override
     public void validateTestReportsExist() {
         //TODO: rewrite validateTestReportExists() to accept one argument or to accept a null as the second argument
-        TestUtils.validateTestReportExists(TEST_REPORT_PATH, TEST_REPORT_PATH);
+        TestUtils.validateTestReportExists(TEST_REPORT_PATH.toFile());
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPSIDProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPSIDProjectTest.java
@@ -253,6 +253,6 @@ public class GradleSingleModMPSIDProjectTest extends SingleModMPProjectTestCommo
      */
     @Override
     public void validateTestReportsExist() {
-        TestUtils.validateTestReportExists(TEST_REPORT_PATH, TEST_REPORT_PATH);
+        TestUtils.validateTestReportExists(TEST_REPORT_PATH.toFile());
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPProjectTest.java
@@ -90,6 +90,8 @@ public class MavenSingleModMPProjectTest extends SingleModMPProjectTestCommon {
     @BeforeAll
     public static void setup() {
         StepWorker.registerProcessor(new StepLogger());
+        // Clear the cache to force the download of the Maven report plugin. It is not specified in the test case so the latest will be used (3.5.0 or later)
+        TestUtils.clearMavenPluginCache();
         prepareEnv(PROJECTS_PATH, SM_MP_PROJECT_NAME);
     }
 
@@ -213,10 +215,17 @@ public class MavenSingleModMPProjectTest extends SingleModMPProjectTestCommon {
 
     /**
      * Validates that test reports were generated.
+     * Since no specific report generator was chosen in the pom the
+     * latest report generator should be used (3.5 or later, see setup()).
+     *
      */
     @Override
     public void validateTestReportsExist() {
-        TestUtils.validateTestReportExists(pathToITReport34, pathToITReport35);
-        TestUtils.validateTestReportExists(pathToUTReport34, pathToUTReport35);
+        TestUtils.validateTestReportExists(pathToITReport34.toFile(), pathToITReport35.toFile());
+        TestUtils.validateTestReportExists(pathToUTReport34.toFile(), pathToUTReport35.toFile());
+        Assertions.assertTrue(pathToITReport35.toFile().exists(), "Integration test report missing: " + pathToITReport35);
+        Assertions.assertTrue(pathToUTReport35.toFile().exists(), "Unit test report missing: " + pathToUTReport35);
+        Assertions.assertFalse(pathToITReport34.toFile().exists(), "Integration test report should not be generated: " + pathToITReport34);
+        Assertions.assertFalse(pathToUTReport34.toFile().exists(), "Unit test report should not be generated: " + pathToUTReport34);
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -18,6 +18,10 @@ import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Map;
@@ -1004,6 +1008,15 @@ public abstract class SingleModMPProjectTestCommon {
         if (dir.exists()) {
             TestUtils.deleteDirectory(dir);
         }
+    }
+
+    protected static void replaceString(String str, String replacement, File file) throws IOException {
+        Path path = file.toPath();
+        Charset charset = StandardCharsets.UTF_8;
+        String content = new String(Files.readAllBytes(path), charset);
+
+        content = content.replaceAll(str, replacement);
+        Files.write(path, content.getBytes(charset));
     }
 
     /**

--- a/src/test/resources/projects/maven/singleModMavenMP/pom.xml
+++ b/src/test/resources/projects/maven/singleModMavenMP/pom.xml
@@ -89,6 +89,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
+            <!-- Test report insertion point, do not remove -->
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updated two test cases to focus on the report generator. 

Existing test case `MavenSingleModMPProjectTest` already tests the integration and unit test reports. We delete the Maven cache of the Maven plugins so that they must be downloaded when used. The report generator plugin is not called out in the pom so when we run the tests dev mode downloads the latest report generator, 3.5.0. The test also deletes existing reports before it begins so we validate that the 3.5 test report is generated and the 3.4 is not.

Existing test case `MavenSingleModMPSIDProjectTest` also tests the reports. Again we delete the Maven cache and the existing test reports. This test case copies all the files into a new directory so we can safely modify pom.xml to specify Maven report generator 3.4.0 (this will all be deleted afterwards). When tests are run we validate that the 3.4 location was used and the 3.5 location is not.

Fixes #940