### PR TITLE
Support IntelliJ IDEA 2024.1.* only

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
     <depends>com.intellij.gradle</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
 
-    <idea-version since-build="232" until-build="241.*"/>
+    <idea-version since-build="241" until-build="241.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"


### PR DESCRIPTION
Due to backwards compatibility issues with the changes to remove deprecated APIs and other deprecated code, moving forward the minimum supported version of IntelliJ will be 2024.1.