### PR TITLE
Workaround Fix for Server.env Diagnostic and Popup Not Appearing Issue

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -335,6 +335,9 @@ public abstract class SingleModLibertyLSTestCommon {
 
         try {
             UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "server.env", envCfgSnippet, envCfgNameChooserSnippet, incorrectValue, false);
+            // Close and reopen the server.env file as a workaround for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/945. Remove the two lines below once the root cause of the failure is fixed.
+            UIBotTestUtils.closeFileEditorTab(remoteRobot, "server.env", "5");
+            UIBotTestUtils.openFile(remoteRobot, projectName, "server.env", projectName, "src", "main", "liberty", "config");
             //move cursor to hover point
             UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, "NONE", "server.env", UIBotTestUtils.PopupType.DIAGNOSTIC);
             String foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -335,7 +335,8 @@ public abstract class SingleModLibertyLSTestCommon {
 
         try {
             UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "server.env", envCfgSnippet, envCfgNameChooserSnippet, incorrectValue, false);
-            //TODO: Close and reopen the server.env file as a workaround for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/945. Remove the two lines below once the root cause of the failure is fixed.
+            //Close and reopen the server.env file as a workaround for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/945. 
+            //TODO: Remove the two lines below once the root cause of issue 945 is fixed.
             UIBotTestUtils.closeFileEditorTab(remoteRobot, "server.env", "5");
             UIBotTestUtils.openFile(remoteRobot, projectName, "server.env", projectName, "src", "main", "liberty", "config");
             //move cursor to hover point

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -335,7 +335,7 @@ public abstract class SingleModLibertyLSTestCommon {
 
         try {
             UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "server.env", envCfgSnippet, envCfgNameChooserSnippet, incorrectValue, false);
-            // Close and reopen the server.env file as a workaround for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/945. Remove the two lines below once the root cause of the failure is fixed.
+            //TODO: Close and reopen the server.env file as a workaround for the issue: https://github.com/OpenLiberty/liberty-tools-intellij/issues/945. Remove the two lines below once the root cause of the failure is fixed.
             UIBotTestUtils.closeFileEditorTab(remoteRobot, "server.env", "5");
             UIBotTestUtils.openFile(remoteRobot, projectName, "server.env", projectName, "src", "main", "liberty", "config");
             //move cursor to hover point


### PR DESCRIPTION
As a workaround for this issue #945, the team has agreed to try `closing and reopening server.env ` after inserting the invalid value 'NONE'. 
We need to ensure the underlying issue is resolved in the future, and the workaround added in the PR should be removed at that time.


NOTE: I observed that there is no issue in the `server.env` files for version `0.3.0` (for all builds), but I found that the 'diagnostic not appearing' error leads to the 'hover not present' error in the server.env files for versions `0.4.0` and `0.5.0` (for all builds). Aparna also confirmed that the same issue is present in version 0.6.0 as well