### PR TITLE
Fixes 997 : Invalid gradle test param example in hover for start parameters 

### DIFF
--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -129,7 +129,7 @@ cannot.attach.debugger.host.port=Unable to automatically attach the debugger to 
 run.config.liberty.project=Liberty project
 run.config.liberty.project.tool.tip=Select the build file for your Liberty project.
 run.config.start.parameters=Start parameters:
-run.config.start.parameters.tool.tip=eg. -DhotTests=true or -DhotTests (Maven) --hotTests (Gradle)
+run.config.start.parameters.tool.tip=eg. -DhotTests=true or -DhotTests (Maven), --hotTests (Gradle)
 specify.custom.parameters.for.the.liberty.dev.command=Specify custom parameters for Liberty dev mode.
 
 # Maven and Gradle exceptions

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -129,7 +129,7 @@ cannot.attach.debugger.host.port=Unable to automatically attach the debugger to 
 run.config.liberty.project=Liberty project
 run.config.liberty.project.tool.tip=Select the build file for your Liberty project.
 run.config.start.parameters=Start parameters:
-run.config.start.parameters.tool.tip=eg. -DhotTests=true (Maven) --hotTests=true (Gradle)
+run.config.start.parameters.tool.tip=eg. -DhotTests=true or -DhotTests (Maven) --hotTests (Gradle)
 specify.custom.parameters.for.the.liberty.dev.command=Specify custom parameters for Liberty dev mode.
 
 # Maven and Gradle exceptions


### PR DESCRIPTION
Fixes #997  corrected Invalid Gradle test param example in hover for start parameters