### PR TITLE
Set languageId for each of the MicroProfile language mappings.

### DIFF
--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -24,9 +24,9 @@
                 ]]>
             </description>
         </server>
-        <languageMapping language="Properties" serverId="lsp4mp"
+        <languageMapping language="Properties" serverId="lsp4mp" languageId="microprofile-properties"
                          documentMatcher="io.openliberty.tools.intellij.lsp4mp.lsp.MicroProfileMatcher"/>
-        <languageMapping language="JAVA" serverId="lsp4mp"/>
+        <languageMapping language="JAVA" serverId="lsp4mp" languageId="java"/>
 
         <!-- LemMinX LS with Liberty LemMinX ext -->
         <!-- TODO changing the server interface to org.eclipse.lemminx.customservice.XMLLanguageClientAPI results in class cast exception -->


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1007

This will take effect with the release of LSP4IJ 0.7.0.