### PR TITLE
Check for null or empty class name in generate OpenAPI annotations

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -69,6 +69,9 @@ public class MicroProfileGenerateOpenAPIOperation implements IJavaCodeActionPart
 			if (type instanceof PsiClass) {
 				PsiClass typeDeclaration = (PsiClass) type;
 				String typeName = typeDeclaration.getQualifiedName();
+				if (typeName == null || typeName.isBlank()) {
+					continue;
+				}
 
 				Map<String, Object> extendedData = new HashMap<>();
 				extendedData.put(TYPE_NAME_KEY, typeName);


### PR DESCRIPTION
In MicroProfileGenerateOpenAPIOperation we call PsiClass.getQualifiedName() which is nullable. It returns null when the class is local or a type parameter. In our test case we used a type parameter so we see the need to check the return type.

Fixes #995