### PR TITLE
Wait after clicking button to open window

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -179,7 +179,7 @@ public abstract class SingleModJakartaLSTestCommon {
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        // IntelliJ does not start building and indexing until the project is open in the UI
+        // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -391,7 +391,7 @@ public abstract class SingleModLibertyLSTestCommon {
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        // IntelliJ does not start building and indexing until the project is open in the UI
+        // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -313,7 +313,7 @@ public abstract class SingleModMPLSTestCommon {
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        // IntelliJ does not start building and indexing until the project is open in the UI
+        // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -915,7 +915,7 @@ public abstract class SingleModMPProjectTestCommon {
         remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        // IntelliJ does not start building and indexing until the project is open in the UI
+        // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);
         UIBotTestUtils.expandLibertyToolWindowProjectTree(remoteRobot, projectName);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -226,7 +226,7 @@ public abstract class SingleModNLTRestProjectTestCommon {
         remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        // IntelliJ does not start building and indexing until the project is open in the UI
+        // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openLibertyToolWindow(remoteRobot);
 

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -427,7 +427,7 @@ public class UIBotTestUtils {
         Exception error = null;
         for (int i = 0; i < maxRetries; i++) {
             try {
-                TestUtils.sleepAndIgnoreException(10);
+                TestUtils.sleepAndIgnoreException(10); // wait for UI to be rendered before searching for a button
                 error = null;
                 ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
                 projectFrame.getBaseLabel("Liberty", "5");
@@ -435,6 +435,8 @@ public class UIBotTestUtils {
             } catch (WaitForConditionTimeoutException wfcte) {
                 // The Liberty tool window is closed. Open it.
                 clickOnWindowPaneStripeButton(remoteRobot, "Liberty");
+                // After clicking it can take seconds for the window to open on a slow cloud machine.
+                // Important since this is in a loop and you may click twice if there is no sleep.
                 TestUtils.sleepAndIgnoreException(5);
                 break;
             } catch (Exception e) {

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -476,11 +476,13 @@ public class UIBotTestUtils {
         Exception error = null;
         for (int i = 0; i < maxRetries; i++) {
             try {
+                TestUtils.sleepAndIgnoreException(10);
                 error = null;
                 ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
                 projectFrame.getContentComboLabel("Project", "5");
                 break;
             } catch (WaitForConditionTimeoutException wfcte) {
+                TestUtils.sleepAndIgnoreException(5);
                 // The project view is closed. Open it.
                 clickOnWindowPaneStripeButton(remoteRobot, "Project");
                 break;

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -427,6 +427,7 @@ public class UIBotTestUtils {
         Exception error = null;
         for (int i = 0; i < maxRetries; i++) {
             try {
+                TestUtils.sleepAndIgnoreException(10);
                 error = null;
                 ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
                 projectFrame.getBaseLabel("Liberty", "5");
@@ -434,6 +435,7 @@ public class UIBotTestUtils {
             } catch (WaitForConditionTimeoutException wfcte) {
                 // The Liberty tool window is closed. Open it.
                 clickOnWindowPaneStripeButton(remoteRobot, "Liberty");
+                TestUtils.sleepAndIgnoreException(5);
                 break;
             } catch (Exception e) {
                 // The project frame may hang for a bit while loading/processing work. Retry.
@@ -482,9 +484,9 @@ public class UIBotTestUtils {
                 projectFrame.getContentComboLabel("Project", "5");
                 break;
             } catch (WaitForConditionTimeoutException wfcte) {
-                TestUtils.sleepAndIgnoreException(5);
                 // The project view is closed. Open it.
                 clickOnWindowPaneStripeButton(remoteRobot, "Project");
+                TestUtils.sleepAndIgnoreException(5);
                 break;
             } catch (Exception e) {
                 // The project frame may hang for a bit while loading/processing work. Retry.

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -480,7 +480,7 @@ public class UIBotTestUtils {
         Exception error = null;
         for (int i = 0; i < maxRetries; i++) {
             try {
-                TestUtils.sleepAndIgnoreException(10);
+                TestUtils.sleepAndIgnoreException(10); // wait for UI to be rendered before searching for a button
                 error = null;
                 ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
                 projectFrame.getContentComboLabel("Project", "5");
@@ -488,6 +488,8 @@ public class UIBotTestUtils {
             } catch (WaitForConditionTimeoutException wfcte) {
                 // The project view is closed. Open it.
                 clickOnWindowPaneStripeButton(remoteRobot, "Project");
+                // After clicking it can take seconds for the window to open on a slow cloud machine.
+                // Important since this is in a loop and you may click twice if there is no sleep.
                 TestUtils.sleepAndIgnoreException(5);
                 break;
             } catch (Exception e) {


### PR DESCRIPTION
First we try to find the window and then if it is closed we click on the button to open it. But if the window does not open right away on a slow machine then the next time we repeat this action we will click a second time and end up closing the window we want open. So add a short delay after we click. Also added is a slightly longer delay before we try to look for the window in case a previous operation is still running. 

I believe one of the exceptions listed in the issue is caused by the problem of the first exception: `Exceeded timeout ... Failed to find 'Welcome Frame' ` 

Fixes #971