### PR TITLE
BeanValidationDiagnosticsCollector: Use qualified names and equals() for checking built-in types.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
@@ -60,16 +60,16 @@ public class BeanValidationConstants {
     public static final String CALENDAR = "java.util.Calendar";
     public static final String DATE = "java.util.Date";
     public static final String BOOLEAN = "Boolean";
-    public static final String CHAR_SEQUENCE = "CharSequence";
-    public static final String STRING = "String";
+    public static final String CHAR_SEQUENCE = "java.lang.CharSequence";
+    public static final String STRING = "java.lang.String";
     public static final String DOUBLE = "Double";
     public static final String FLOAT = "Float";
     public static final String LONG = "Long";
     public static final String INTEGER = "Integer";
     public static final String SHORT = "Short";
     public static final String BYTE = "Byte";
-    public static final String BIG_INTEGER = "BigInteger";
-    public static final String BIG_DECIMAL = "BigDecimal";
+    public static final String BIG_INTEGER = "java.math.BigInteger";
+    public static final String BIG_DECIMAL = "java.math.BigDecimal";
 
     public static final String DIAGNOSTIC_SOURCE = "jakarta-bean-validation";
     public static final String DIAGNOSTIC_CODE_INVALID_TYPE = "FixTypeOfElement";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationConstants.java
@@ -59,15 +59,8 @@ public class BeanValidationConstants {
     public static final String INSTANT = "java.time.Instant";
     public static final String CALENDAR = "java.util.Calendar";
     public static final String DATE = "java.util.Date";
-    public static final String BOOLEAN = "Boolean";
     public static final String CHAR_SEQUENCE = "java.lang.CharSequence";
     public static final String STRING = "java.lang.String";
-    public static final String DOUBLE = "Double";
-    public static final String FLOAT = "Float";
-    public static final String LONG = "Long";
-    public static final String INTEGER = "Integer";
-    public static final String SHORT = "Short";
-    public static final String BYTE = "Byte";
     public static final String BIG_INTEGER = "java.math.BigInteger";
     public static final String BIG_DECIMAL = "java.math.BigDecimal";
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -103,9 +103,9 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                     }
                 } else if (matchedAnnotation.equals(DECIMAL_MAX) || matchedAnnotation.equals(DECIMAL_MIN)
                         || matchedAnnotation.equals(DIGITS)) {
-                    if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
-                            && !type.getCanonicalText().endsWith(BIG_INTEGER)
-                            && !type.getCanonicalText().endsWith(CHAR_SEQUENCE)
+                    if (!type.getCanonicalText().equals(BIG_DECIMAL)
+                            && !type.getCanonicalText().equals(BIG_INTEGER)
+                            && !type.getCanonicalText().equals(CHAR_SEQUENCE)
                             && !type.equals(PsiTypes.byteType())
                             && !type.equals(PsiTypes.shortType())
                             && !type.equals(PsiTypes.intType())
@@ -136,8 +136,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
                 } else if (matchedAnnotation.equals(MIN) || matchedAnnotation.equals(MAX)) {
-                    if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
-                            && !type.getCanonicalText().endsWith(BIG_INTEGER)
+                    if (!type.getCanonicalText().equals(BIG_DECIMAL)
+                            && !type.getCanonicalText().equals(BIG_INTEGER)
                             && !type.equals(PsiTypes.byteType())
                             && !type.equals(PsiTypes.shortType())
                             && !type.equals(PsiTypes.intType())
@@ -150,8 +150,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                     }
                 } else if (matchedAnnotation.equals(NEGATIVE) || matchedAnnotation.equals(NEGATIVE_OR_ZERO)
                         || matchedAnnotation.equals(POSITIVE) || matchedAnnotation.equals(POSITIVE_OR_ZERO)) {
-                    if (!type.getCanonicalText().endsWith(BIG_DECIMAL)
-                            && !type.getCanonicalText().endsWith(BIG_INTEGER)
+                    if (!type.getCanonicalText().equals(BIG_DECIMAL)
+                            && !type.getCanonicalText().equals(BIG_INTEGER)
                             && !type.equals(PsiTypes.byteType())
                             && !type.equals(PsiTypes.shortType())
                             && !type.equals(PsiTypes.intType())
@@ -199,8 +199,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
     }
 
     private void checkStringOnly(PsiElement element, List<Diagnostic> diagnostics, String annotationName, boolean isMethod, PsiType type) {
-        if (!type.getCanonicalText().endsWith(STRING)
-                && !type.getCanonicalText().endsWith(CHAR_SEQUENCE)) {
+        if (!type.getCanonicalText().equals(STRING)
+                && !type.getCanonicalText().equals(CHAR_SEQUENCE)) {
             String source = isMethod ?
                     Messages.getMessage("AnnotationStringMethods", "@" + getSimpleName(annotationName)) :
                     Messages.getMessage("AnnotationStringFields", "@" + getSimpleName(annotationName));


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1027

Also removed unused constants for unqualified class names.