### PR TITLE
AnnotationDiagnosticsCollector: Use equals() for checking for equality of qualified names.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -227,7 +227,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
     private static boolean isValidAnnotation(String annotationName, String[] validAnnotations) {
         if (annotationName != null) {
             for (String fqName : validAnnotations) {
-                if (fqName.endsWith(annotationName)) {
+                if (fqName.equals(annotationName)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1026