### PR TITLE
ManagedBeanConstants: Remove unused constants for unqualified class names.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class ManagedBeanConstants {
+    /* Annotation Constants */
     public static final String PRODUCES_FQ_NAME = "jakarta.enterprise.inject.Produces";
     public static final String INJECT_FQ_NAME = "jakarta.inject.Inject";
     public static final String DISPOSES_FQ_NAME = "jakarta.enterprise.inject.Disposes";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation.
+ * Copyright (c) 2021, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,20 +18,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class ManagedBeanConstants {
-    /* Annotation Constants */
-    public static final String PRODUCES = "Produces";
     public static final String PRODUCES_FQ_NAME = "jakarta.enterprise.inject.Produces";
-    public static final String INJECT = "Inject";
     public static final String INJECT_FQ_NAME = "jakarta.inject.Inject";
-    public static final String DISPOSES = "Disposes";
     public static final String DISPOSES_FQ_NAME = "jakarta.enterprise.inject.Disposes";
-    public static final String OBSERVES = "Observes";
     public static final String OBSERVES_FQ_NAME = "jakarta.enterprise.event.Observes";
-    public static final String OBSERVES_ASYNC = "ObservesAsync";
     public static final String OBSERVES_ASYNC_FQ_NAME = "jakarta.enterprise.event.ObservesAsync";
-    public static final String DEPENDENT = "Dependent";
     public static final String DEPENDENT_FQ_NAME = "jakarta.enterprise.context.Dependent";
-
 
     public static final String DIAGNOSTIC_SOURCE = "jakarta-cdi";
     public static final String DIAGNOSTIC_CODE = "InvalidManagedBeanAnnotation";
@@ -40,22 +32,17 @@ public class ManagedBeanConstants {
 
     public static final String CONSTRUCTOR_DIAGNOSTIC_CODE = "InvalidManagedBeanConstructor";
 
-
     public static final String DIAGNOSTIC_CODE_INVALID_INJECT_PARAM = "RemoveInjectOrConflictedAnnotations";
     public static final String DIAGNOSTIC_CODE_INVALID_PRODUCES_PARAM = "RemoveProducesOrConflictedAnnotations";
     public static final String DIAGNOSTIC_CODE_INVALID_DISPOSES_PARAM = "RemoveDisposesOrConflictedAnnotations";
 
     public static final String DIAGNOSTIC_CODE_REDUNDANT_DISPOSES = "RemoveExtraDisposes";
 
-    public static final Set<String> INVALID_INJECT_PARAMS = new HashSet<String>(Arrays.asList(DISPOSES, OBSERVES, OBSERVES_ASYNC));
     public static final String[] INVALID_INJECT_PARAMS_FQ = { DISPOSES_FQ_NAME, OBSERVES_FQ_NAME,
             OBSERVES_ASYNC_FQ_NAME };
 
     // List can be found in the cdi doc here:
     // https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#bean_defining_annotations
-    public static final Set<String> SCOPES = new HashSet<String>(
-            Arrays.asList("Dependent", "ApplicationScoped", "ConversationScoped", "RequestScoped", "SessionScoped",
-                    "NormalScope", "Interceptor", "Decorator", "Stereotype"));
     public static final Set<String> SCOPE_FQ_NAMES = new HashSet<String>(
             Arrays.asList(DEPENDENT_FQ_NAME, "jakarta.enterprise.context.ApplicationScoped",
                     "jakarta.enterprise.context.ConversationScoped", "jakarta.enterprise.context.RequestScoped",


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1028