### PR TITLE
DependencyInjectionConstants: Remove unused constants for unqualified class names.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/di/DependencyInjectionConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/di/DependencyInjectionConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation.
+ * Copyright (c) 2021, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,15 +15,8 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.di;
 
 public class DependencyInjectionConstants {
 
-
     /* Annotation Constants */
-
-    public static final String PRODUCES = "Produces";
-    public static final String INJECT = "Inject";
     public static final String INJECT_FQ_NAME = "jakarta.inject.Inject";
-    public static final String QUALIFIER = "Qualifier";
-    public static final String NAMED = "Named";
-
 
     /* Diagnostics fields constants */
     public static final String DIAGNOSTIC_SOURCE = "jakarta-di";


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1029