### PR TITLE
Fix usage of ProcessCanceledException to support 2024.2

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -40,8 +40,10 @@ public class AnnotationUtil {
                         .filter(scopes::contains)
                         .distinct()
                         .collect(Collectors.toList()),
-                Collections::emptyList,  // Fallback value in case of exception
-                e -> LOGGER.log(Level.WARNING, "Error while calling getScopeAnnotations", e)
+                e -> {
+                    LOGGER.log(Level.WARNING, "Error while calling getScopeAnnotations", e);
+                    return Collections.<String>emptyList();
+                }
         );
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -38,7 +38,11 @@ public class AnnotationUtil {
             // recognised annotations found in scopes.
             return Arrays.stream(type.getAnnotations()).map(annotation -> annotation.getNameReferenceElement().getQualifiedName())
                     .filter(scopes::contains).distinct().collect(Collectors.toList());
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             return Collections.<String>emptyList();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 IBM Corporation, Lidia Ataupillco Ramos and others.
+/* Copyright (c) 2022, 2024 IBM Corporation, Lidia Ataupillco Ramos and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AnnotationUtil.java
@@ -35,6 +35,8 @@ public class AnnotationUtil {
     private static final Logger LOGGER = Logger.getLogger(AnnotationUtil.class.getName());
     public static List<String> getScopeAnnotations(PsiClass type, Set<String> scopes) {
         return ExceptionUtil.executeWithExceptionHandling(
+                // Construct a stream of only the annotations applied to the type that are also
+                // recognised annotations found in scopes.
                 () -> Arrays.stream(type.getAnnotations())
                         .map(annotation -> annotation.getNameReferenceElement().getQualifiedName())
                         .filter(scopes::contains)

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -12,11 +12,8 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.annotations;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiPrimitiveType;
 import com.intellij.psi.PsiTypes;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
@@ -26,13 +23,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,17 +71,17 @@ public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipa
         assert parentType != null;
         ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, PsiTypes.voidType());
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to change return type to void", e);
+
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to change return type to void", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -77,7 +77,11 @@ public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipa
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to change return type to void", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/PostConstructReturnTypeQuickFix.java
@@ -26,11 +26,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -72,17 +70,7 @@ public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipa
         ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, PsiTypes.voidType());
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to change return type to void", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to change return type to void");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
@@ -23,13 +21,13 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.Remo
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCodeActionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.*;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -111,17 +109,16 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 final RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(name, context.getSource().getCompilationUnit(),
                         context.getASTRoot(), parentType, 0, Collections.singletonList(annotationToRemove.get()), isFormatRequired);
 
-                try {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                } catch (ProcessCanceledException e) {
-                    //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-                    //TODO delete block when minimum required version is 2024.2
-                    throw e;
-                } catch (IndexNotReadyException | CancellationException e) {
-                    throw e;
-                } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove constraint annotation", e);
+                Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                        () -> {
+                            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                            toResolve.setEdit(we);
+                            return true;
+                        },
+                        e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove constraint annotation", e)
+                );
+                if (success == null || !success) {
+                    System.out.println("An error occurred during the code action resolution.");
                 }
             }
         }
@@ -138,17 +135,16 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(),
                 Collections.singletonList("static"));
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove static modifier", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove static modifier", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -114,7 +114,11 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 try {
                     WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                     toResolve.setEdit(we);
-                } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+                } catch (ProcessCanceledException e) {
+                    //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                    //TODO delete block when minimum required version is 2024.2
+                    throw e;
+                } catch (IndexNotReadyException | CancellationException e) {
                     throw e;
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove constraint annotation", e);
@@ -137,7 +141,11 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove static modifier", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -24,11 +24,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCode
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -109,17 +107,7 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 final RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(name, context.getSource().getCompilationUnit(),
                         context.getASTRoot(), parentType, 0, Collections.singletonList(annotationToRemove.get()), isFormatRequired);
 
-                Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                        () -> {
-                            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                            toResolve.setEdit(we);
-                            return true;
-                        },
-                        e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove constraint annotation", e)
-                );
-                if (success == null || !success) {
-                    System.out.println("An error occurred during the code action resolution.");
-                }
+                ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to remove constraint annotation");
             }
         }
     }
@@ -135,17 +123,7 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
                 context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(),
                 Collections.singletonList("static"));
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove static modifier", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to remove static modifier");
     }
 
     private void removeStaticModifierCodeActions(Diagnostic diagnostic, JavaCodeActionContext context,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -77,7 +77,11 @@ public class ManagedBeanNoArgConstructorQuickFix implements IJavaCodeActionParti
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -26,12 +26,10 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -72,17 +70,7 @@ public class ManagedBeanNoArgConstructorQuickFix implements IJavaCodeActionParti
                 context.getSource().getCompilationUnit(), context.getASTRoot(), parentType, 0,
                 constructorName.equals(Messages.getMessage("AddProtectedConstructor")) ? "protected" : "public");
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code actions to add constructors");
 
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -13,8 +13,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -25,6 +23,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -32,7 +31,6 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,17 +72,16 @@ public class ManagedBeanNoArgConstructorQuickFix implements IJavaCodeActionParti
                 context.getSource().getCompilationUnit(), context.getASTRoot(), parentType, 0,
                 constructorName.equals(Messages.getMessage("AddProtectedConstructor")) ? "protected" : "public");
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
 
         return toResolve;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
@@ -27,11 +27,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants.SCOPE_FQ_NAMES;
@@ -72,17 +70,7 @@ public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
                 context.getASTRoot(), parentType, 0, ADD_ANNOTATION, context.getSource().getCompilationUnit(),
                 REMOVE_ANNOTATION_NAMES);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
@@ -15,8 +15,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiModifierListOwner;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
@@ -26,13 +24,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCode
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ReplaceAnnotationProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,17 +72,16 @@ public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
                 context.getASTRoot(), parentType, 0, ADD_ANNOTATION, context.getSource().getCompilationUnit(),
                 REMOVE_ANNOTATION_NAMES);
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
@@ -77,7 +77,11 @@ public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -26,10 +26,8 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -89,17 +87,7 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
                 context.getASTRoot(), parentType, 0, context.getSource().getCompilationUnit(),
                 annotations);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -93,7 +93,11 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -96,7 +96,11 @@ public abstract class InsertAnnotationQuickFix implements IJavaCodeActionPartici
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
@@ -27,6 +25,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -34,7 +33,6 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,17 +91,17 @@ public abstract class InsertAnnotationQuickFix implements IJavaCodeActionPartici
         String label = getLabel(this.annotation, attributes);
         ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(label, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), binding, annotationNode, 0, this.annotation, Arrays.asList(attributes));
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);
+
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -28,12 +28,10 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -92,17 +90,7 @@ public abstract class InsertAnnotationQuickFix implements IJavaCodeActionPartici
         ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(label, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), binding, annotationNode, 0, this.annotation, Arrays.asList(attributes));
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action " + label);
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationQuickFix.java
@@ -98,7 +98,7 @@ public abstract class InsertAnnotationQuickFix implements IJavaCodeActionPartici
                     toResolve.setEdit(we);
                     return true;
                 },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e)
         );
         if (success == null || !success) {
             System.out.println("An error occurred during the code action resolution.");

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
@@ -30,6 +28,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -41,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -117,17 +115,16 @@ public abstract class RemoveAnnotationConflictQuickFix implements IJavaCodeActio
         ChangeCorrectionProposal proposal = new DeleteAnnotationProposal(name, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, declaringNode, resolveAnnotationsArray);
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove annotation", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove annotation", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -120,7 +120,11 @@ public abstract class RemoveAnnotationConflictQuickFix implements IJavaCodeActio
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -31,7 +31,6 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.HashMap;
@@ -40,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -115,17 +113,7 @@ public abstract class RemoveAnnotationConflictQuickFix implements IJavaCodeActio
         ChangeCorrectionProposal proposal = new DeleteAnnotationProposal(name, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, declaringNode, resolveAnnotationsArray);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to remove annotation", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to remove annotation");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
@@ -78,7 +78,11 @@ public class RemoveMethodParametersQuickFix implements IJavaCodeActionParticipan
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveMethodParametersQuickFix.java
@@ -28,12 +28,10 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -74,17 +72,7 @@ public class RemoveMethodParametersQuickFix implements IJavaCodeActionParticipan
         ChangeCorrectionProposal proposal = new RemoveParamsProposal(NAME, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, Arrays.asList(parameterList.getParameters()), false);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action");
         return toResolve;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -24,13 +24,11 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCode
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -106,17 +104,7 @@ public abstract class RemoveModifierConflictQuickFix implements IJavaCodeActionP
         ModifyModifiersProposal proposal = new ModifyModifiersProposal(label, context.getSource().getCompilationUnit(),
             context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(), Arrays.asList(modifiers), false);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action " + label);
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -13,8 +13,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
@@ -23,6 +21,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.Modi
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCodeActionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -31,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -108,17 +106,16 @@ public abstract class RemoveModifierConflictQuickFix implements IJavaCodeActionP
         ModifyModifiersProposal proposal = new ModifyModifiersProposal(label, context.getSource().getCompilationUnit(),
             context.getASTRoot(), parentType, 0, modifierListOwner.getModifierList(), Collections.emptyList(), Arrays.asList(modifiers), false);
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveModifierConflictQuickFix.java
@@ -111,7 +111,11 @@ public abstract class RemoveModifierConflictQuickFix implements IJavaCodeActionP
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action " + label, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -23,7 +23,6 @@
  import io.openliberty.tools.intellij.util.ExceptionUtil;
  import org.eclipse.lsp4j.CodeAction;
  import org.eclipse.lsp4j.Diagnostic;
- import org.eclipse.lsp4j.WorkspaceEdit;
  import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
  import java.util.*;
@@ -120,17 +119,7 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
          RemoveAnnotationsProposal proposal = new RemoveAnnotationsProposal(label, context.getSource().getCompilationUnit(),
                  context.getASTRoot(), parentType, 0, psiAnnotationsToRemove);
 
-         Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                 () -> {
-                     WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                     toResolve.setEdit(we);
-                     return true;
-                 },
-                 e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class", e)
-         );
-         if (success == null || !success) {
-             System.out.println("An error occurred during the code action resolution.");
-         }
+         ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to extend the HttpServlet class");
          return toResolve;
      }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -124,7 +124,11 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
          try {
              WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
              toResolve.setEdit(we);
-         } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+         } catch (ProcessCanceledException e) {
+             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+             //TODO delete block when minimum required version is 2024.2
+             throw e;
+         } catch (IndexNotReadyException | CancellationException e) {
              throw e;
          } catch (Exception e) {
              LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -28,12 +28,10 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -101,16 +99,7 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
     }
 
     public void convertWorkspaceEdit(ChangeCorrectionProposal proposal, String warningMessage, JavaCodeActionResolveContext context) {
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    context.getUnresolved().setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, warningMessage, e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        final CodeAction toResolve = context.getUnresolved();
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, warningMessage);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -13,8 +13,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
@@ -27,6 +25,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -34,7 +33,6 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -103,17 +101,16 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
     }
 
     public void convertWorkspaceEdit(ChangeCorrectionProposal proposal, String warningMessage, JavaCodeActionResolveContext context) {
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            context.getUnresolved().setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, warningMessage, e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    context.getUnresolved().setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, warningMessage, e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -106,7 +106,11 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             context.getUnresolved().setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, warningMessage, e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -13,8 +13,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
@@ -26,13 +24,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -77,17 +75,17 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
         assert parentMethod != null;
         ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e);
+
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -80,7 +80,11 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -27,11 +27,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -76,17 +74,7 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
         ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, parentMethod.getModifierList(), Collections.singletonList("public"));
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to make method public", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to make method public");
         return toResolve;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -13,8 +13,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.jax_rs;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
@@ -24,13 +22,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.*;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -129,17 +127,16 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
         ChangeCorrectionProposal proposal = new RemoveParamsProposal(title, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0,  entityParams, false);
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -25,11 +25,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -127,17 +125,7 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
         ChangeCorrectionProposal proposal = new RemoveParamsProposal(title, context.getSource().getCompilationUnit(),
                 context.getASTRoot(), parentType, 0,  entityParams, false);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -132,7 +132,11 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
@@ -78,7 +78,11 @@ public class PersistenceAnnotationQuickFix extends InsertAnnotationMissingQuickF
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceAnnotationQuickFix.java
@@ -23,12 +23,10 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -73,17 +71,7 @@ public class PersistenceAnnotationQuickFix extends InsertAnnotationMissingQuickF
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), binding, annotationNode, 0, attributes, this.getAnnotations());
 
-            Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                    () -> {
-                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                        toResolve.setEdit(we);
-                        return true;
-                    },
-                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-            );
-            if (success == null || !success) {
-                System.out.println("An error occurred during the code action resolution.");
-            }
+            ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         }
 
         return toResolve;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -96,7 +96,11 @@ public class PersistenceEntityQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -25,11 +25,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -90,17 +88,7 @@ public class PersistenceEntityQuickFix implements IJavaCodeActionParticipant {
                 context.getSource().getCompilationUnit(), context.getASTRoot(), parentType, 0,
                 constructorName.equals(Messages.getMessage("AddNoArgProtectedConstructor")) ? "protected" : "public");
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code actions to add constructors");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityQuickFix.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence;
 
-
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -25,13 +22,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,17 +90,16 @@ public class PersistenceEntityQuickFix implements IJavaCodeActionParticipant {
                 context.getSource().getCompilationUnit(), context.getASTRoot(), parentType, 0,
                 constructorName.equals(Messages.getMessage("AddNoArgProtectedConstructor")) ? "protected" : "public");
 
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code actions to add constructors", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
@@ -105,7 +105,11 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
@@ -125,7 +129,11 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
@@ -28,14 +28,12 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -101,17 +99,7 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, attributesToAdd);
 
-            Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                    () -> {
-                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                        toResolve.setEdit(we);
-                        return true;
-                    },
-                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-            );
-            if (success == null || !success) {
-                System.out.println("An error occurred during the code action resolution.");
-            }
+            ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         }
 
         if (diagnosticCode.equals(ServletConstants.DIAGNOSTIC_CODE_FILTER_DUPLICATE_ATTRIBUTES)) {
@@ -125,17 +113,7 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, new ArrayList<String>(), attributesToRemove);
 
-            Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                    () -> {
-                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                        toResolve.setEdit(we);
-                        return true;
-                    },
-                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-            );
-            if (success == null || !success) {
-                System.out.println("An error occurred during the code action resolution.");
-            }
+            ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -28,14 +28,12 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -100,17 +98,7 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, attributesToAdd);
 
-            Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                    () -> {
-                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                        toResolve.setEdit(we);
-                        return true;
-                    },
-                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-            );
-            if (success == null || !success) {
-                System.out.println("An error occurred during the code action resolution.");
-            }
+            ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         }
         if (diagnosticCode.equals(ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES)) {
             node = context.getCoveringNode();
@@ -123,17 +111,7 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, new ArrayList<String>(), attributesToRemove);
 
-            Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                    () -> {
-                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                        toResolve.setEdit(we);
-                        return true;
-                    },
-                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
-            );
-            if (success == null || !success) {
-                System.out.println("An error occurred during the code action resolution.");
-            }
+            ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action.");
         }
 
         return toResolve;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -104,7 +104,11 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
@@ -123,7 +127,11 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             try {
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
-            } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+            } catch (ProcessCanceledException e) {
+                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                //TODO delete block when minimum required version is 2024.2
+                throw e;
+            } catch (IndexNotReadyException | CancellationException e) {
                 throw e;
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -14,8 +14,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiModifierListOwner;
@@ -27,6 +25,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quic
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -101,17 +99,17 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             String name = toResolve.getTitle();
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, attributesToAdd);
-            try {
-                WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                toResolve.setEdit(we);
-            } catch (ProcessCanceledException e) {
-                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-                //TODO delete block when minimum required version is 2024.2
-                throw e;
-            } catch (IndexNotReadyException | CancellationException e) {
-                throw e;
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
+
+            Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                    () -> {
+                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                        toResolve.setEdit(we);
+                        return true;
+                    },
+                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
+            );
+            if (success == null || !success) {
+                System.out.println("An error occurred during the code action resolution.");
             }
         }
         if (diagnosticCode.equals(ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES)) {
@@ -124,17 +122,17 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
             String name = toResolve.getTitle();
             ChangeCorrectionProposal proposal = new ModifyAnnotationProposal(name, context.getSource().getCompilationUnit(),
                     context.getASTRoot(), parentType, annotationNode, 0, annotation, new ArrayList<String>(), attributesToRemove);
-            try {
-                WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                toResolve.setEdit(we);
-            } catch (ProcessCanceledException e) {
-                //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-                //TODO delete block when minimum required version is 2024.2
-                throw e;
-            } catch (IndexNotReadyException | CancellationException e) {
-                throw e;
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e);
+
+            Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                    () -> {
+                        WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                        toResolve.setEdit(we);
+                        return true;
+                    },
+                    e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action.", e)
+            );
+            if (success == null || !success) {
+                System.out.println("An error occurred during the code action resolution.");
             }
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
@@ -81,7 +81,11 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to filter implementation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
@@ -14,8 +14,6 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -26,13 +24,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCode
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ImplementInterfaceProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -78,17 +76,17 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
         ChangeCorrectionProposal proposal = new ImplementInterfaceProposal(
                 context.getCompilationUnit(), parentType, context.getASTRoot(),
                 "jakarta.servlet.Filter", 0, context.getSource().getCompilationUnit());
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to filter implementation", e);
+
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to filter implementation", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/FilterImplementationQuickFix.java
@@ -27,11 +27,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -77,17 +75,7 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
                 context.getCompilationUnit(), parentType, context.getASTRoot(),
                 "jakarta.servlet.Filter", 0, context.getSource().getCompilationUnit());
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to filter implementation", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to filter implementation");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
@@ -15,8 +15,6 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.servlet;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -27,13 +25,13 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCod
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -95,17 +93,17 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
         ChangeCorrectionProposal proposal = new ExtendClassProposal(title, context.getCompilationUnit(),
                 context.getSource().getCompilationUnit(), parentType,
                 "jakarta.servlet.http.HttpServlet", 0);
-        try {
-            WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-            toResolve.setEdit(we);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e);
+
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                    toResolve.setEdit(we);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred during the code action resolution.");
         }
         return toResolve;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
@@ -98,7 +98,11 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/HttpServletQuickFix.java
@@ -28,11 +28,9 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -94,17 +92,7 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
                 context.getSource().getCompilationUnit(), parentType,
                 "jakarta.servlet.http.HttpServlet", 0);
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to extend the HttpServlet class.", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to extend the HttpServlet class.");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
@@ -28,14 +28,12 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -98,17 +96,7 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
                 context.getCompilationUnit(), parentType, context.getASTRoot(),
                 interfaceType, 0, context.getSource().getCompilationUnit());
 
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-                    toResolve.setEdit(we);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to listener implementation", e)
-        );
-        if (success == null || !success) {
-            System.out.println("An error occurred during the code action resolution.");
-        }
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to listener implementation");
         return toResolve;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
@@ -102,7 +102,11 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
         try {
             WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
             toResolve.setEdit(we);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to listener implementation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
@@ -83,7 +83,11 @@ public abstract class InsertAnnotationAttributeQuickFix implements IJavaCodeActi
 				annotation, 0, context.getSource().getCompilationUnit(), attributeName);
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Unable to resolve code action edit for inserting an attribute value", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
@@ -31,7 +31,6 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -81,16 +80,7 @@ public abstract class InsertAnnotationAttributeQuickFix implements IJavaCodeActi
 		ChangeCorrectionProposal proposal = new InsertAnnotationAttributeProposal(name, context.getCompilationUnit(),
 				annotation, 0, context.getSource().getCompilationUnit(), attributeName);
 
-		Boolean success = ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-					return true;
-				},
-				e -> LOGGER.log(Level.WARNING, "Unable to resolve code action edit for inserting an attribute value", e)
-		);
-		if (success == null || !success) {
-			System.out.println("An error occurred during the code action resolution.");
-		}
+		ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to resolve code action edit for inserting an attribute value");
 		return toResolve;
 	}
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationAttributeQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2021, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.intellij.psi.PsiClass;
@@ -33,7 +32,6 @@ import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 import org.eclipse.lsp4mp.commons.codeaction.ICodeActionId;
 
@@ -101,17 +99,7 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
 				context.getASTRoot(), parentType, 0, context.getSource().getCompilationUnit(),
 				resolveAnnotationsArray);
 
-		Boolean success = ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
-					toResolve.setEdit(we);
-					return true;
-				},
-				e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to insert missing annotation", e)
-		);
-		if (success == null || !success) {
-			System.out.println("An error occurred during the code action resolution.");
-		}
+		ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action to insert missing annotation");
 
 		return toResolve;
 	}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -105,7 +105,11 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
 		try {
 			WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
 			toResolve.setEdit(we);
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action to insert missing annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -96,8 +96,10 @@ public class AnnotationValidator {
 					}
 					return rule.validate(value);
 				},
-				() -> null,  // Fallback value supplier in case of exception
-				e -> LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e)
+				e -> {
+					LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+					return null;
+				}
 		);
 	}
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -93,7 +93,11 @@ public class AnnotationValidator {
 				return null;
 			}
 			return rule.validate(value);
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -90,16 +90,16 @@ public class AnnotationValidator {
 	 */
 	public String validate(String value, AnnotationAttributeRule rule) {
 		return ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					if (rule == null) {
-						return null;
-					}
-					return rule.validate(value);
-				},
-				e -> {
-					LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+			() -> {
+				if (rule == null) {
 					return null;
 				}
+				return rule.validate(value);
+			},
+			e -> {
+				LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
+				return null;
+			}
 		);
 	}
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -95,7 +95,6 @@ public class AnnotationValidator {
 			return rule.validate(value);
 		} catch (ProcessCanceledException e) {
 			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-			//TODO delete block when minimum required version is 2024.2
 			throw e;
 		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -96,7 +96,7 @@ public class AnnotationValidator {
 					}
 					return rule.validate(value);
 				},
-				null,  // Fallback value in case of exception
+				() -> null,  // Fallback value supplier in case of exception
 				e -> LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e)
 		);
 	}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -16,6 +16,7 @@ package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.validators.annotat
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.IndexNotReadyException;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -88,20 +89,16 @@ public class AnnotationValidator {
 	 * @return the error message of the validation result of the attribute value and null otherwise.
 	 */
 	public String validate(String value, AnnotationAttributeRule rule) {
-		try {
-			if (rule == null) {
-				return null;
-			}
-			return rule.validate(value);
-		} catch (ProcessCanceledException e) {
-			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-			throw e;
-		} catch (IndexNotReadyException | CancellationException e) {
-			throw e;
-		} catch (Exception e) {
-			LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e);
-			return null;
-		}
+		return ExceptionUtil.executeWithExceptionHandling(
+				() -> {
+					if (rule == null) {
+						return null;
+					}
+					return rule.validate(value);
+				},
+				null,  // Fallback value in case of exception
+				e -> LOGGER.log(Level.WARNING, e.getLocalizedMessage(), e)
+		);
 	}
 
 	/**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/validators/annotations/AnnotationValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2021, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -52,8 +52,11 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public boolean isAdaptedForCompletion(JavaCompletionContext context) {
         try {
             return getInstance().isAdaptedForCompletion(context);
-        }
-        catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         }
         catch (Exception e) {
@@ -66,8 +69,11 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public List<? extends CompletionItem> collectCompletionItems(JavaCompletionContext context) {
         try {
             return getInstance().collectCompletionItems(context);
-        }
-        catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         }
         catch (Exception e) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -54,7 +54,6 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
             return getInstance().isAdaptedForCompletion(context);
         } catch (ProcessCanceledException e) {
             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;
@@ -71,7 +70,6 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
             return getInstance().collectCompletionItems(context);
         } catch (ProcessCanceledException e) {
             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -50,8 +50,10 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public boolean isAdaptedForCompletion(JavaCompletionContext context) {
         return ExceptionUtil.executeWithExceptionHandling(
                 () -> getInstance().isAdaptedForCompletion(context),
-                () -> false,  // Fallback value in case of exception
-                e -> LOGGER.log(Level.WARNING, "Error while calling isAdaptedForCompletion", e)
+                e -> {
+                    LOGGER.log(Level.WARNING, "Error while calling isAdaptedForCompletion", e);
+                    return false;
+                }
         );
     }
 
@@ -59,8 +61,10 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
     public List<? extends CompletionItem> collectCompletionItems(JavaCompletionContext context) {
         return ExceptionUtil.executeWithExceptionHandling(
                 () -> getInstance().collectCompletionItems(context),
-                Collections::emptyList,  // Fallback value in case of exception
-                e -> LOGGER.log(Level.WARNING, "Error while calling collectCompletionItems", e)
+                e ->  {
+                    LOGGER.log(Level.WARNING, "Error while calling collectCompletionItems", e);
+                    return Collections.emptyList();
+                }
         );
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/completion/JavaCompletionDefinition.java
@@ -15,18 +15,16 @@
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java.completion;
 
 import com.intellij.openapi.extensions.ExtensionPointName;
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.IJavaCompletionParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.completion.JavaCompletionContext;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CompletionItem;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -50,34 +48,20 @@ public final class JavaCompletionDefinition extends BaseKeyedLazyInstance<IJavaC
 
     @Override
     public boolean isAdaptedForCompletion(JavaCompletionContext context) {
-        try {
-            return getInstance().isAdaptedForCompletion(context);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        }
-        catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling isAdaptedForCompletion", e);
-            return false;
-        }
+        return ExceptionUtil.executeWithExceptionHandling(
+                () -> getInstance().isAdaptedForCompletion(context),
+                () -> false,  // Fallback value in case of exception
+                e -> LOGGER.log(Level.WARNING, "Error while calling isAdaptedForCompletion", e)
+        );
     }
 
     @Override
     public List<? extends CompletionItem> collectCompletionItems(JavaCompletionContext context) {
-        try {
-            return getInstance().collectCompletionItems(context);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        }
-        catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling collectCompletionItems", e);
-            return Collections.emptyList();
-        }
+        return ExceptionUtil.executeWithExceptionHandling(
+                () -> getInstance().collectCompletionItems(context),
+                Collections::emptyList,  // Fallback value in case of exception
+                e -> LOGGER.log(Level.WARNING, "Error while calling collectCompletionItems", e)
+        );
     }
 
     public @Nullable String getGroup() {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -71,25 +71,23 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().beginDiagnostics(context);
                 return true;
             },
+                null,
             e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
         );
     }
 
     @Override
     public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context) {
-        try {
-            List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
-            return diagnostics != null ? diagnostics : Collections.emptyList();
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e);
-            return Collections.emptyList();
-        }
+        return ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
+                    return diagnostics != null ? diagnostics : Collections.emptyList();
+                },
+                Collections::emptyList,
+                e -> LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e)
+        );
     }
+
 
     @Override
     public void endDiagnostics(JavaDiagnosticsContext context) {
@@ -98,6 +96,7 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().endDiagnostics(context);
                 return true;
             },
+                null,
             e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -55,7 +55,6 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
             return getInstance().isAdaptedForDiagnostics(context);
         } catch (ProcessCanceledException e) {
             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;
@@ -67,12 +66,12 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
 
     @Override
     public void beginDiagnostics(JavaDiagnosticsContext context) {
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    getInstance().beginDiagnostics(context);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
+        ExceptionUtil.executeWithExceptionHandling(
+            () -> {
+                getInstance().beginDiagnostics(context);
+                return true;
+            },
+            e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
         );
     }
 
@@ -83,7 +82,6 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
             return diagnostics != null ? diagnostics : Collections.emptyList();
         } catch (ProcessCanceledException e) {
             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;
@@ -95,12 +93,12 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
 
     @Override
     public void endDiagnostics(JavaDiagnosticsContext context) {
-        Boolean success = ExceptionUtil.executeWithExceptionHandling(
-                () -> {
-                    getInstance().endDiagnostics(context);
-                    return true;
-                },
-                e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
+        ExceptionUtil.executeWithExceptionHandling(
+            () -> {
+                getInstance().endDiagnostics(context);
+                return true;
+            },
+            e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
         );
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -74,9 +74,6 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 },
                 e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
         );
-        if (success == null || !success) {
-            System.out.println("An error occurred");
-        }
     }
 
     @Override
@@ -105,9 +102,6 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 },
                 e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
         );
-        if (success == null || !success) {
-            System.out.println("An error occurred");
-        }
     }
 
     public @Nullable String getGroup() {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -65,7 +65,7 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().beginDiagnostics(context);
                 return true;
             },
-                null,
+            () -> null,  // Fallback value supplier in case of exception
             e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
         );
     }
@@ -90,7 +90,7 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().endDiagnostics(context);
                 return true;
             },
-                null,
+            () -> null,  // Fallback value supplier in case of exception
             e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -52,7 +52,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
         try {
             return getInstance().isAdaptedForDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e);
@@ -64,7 +68,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public void beginDiagnostics(JavaDiagnosticsContext context) {
         try {
             getInstance().beginDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
@@ -76,7 +84,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
         try {
             List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
             return diagnostics != null ? diagnostics : Collections.emptyList();
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e);
@@ -88,7 +100,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public void endDiagnostics(JavaDiagnosticsContext context) {
         try {
             getInstance().endDiagnostics(context);
-        } catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -51,17 +51,11 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
 
     @Override
     public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
-        try {
-            return getInstance().isAdaptedForDiagnostics(context);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e);
-            return false;
-        }
+        return ExceptionUtil.executeWithExceptionHandling(
+                () -> getInstance().isAdaptedForDiagnostics(context),
+                () -> false,  // Fallback value in case of exception
+                e -> LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e)
+        );
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -53,8 +53,10 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
     public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
         return ExceptionUtil.executeWithExceptionHandling(
                 () -> getInstance().isAdaptedForDiagnostics(context),
-                () -> false,  // Fallback value in case of exception
-                e -> LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e)
+                e -> {
+                    LOGGER.log(Level.WARNING, "Error while calling isAdaptedForDiagnostics", e);
+                    return false;
+                }
         );
     }
 
@@ -65,8 +67,10 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().beginDiagnostics(context);
                 return true;
             },
-            () -> null,  // Fallback value supplier in case of exception
-            e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
+            e -> {
+                LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
+                return null;
+            }
         );
     }
 
@@ -77,8 +81,10 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                     List<Diagnostic> diagnostics = getInstance().collectDiagnostics(context);
                     return diagnostics != null ? diagnostics : Collections.emptyList();
                 },
-                Collections::emptyList,
-                e -> LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e)
+                e -> {
+                    LOGGER.log(Level.WARNING, "Error while calling collectDiagnostics", e);
+                    return Collections.emptyList();
+                }
         );
     }
 
@@ -90,8 +96,10 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
                 getInstance().endDiagnostics(context);
                 return true;
             },
-            () -> null,  // Fallback value supplier in case of exception
-            e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
+            e -> {
+                LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);
+                return null;
+            }
         );
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -69,7 +69,7 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
             },
             e -> {
                 LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
-                return null;
+                return false;
             }
         );
     }
@@ -98,7 +98,7 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
             },
             e -> {
                 LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);
-                return null;
+                return false;
             }
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/corrections/JavaDiagnosticsDefinition.java
@@ -21,6 +21,7 @@ import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaDiagnosticsParticipant;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics.JavaDiagnosticsContext;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.Diagnostic;
 import org.jetbrains.annotations.Nullable;
 
@@ -66,16 +67,15 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
 
     @Override
     public void beginDiagnostics(JavaDiagnosticsContext context) {
-        try {
-            getInstance().beginDiagnostics(context);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    getInstance().beginDiagnostics(context);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Error while calling beginDiagnostics", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred");
         }
     }
 
@@ -98,16 +98,15 @@ public final class JavaDiagnosticsDefinition extends BaseKeyedLazyInstance<IJava
 
     @Override
     public void endDiagnostics(JavaDiagnosticsContext context) {
-        try {
-            getInstance().endDiagnostics(context);
-        } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            throw e;
-        } catch (IndexNotReadyException | CancellationException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e);
+        Boolean success = ExceptionUtil.executeWithExceptionHandling(
+                () -> {
+                    getInstance().endDiagnostics(context);
+                    return true;
+                },
+                e -> LOGGER.log(Level.WARNING, "Error while calling endDiagnostics", e)
+        );
+        if (success == null || !success) {
+            System.out.println("An error occurred");
         }
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -159,7 +159,7 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 			},
 			e -> {
 				LOGGER.log(Level.WARNING, "An error occurred", e);
-                return null;
+				return null;
             }
 		);
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -159,7 +159,7 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 			},
 			e -> {
 				LOGGER.log(Level.WARNING, "An error occurred", e);
-				throw new RuntimeException("Failed to validate asynchronous annotation", e);
+				throw e;
             }
 		);
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -157,8 +157,10 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 				PsiType methodReturnType = node.getReturnType();
 				return methodReturnType.getCanonicalText();
 			},
-				null,
-			e -> LOGGER.log(Level.WARNING, "An error occurred", e)
+			e -> {
+				LOGGER.log(Level.WARNING, "An error occurred", e);
+                return null;
+            }
 		);
 
 		if ((!isAllowedReturnTypeForAsynchronousAnnotation(methodReturnTypeString))) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -156,7 +156,11 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 		String methodReturnTypeString;
 		try {
 			methodReturnTypeString = methodReturnType.getCanonicalText();
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			throw e;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -153,11 +153,11 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 	private void validateAsynchronousAnnotation(PsiMethod node, PsiAnnotation annotation) {
 		// Use lambda expression to avoid code duplication
 		String methodReturnTypeString = ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					PsiType methodReturnType = node.getReturnType();
-					return methodReturnType.getCanonicalText();
-				},
-				e -> LOGGER.log(Level.WARNING, "An error occurred", e)
+			() -> {
+				PsiType methodReturnType = node.getReturnType();
+				return methodReturnType.getCanonicalText();
+			},
+			e -> LOGGER.log(Level.WARNING, "An error occurred", e)
 		);
 
 		if ((!isAllowedReturnTypeForAsynchronousAnnotation(methodReturnTypeString))) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -159,7 +159,7 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 			},
 			e -> {
 				LOGGER.log(Level.WARNING, "An error occurred", e);
-				return null;
+				throw new RuntimeException("Failed to validate asynchronous annotation", e);
             }
 		);
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/faulttolerance/java/MicroProfileFaultToleranceASTValidator.java
@@ -157,6 +157,7 @@ public class MicroProfileFaultToleranceASTValidator extends JavaASTValidator {
 				PsiType methodReturnType = node.getReturnType();
 				return methodReturnType.getCanonicalText();
 			},
+				null,
 			e -> LOGGER.log(Level.WARNING, "An error occurred", e)
 		);
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -87,7 +87,11 @@ public class ImplementHealthCheckQuickFix implements IJavaCodeActionParticipant 
 					context.getSource().getCompilationUnit());
 			try {
 				toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-			} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+			} catch (ProcessCanceledException e) {
+				//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+				//TODO delete block when minimum required version is 2024.2
+				throw e;
+			} catch (IndexNotReadyException | CancellationException e) {
 				throw e;
 			} catch (Exception e) {
 				LOGGER.log(Level.WARNING, "Unable to create workspace edit to make the class implement @HealthCheck", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -83,16 +82,7 @@ public class ImplementHealthCheckQuickFix implements IJavaCodeActionParticipant 
 					context.getASTRoot(), MicroProfileHealthConstants.HEALTH_CHECK_INTERFACE, 0,
 					context.getSource().getCompilationUnit());
 
-			Boolean success = ExceptionUtil.executeWithExceptionHandling(
-					() -> {
-						toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-						return true;
-					},
-					e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit to make the class implement @HealthCheck", e)
-			);
-			if (success == null || !success) {
-				System.out.println("An error occurred during the code action resolution.");
-			}
+			ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit to make the class implement @HealthCheck");
 		}
 		return context.getUnresolved();
 	}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/health/java/ImplementHealthCheckQuickFix.java
@@ -13,11 +13,8 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.java;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiVariable;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -28,6 +25,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCode
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ImplementInterfaceProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.health.MicroProfileHealthConstants;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
@@ -36,7 +34,6 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,16 +82,16 @@ public class ImplementHealthCheckQuickFix implements IJavaCodeActionParticipant 
 			ChangeCorrectionProposal proposal = new ImplementInterfaceProposal(context.getCompilationUnit(), parentType,
 					context.getASTRoot(), MicroProfileHealthConstants.HEALTH_CHECK_INTERFACE, 0,
 					context.getSource().getCompilationUnit());
-			try {
-				toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-			} catch (ProcessCanceledException e) {
-				//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-				//TODO delete block when minimum required version is 2024.2
-				throw e;
-			} catch (IndexNotReadyException | CancellationException e) {
-				throw e;
-			} catch (Exception e) {
-				LOGGER.log(Level.WARNING, "Unable to create workspace edit to make the class implement @HealthCheck", e);
+
+			Boolean success = ExceptionUtil.executeWithExceptionHandling(
+					() -> {
+						toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
+						return true;
+					},
+					e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit to make the class implement @HealthCheck", e)
+			);
+			if (success == null || !success) {
+				System.out.println("An error occurred during the code action resolution.");
 			}
 		}
 		return context.getUnresolved();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -103,7 +103,11 @@ public class ApplicationScopedAnnotationMissingQuickFix implements IJavaCodeActi
 				REMOVE_ANNOTATION_NAMES);
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 			LOGGER.log(Level.WARNING, "Failed to create workspace edit to replace bean scope annotation", e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -13,8 +13,6 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.metrics.java;
 
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiModifierListOwner;
@@ -28,6 +26,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposa
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ReplaceAnnotationProposal;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
@@ -36,7 +35,6 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -101,16 +99,16 @@ public class ApplicationScopedAnnotationMissingQuickFix implements IJavaCodeActi
 		ChangeCorrectionProposal proposal = new ReplaceAnnotationProposal(name, context.getCompilationUnit(),
 				context.getASTRoot(), parentType, 0, addAnnotation, context.getSource().getCompilationUnit(),
 				REMOVE_ANNOTATION_NAMES);
-		try {
-			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (ProcessCanceledException e) {
-			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-			//TODO delete block when minimum required version is 2024.2
-			throw e;
-		} catch (IndexNotReadyException | CancellationException e) {
-			throw e;
-		} catch (Exception e) {
-			LOGGER.log(Level.WARNING, "Failed to create workspace edit to replace bean scope annotation", e);
+
+		Boolean success = ExceptionUtil.executeWithExceptionHandling(
+				() -> {
+					toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
+					return true;
+				},
+				e -> LOGGER.log(Level.WARNING, "Failed to create workspace edit to replace bean scope annotation", e)
+		);
+		if (success == null || !success) {
+			System.out.println("An error occurred during the code action resolution.");
 		}
 
 		return toResolve;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -35,7 +35,6 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -100,16 +99,7 @@ public class ApplicationScopedAnnotationMissingQuickFix implements IJavaCodeActi
 				context.getASTRoot(), parentType, 0, addAnnotation, context.getSource().getCompilationUnit(),
 				REMOVE_ANNOTATION_NAMES);
 
-		Boolean success = ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-					return true;
-				},
-				e -> LOGGER.log(Level.WARNING, "Failed to create workspace edit to replace bean scope annotation", e)
-		);
-		if (success == null || !success) {
-			System.out.println("An error occurred during the code action resolution.");
-		}
+		ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Failed to create workspace edit to replace bean scope annotation");
 
 		return toResolve;
 	}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 IBM Corporation and others.
+* Copyright (c) 2020, 2024 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
 
 import java.text.MessageFormat;
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -125,17 +124,7 @@ public class MicroProfileGenerateOpenAPIOperation implements IJavaCodeActionPart
 				typeDeclaration, MicroProfileOpenAPIConstants.OPERATION_ANNOTATION, 0,
 				context.getSource().getCompilationUnit());
 
-		Boolean success = ExceptionUtil.executeWithExceptionHandling(
-				() -> {
-					toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-					return true;
-				},
-				e -> LOGGER.log(Level.WARNING, "Unable to create workspace edit for code action", e)
-		);
-		if (success == null || !success) {
-			System.out.println("An error occurred during the code action resolution.");
-		}
-
+		ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code action");
 		return toResolve;
 	}
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -125,7 +125,11 @@ public class MicroProfileGenerateOpenAPIOperation implements IJavaCodeActionPart
 
 		try {
 			toResolve.setEdit(context.convertToWorkspaceEdit(proposal));
-		} catch (IndexNotReadyException | ProcessCanceledException | CancellationException e) {
+		} catch (ProcessCanceledException e) {
+			//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+			//TODO delete block when minimum required version is 2024.2
+			throw e;
+		} catch (IndexNotReadyException | CancellationException e) {
 			throw e;
 		} catch (Exception e) {
 		}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/openapi/java/MicroProfileGenerateOpenAPIOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.IndexNotReadyException;
 
 import java.util.concurrent.CancellationException;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
@@ -23,8 +22,20 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * This class is intended for cases where exception handling is repetitive
+ */
 public class ExceptionUtil {
 
+    /**
+     * Executes a supplied action with structured exception handling, allowing
+     * the caller to specify a fallback function in case of an exception.
+     *
+     * @param action  the main operation to execute, represented by a Supplier
+     * @param fallback a function to handle exceptions and provide a safe return value
+     * @param <T>     the type of result expected from the action
+     * @return        the result of the action or the fallback value in case of an exception
+     */
     public static <T> T executeWithExceptionHandling(Supplier<T> action, Function<Exception, T> fallback) {
         try {
             return action.get();
@@ -40,6 +51,15 @@ public class ExceptionUtil {
         }
     }
 
+    /**
+     * Executes a workspace edit operation, handling any errors by logging them.
+     *
+     * @param context    the context required to convert a correction proposal to a workspace edit
+     * @param proposal   the proposed correction to be applied
+     * @param toResolve  the code action to be resolved with the edit
+     * @param logger     a logger instance for logging exceptions if they occur
+     * @param logMessage a message to log if an exception is encountered
+     */
     public static void executeWithWorkspaceEditHandling(JavaCodeActionResolveContext context, ChangeCorrectionProposal proposal, CodeAction toResolve, Logger logger, String logMessage) {
         executeWithExceptionHandling(
             () -> {

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -46,7 +46,7 @@ public class ExceptionUtil {
                 toResolve.setEdit(we);
                 return true;
             },
-                null,
+            () -> null,  // Fallback value supplier in case of exception
             e -> logger.log(Level.WARNING, logMessage, e)
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 
 public class ExceptionUtil {
 
-    public static <T> T executeWithExceptionHandling(Supplier<T> action, Consumer<Exception> logger) {
+    public static <T> T executeWithExceptionHandling(Supplier<T> action, Supplier<T> fallback, Consumer<Exception> logger) {
         try {
             return action.get();
         } catch (ProcessCanceledException e) {
@@ -33,9 +33,8 @@ public class ExceptionUtil {
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;
         } catch (Exception e) {
-            // Log the exception using the provided logger
             logger.accept(e);
-            return null; // Return null to indicate failure
+            return fallback.get(); // Return the fallback value in case of failure
         }
     }
 
@@ -46,6 +45,7 @@ public class ExceptionUtil {
                 toResolve.setEdit(we);
                 return true;
             },
+                null,
             e -> logger.log(Level.WARNING, logMessage, e)
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package io.openliberty.tools.intellij.util;
+
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.project.IndexNotReadyException;
+
+import java.util.concurrent.CancellationException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ExceptionUtil {
+
+    public static <T> T executeWithExceptionHandling(Supplier<T> action, Consumer<Exception> logger) {
+        try {
+            return action.get();
+        } catch (ProcessCanceledException e) {
+            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multi-catch to keep backward compatibility
+            throw e;
+        } catch (IndexNotReadyException | CancellationException e) {
+            throw e;
+        } catch (Exception e) {
+            // Log the exception using the provided logger
+            logger.accept(e);
+            return null; // Return null to indicate failure
+        }
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -40,11 +40,8 @@ public class ExceptionUtil {
     }
 
     public static void executeWithWorkspaceEditHandling(JavaCodeActionResolveContext context, ChangeCorrectionProposal proposal, CodeAction toResolve, Logger logger, String logMessage) {
-        ExceptionUtil.executeWithExceptionHandling(
+        executeWithExceptionHandling(
             () -> {
-                int a =10;
-                int b = 0;
-                int c = a / b;
                 WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
                 toResolve.setEdit(we);
                 return true;

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -29,6 +29,7 @@ public class ExceptionUtil {
             return action.get();
         } catch (ProcessCanceledException e) {
             //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multi-catch to keep backward compatibility
+            //TODO delete block when minimum required version is 2024.2
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -69,7 +69,7 @@ public class ExceptionUtil {
             },
             e -> {
                 logger.log(Level.WARNING, logMessage, e);
-                return null;
+                return false;
             }
         );
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -15,6 +15,12 @@ import com.intellij.openapi.project.IndexNotReadyException;
 import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ExceptionUtil {
 
@@ -31,5 +37,19 @@ public class ExceptionUtil {
             logger.accept(e);
             return null; // Return null to indicate failure
         }
+    }
+
+    public static void executeWithWorkspaceEditHandling(JavaCodeActionResolveContext context, ChangeCorrectionProposal proposal, CodeAction toResolve, Logger logger, String logMessage) {
+        ExceptionUtil.executeWithExceptionHandling(
+            () -> {
+                int a =10;
+                int b = 0;
+                int c = a / b;
+                WorkspaceEdit we = context.convertToWorkspaceEdit(proposal);
+                toResolve.setEdit(we);
+                return true;
+            },
+            e -> logger.log(Level.WARNING, logMessage, e)
+        );
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/ExceptionUtil.java
@@ -36,7 +36,7 @@ public class ExceptionUtil {
      * @param <T>     the type of result expected from the action
      * @return        the result of the action or the fallback value in case of an exception
      */
-    public static <T> T executeWithExceptionHandling(Supplier<T> action, Function<Exception, T> fallback) {
+    public static <T> T executeWithExceptionHandling(Supplier<T> action, Function<RuntimeException, T> fallback) {
         try {
             return action.get();
         } catch (ProcessCanceledException e) {
@@ -45,7 +45,7 @@ public class ExceptionUtil {
             throw e;
         } catch (IndexNotReadyException | CancellationException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // Invoke the fallback function with the exception to generate a safe return value.
             return fallback.apply(e);
         }


### PR DESCRIPTION
Part of #767 

I have created a new common class called `ExceptionUtil`, which other quick-fix classes use to call the common exception methods via `lambda expression`, in order to avoid code duplication.