### PR TITLE
Wait 5s after UI robot types in a config file

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1104,6 +1104,7 @@ public class UIBotTestUtils {
                 keyboard.enter();
 
                 keyboard.enterText(configNameSnippet);
+                TestUtils.sleepAndIgnoreException(5);
 
                 // Narrow down the config name completion suggestions in the pop-up window that is automatically
                 // opened as text is typed based on the value of configNameSnippet. Avoid hitting ctrl + space as it has the side effect of selecting
@@ -1123,6 +1124,7 @@ public class UIBotTestUtils {
                 keyboard.hotKey(VK_END);
 
                 keyboard.enterText(configValueSnippet);
+                TestUtils.sleepAndIgnoreException(5);
 
                 if (completeWithPopup) {
                     // Select the appropriate value completion suggestion in the pop-up window that is automatically


### PR DESCRIPTION
The diagnostic fails to appear in the editor because the robot clicks on the editor tab *immediately* after typing the value (after the equals. sign). A bug or feature in IntelliJ makes it give up on the unrendered diagnostic when the user turns attention somewhere else.

Here is how I decided on the amount of time to wait. It may take 1s so I doubled it. On Mac it might be slow so I doubled it again and rounded up.

This fix relies on using the LCLS 2.2-SNAPSHOT. I do not include it here because someone else has been testing this and will make a separate pull request. Here is the test result when you do use 2.2-snapshot:
<img width="255" alt="image" src="https://github.com/user-attachments/assets/66881a68-efff-4464-9fe5-d3a53feb5b64">

Fixes #945 