### PR TITLE
#911 support intellij 2024.2 by updating gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,12 @@ task copyDeps(type: Copy) {
 }
 
 runIde {
-    jvmArgs '--add-exports', 'java.base/jdk.internal.vm=ALL-UNNAMED'
+    jvmArgumentProviders.add({
+        [
+                "--add-exports",
+                "java.base/jdk.internal.vm=ALL-UNNAMED",
+        ]
+    } as CommandLineArgumentProvider)
 }
 
 downloadRobotServerPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.17.3'
-    id 'org.jetbrains.kotlin.jvm' version '1.7.22'
+    id 'org.jetbrains.intellij.platform' version '2.1.0'
+    id "org.jetbrains.kotlin.jvm" version '1.9.24'
 }
 
 group 'io.openliberty.tools'

--- a/build.gradle
+++ b/build.gradle
@@ -192,18 +192,15 @@ test {
     }
 }
 
-tasks {
-    // Disabling buildSearchableOptions, which runs as part of the buildPlugin task.
-    // this is to buildSearchableOptions to workaround the "Only one instance of IDEA can be run at a time" problem.
-    // Per documentation: https://plugins.jetbrains.com/docs/intellij/ide-development-instance.html#the-development-instance-sandbox-directory
-    buildSearchableOptions {
-        enabled = false
-    }
-}
-
-patchPluginXml {
-    changeNotes = """
-        <h2> 24.0.9 </h2>
+intellijPlatform {
+    buildSearchableOptions = false
+    pluginConfiguration {
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+            untilBuild = providers.gradleProperty("pluginUntilBuild")
+        }
+        changeNotes = """
+         <h2> 24.0.9 </h2>
         <p>Version 24.0.9 of Liberty Tools for IntelliJ IDEA contains enhancements and fixes. Version 24.0.9 requires IntelliJ IDEA version 2024.1.* ONLY and a minimum of Java 17.</p>
         Notable changes:
         <ul>
@@ -341,5 +338,6 @@ patchPluginXml {
         <li> First preview release
         </ul>
         """
-    version project.version
+        version project.version
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,15 +7,15 @@ plugins {
 group 'io.openliberty.tools'
 version '24.0.9'
 
+def remoteRobotVersion = "0.11.23"
+// To switch to nightly version, append "@nightly" to the version number (i.e. 0.4.1-20240828-013108@nightly)
+def lsp4ijVersion = '0.7.0'
+
 allprojects {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 }
-
-def remoteRobotVersion = "0.11.18"
-// To switch to nightly version, append "@nightly" to the version number (i.e. 0.4.1-20240828-013108@nightly)
-def lsp4ijVersion = '0.7.0'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ group 'io.openliberty.tools'
 version '24.0.9'
 
 allprojects {
-    apply plugin: 'java'
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 plugins {
     id 'java'
     id 'org.jetbrains.intellij.platform' version '2.1.0'
-    id "org.jetbrains.kotlin.jvm" version '2.0.20'
+    id 'org.jetbrains.kotlin.jvm' version '2.0.20'
 }
 
 group 'io.openliberty.tools'
@@ -134,6 +134,7 @@ dependencies {
         builtBy 'copyDeps'
     }
     intellijPlatform {
+        // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
         bundledPlugins providers.gradleProperty("platformBundledPlugins").orElse("").get().split(',').toList()
 
@@ -165,22 +166,6 @@ runIde {
         ]
     } as CommandLineArgumentProvider)
 }
-
-//downloadRobotServerPlugin {
-//    version.set(remoteRobotVersion)
-//}
-
-//runIdeForUiTests {
-//    systemProperty "robot-server.port", "8082"
-//    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
-//    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
-//    systemProperty "jb.consents.confirmation.enabled", "false"
-//    systemProperty "idea.trust.all.projects", "true"
-//    systemProperty "ide.show.tips.on.startup.default.value", "false"
-//    systemProperty "ide.mac.file.chooser.native", "false"
-//    systemProperty "jbScreenMenuBar.enabled", "false"
-//    systemProperty "apple.laf.useScreenMenuBar", "false"
-//}
 
 test {
     useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 plugins {
     id 'java'
     id 'org.jetbrains.intellij.platform' version '2.1.0'
@@ -165,21 +166,21 @@ runIde {
     } as CommandLineArgumentProvider)
 }
 
-downloadRobotServerPlugin {
-    version.set(remoteRobotVersion)
-}
+//downloadRobotServerPlugin {
+//    version.set(remoteRobotVersion)
+//}
 
-runIdeForUiTests {
-    systemProperty "robot-server.port", "8082"
-    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
-    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
-    systemProperty "jb.consents.confirmation.enabled", "false"
-    systemProperty "idea.trust.all.projects", "true"
-    systemProperty "ide.show.tips.on.startup.default.value", "false"
-    systemProperty "ide.mac.file.chooser.native", "false"
-    systemProperty "jbScreenMenuBar.enabled", "false"
-    systemProperty "apple.laf.useScreenMenuBar", "false"
-}
+//runIdeForUiTests {
+//    systemProperty "robot-server.port", "8082"
+//    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
+//    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
+//    systemProperty "jb.consents.confirmation.enabled", "false"
+//    systemProperty "idea.trust.all.projects", "true"
+//    systemProperty "ide.show.tips.on.startup.default.value", "false"
+//    systemProperty "ide.mac.file.chooser.native", "false"
+//    systemProperty "jbScreenMenuBar.enabled", "false"
+//    systemProperty "apple.laf.useScreenMenuBar", "false"
+//}
 
 test {
     useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ plugins {
 group 'io.openliberty.tools'
 version '24.0.9'
 
-sourceCompatibility = 17
-targetCompatibility = 17
+allprojects {
+    apply plugin: 'java'
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+    tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
+}
 
 def remoteRobotVersion = "0.11.18"
 // To switch to nightly version, append "@nightly" to the version number (i.e. 0.4.1-20240828-013108@nightly)

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,9 @@ repositories {
     maven {
         url = "https://cache-redirector.jetbrains.com/download-pgp-verifier"
     }
-
+    intellijPlatform {
+        defaultRepositories()
+    }
     mavenLocal() // TODO remove once Liberty LS is publicly available
 }
 
@@ -64,7 +66,7 @@ configurations {
     // Ensures that the JVM target is set to 17 for all Kotlin compilation tasks, including both main and test sources.
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
-            jvmTarget = "17"
+            jvmTarget = javaVersion
         }
     }
 }
@@ -101,7 +103,7 @@ dependencies {
     testImplementation 'com.intellij.remoterobot:remote-robot:' + remoteRobotVersion
     testImplementation 'com.intellij.remoterobot:remote-fixtures:' + remoteRobotVersion
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:241.15989.150') {
+    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:242.23726.103') {
         transitive = false
     }
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
@@ -133,6 +135,21 @@ dependencies {
     implementation files(new File(buildDir, 'server')) {
         builtBy 'copyDeps'
     }
+    intellijPlatform {
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        bundledPlugins providers.gradleProperty("platformBundledPlugins").orElse("").get().split(',').toList()
+
+        def lsp4ij = providers.gradleProperty('useLocal') && providers.gradleProperty('useLocal') == 'true' ?
+                file("../lsp4ij/build/distributions/LSP4IJ/") :
+                'com.redhat.devtools.lsp4ij:' + lsp4ijVersion
+        plugins lsp4ij
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
+
+        testFramework TestFrameworkType.Platform.INSTANCE
+        testFramework TestFrameworkType.Plugin.Java.INSTANCE
+    }
 }
 
 task copyDeps(type: Copy) {
@@ -143,17 +160,6 @@ task copyDeps(type: Copy) {
 
 runIde {
     jvmArgs '--add-exports', 'java.base/jdk.internal.vm=ALL-UNNAMED'
-}
-
-intellij {
-    // For a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
-    version = '2024.1.6'
-
-    def lsp4ij = project.hasProperty('useLocal') && project.property('useLocal') == 'true' ?
-            file("../lsp4ij/build/distributions/LSP4IJ/") :
-            'com.redhat.devtools.lsp4ij:' + lsp4ijVersion
-    plugins = ['java', 'maven', 'gradle-java', 'properties', 'terminal', 'org.jetbrains.idea.maven', 'com.intellij.gradle', lsp4ij]
-    updateSinceUntilBuild = false
 }
 
 downloadRobotServerPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ dependencies {
 
         testFramework TestFrameworkType.Platform.INSTANCE
         testFramework TestFrameworkType.Plugin.Java.INSTANCE
-        testFramework TestFrameworkType.Plugin.Ma
+        testFramework TestFrameworkType.Plugin.Maven.INSTANCE
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,6 @@ dependencies {
         testFramework TestFrameworkType.Plugin.Maven.INSTANCE
     }
 }
-
 task copyDeps(type: Copy) {
     from configurations.lsp
     into new File(buildDir, 'server/server')
@@ -174,6 +173,21 @@ test {
         showStandardStreams = true
         exceptionFormat = 'full'
     }
+}
+downloadRobotServerPlugin {
+    version.set(remoteRobotVersion)
+}
+
+runIdeForUiTests {
+    systemProperty "robot-server.port", "8082"
+    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
+    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
+    systemProperty "jb.consents.confirmation.enabled", "false"
+    systemProperty "idea.trust.all.projects", "true"
+    systemProperty "ide.show.tips.on.startup.default.value", "false"
+    systemProperty "ide.mac.file.chooser.native", "false"
+    systemProperty "jbScreenMenuBar.enabled", "false"
+    systemProperty "apple.laf.useScreenMenuBar", "false"
 }
 
 intellijPlatform {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.jetbrains.intellij.platform' version '2.1.0'
-    id "org.jetbrains.kotlin.jvm" version '1.9.24'
+    id "org.jetbrains.kotlin.jvm" version '2.0.20'
 }
 
 group 'io.openliberty.tools'
@@ -103,9 +103,7 @@ dependencies {
     testImplementation 'com.intellij.remoterobot:remote-robot:' + remoteRobotVersion
     testImplementation 'com.intellij.remoterobot:remote-fixtures:' + remoteRobotVersion
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testImplementation('com.jetbrains.intellij.maven:maven-test-framework:242.23726.103') {
-        transitive = false
-    }
+
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
 
@@ -149,6 +147,7 @@ dependencies {
 
         testFramework TestFrameworkType.Platform.INSTANCE
         testFramework TestFrameworkType.Plugin.Java.INSTANCE
+        testFramework TestFrameworkType.Plugin.Ma
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,3 @@ platformVersion=2024.1.7
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties
-kotlin.stdlib.default.dependency=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaTargetVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.1
+platformVersion=2024.1.7
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,10 @@ pluginUntilBuild=242.*
 javaVersion=17
 javaTargetVersion=17
 
-
-# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1
 
-# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 # Example: platformBundledPlugins = com.intellij.java
-# We need com.intellij.java to compile JPS, and markdown.
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties
 kotlin.stdlib.default.dependency=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,17 @@
+useLocal=false
+pluginSinceBuild=241.14494.240
+pluginUntilBuild=242.*
+
 javaVersion=17
 javaTargetVersion=17
 
 
+# IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
+# Target IntelliJ Community by default
+platformType=IC
+platformVersion=2024.1
+
+# Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
+# Example: platformBundledPlugins = com.intellij.java
+# We need com.intellij.java to compile JPS, and markdown.
+platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ platformVersion=2024.1
 # Example: platformBundledPlugins = com.intellij.java
 # We need com.intellij.java to compile JPS, and markdown.
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties
+kotlin.stdlib.default.dependency=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 useLocal=false
-pluginSinceBuild=241.14494.240
+pluginSinceBuild=241
 pluginUntilBuild=242.*
 
 javaVersion=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+javaVersion=17
+javaTargetVersion=17
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ javaTargetVersion=17
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.4
+platformVersion=2024.1
 
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 # Example: platformBundledPlugins = com.intellij.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ javaTargetVersion=17
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.1
+platformVersion=2024.2.4
 
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 # Example: platformBundledPlugins = com.intellij.java

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,8 +20,6 @@
     <depends>com.intellij.gradle</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
 
-    <idea-version since-build="241" until-build="241.*"/>
-
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty" icon="/icons/OL_logo_13.svg"
                     factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/liberty-tools-intellij/issues/911
Updated intellij platform and kotlin jvm version
Updated source compatability and target compatability in build.gradle and given java version inside gradle.properties file
Changed intellij to intellijPlatform and added it inside dependencies tag
Updated runIde task in build.gradle
Added intellijPlatform tag to add buildSearchableOptions, since build, until build and add the changeNotes
updated platformVersion in gradle.properties
