### PR TITLE
Add environment variable to set the timeout when starting dev mode Liberty for debugging

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -165,7 +165,8 @@ public class DebugModeHandler {
      */
     private String waitForSocketActivation(ProgressIndicator monitor, LibertyModule libertyModule, String host, int debugPort) throws Exception {
         byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
-        int retryLimit = 60; // wait up to 3 minutes for dev mode to start (polling rate 20 per minute, 3s)
+        int retryLimit = 360; // seconds to wait for Liberty dev mode to start. It can take 4-5 minutes during testing.
+        int retryInc = 3; // time to wait after each try
 
         // Retrieve the location of the server.env in the liberty installation at the default location (wpl/usr/servers/<serverName>).
         Path serverEnvPath = getServerEnvPath(libertyModule);
@@ -173,7 +174,7 @@ public class DebugModeHandler {
         boolean cleanStart = serverEnvPath == null;
         Path serverEnvBakPath = null;
 
-        for (int retryCount = 0; retryCount < retryLimit; retryCount++) {
+        for (int retryCount = 0; retryCount < retryLimit; retryCount+=retryInc) {
             // check if cancelled
             if (monitor.isCanceled()) {
                 return null;
@@ -210,7 +211,7 @@ public class DebugModeHandler {
                     LOGGER.trace(String.format("ConnectException waiting for runtime to start on port %d", debugPort));
                 }
             }
-            TimeUnit.SECONDS.sleep(3);
+            TimeUnit.SECONDS.sleep(retryInc);
         }
         throw new Exception(LocalizedResourceUtil.getMessage("cannot.attach.debugger.host.port", host, String.format("%d",debugPort)));
     }

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -165,7 +165,7 @@ public class DebugModeHandler {
      */
     private String waitForSocketActivation(ProgressIndicator monitor, LibertyModule libertyModule, String host, int debugPort) throws Exception {
         byte[] handshakeString = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
-        int retryLimit = 360; // seconds to wait for Liberty dev mode to start. It can take 4-5 minutes during testing.
+        int retryLimit = getDebuggerTimeoutInSeconds();
         int retryInc = 3; // time to wait after each try
 
         // Retrieve the location of the server.env in the liberty installation at the default location (wpl/usr/servers/<serverName>).
@@ -214,6 +214,25 @@ public class DebugModeHandler {
             TimeUnit.SECONDS.sleep(retryInc);
         }
         throw new Exception(LocalizedResourceUtil.getMessage("cannot.attach.debugger.host.port", host, String.format("%d",debugPort)));
+    }
+
+    /**
+     * Check an environment variable to see if the user specifies a timeout to use for the debugger.
+     * This is not an exposed environment variable, it is only used for testing.
+     */
+    private int getDebuggerTimeoutInSeconds() {
+        // Number of seconds to wait for Liberty dev mode to start. Note that Gradle can take a while
+        // to get going so we default to 3 minutes. During testing it can take even longer, 4-5 minutes.
+        int defaultTimeout = 180;
+        String userSpecifiedTimeout = System.getenv("LIBERTY_TOOLS_INTELLIJ_DEBUGGER_TIMEOUT");
+        if (userSpecifiedTimeout != null) {
+            try {
+                return Integer.parseInt(userSpecifiedTimeout);
+            } catch (NumberFormatException n) {
+                // return the default below
+            }
+        }
+        return defaultTimeout;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation.
+ * Copyright (c) 2022, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -155,6 +155,8 @@ main() {
 
     # Start the IDE.
     echo -e "\n$(${currentTime[@]}): INFO: Starting the IntelliJ IDE..."
+    # Have liberty tools debugger wait 480s for Maven or Gradle dev mode to start
+    export LIBERTY_TOOLS_INTELLIJ_DEBUGGER_TIMEOUT=480
     ./gradlew runIdeForUiTests -PuseLocal=$USE_LOCAL_PLUGIN --info  > remoteServer.log  2>&1 &
 
     # Wait for the IDE to come up.


### PR DESCRIPTION
Fixes #1060

The default value is 3 minutes. This was chosen because Gradle can be slow to start. On github action machines it can take 4-5 minutes to start Liberty dev mode. So we added an environment variable to allow us to specify a longer timeout when testing. The timeout when testing is 8 minutes.