### PR TITLE
Create java.lang and java.math imposter classes for use in testing qualified names.

### DIFF
--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Boolean {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
@@ -1,5 +1,11 @@
 package ng;
 
-public class Boolean {
+import java.io.Serializable;
 
+public class Boolean implements Serializable, Comparable<Boolean> {
+
+    @Override
+    public int compareTo(Boolean o) {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Boolean.java
@@ -1,7 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
 import java.io.Serializable;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Boolean in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Boolean implements Serializable, Comparable<Boolean> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Byte {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Byte in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Byte extends Number implements Comparable<Byte> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Byte.java
@@ -1,5 +1,29 @@
 package ng;
 
-public class Byte {
+public class Byte extends Number implements Comparable<Byte> {
 
+    @Override
+    public int compareTo(Byte o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/CharSequence.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/CharSequence.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.CharSequence in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public interface CharSequence {
 
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/CharSequence.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/CharSequence.java
@@ -1,0 +1,5 @@
+package ng;
+
+public interface CharSequence {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Character {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
@@ -1,5 +1,11 @@
 package ng;
 
-public class Character {
+import java.io.Serializable;
 
+public class Character implements Serializable, Comparable<Character> {
+
+    @Override
+    public int compareTo(Character o) {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Character.java
@@ -1,7 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
 import java.io.Serializable;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Character in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Character implements Serializable, Comparable<Character> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Double in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Double extends Number implements Comparable<Double> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Double {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Double.java
@@ -1,5 +1,29 @@
 package ng;
 
-public class Double {
+public class Double extends Number implements Comparable<Double> {
 
+    @Override
+    public int compareTo(Double o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Float {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
@@ -1,5 +1,29 @@
 package ng;
 
-public class Float {
+public class Float extends Number implements Comparable<Float> {
 
+    @Override
+    public int compareTo(Float o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Float.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Float in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Float extends Number implements Comparable<Float> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
@@ -1,4 +1,29 @@
 package ng;
 
-public class Integer {
+public class Integer extends Number implements Comparable<Integer> {
+
+    @Override
+    public int compareTo(Integer o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Integer in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Integer extends Number implements Comparable<Integer> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Integer.java
@@ -1,0 +1,4 @@
+package ng;
+
+public class Integer {
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Long {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
@@ -1,5 +1,29 @@
 package ng;
 
-public class Long {
+public class Long extends Number implements Comparable<Long> {
 
+    @Override
+    public int compareTo(Long o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Long.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Long in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Long extends Number implements Comparable<Long> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
+/**
+ * This class can be used in testing to impersonate java.lang.Short in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class Short extends Number implements Comparable<Short> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class Short {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/Short.java
@@ -1,5 +1,29 @@
 package ng;
 
-public class Short {
+public class Short extends Number implements Comparable<Short> {
 
+    @Override
+    public int compareTo(Short o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
@@ -1,0 +1,5 @@
+package ng;
+
+public class String {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
@@ -1,5 +1,11 @@
 package ng;
 
-public class String {
+import java.io.Serializable;
 
+public class String implements Serializable, Comparable<String>, CharSequence {
+
+    @Override
+    public int compareTo(String o) {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/ng/String.java
@@ -1,7 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package ng;
 
 import java.io.Serializable;
 
+/**
+ * This class can be used in testing to impersonate java.lang.String in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class String implements Serializable, Comparable<String>, CharSequence {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
@@ -1,5 +1,29 @@
 package th;
 
-public class BigDecimal {
+public class BigDecimal extends Number implements Comparable<BigDecimal> {
 
+    @Override
+    public int compareTo(BigDecimal o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package th;
 
+/**
+ * This class can be used in testing to impersonate java.math.BigDecimal in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class BigDecimal extends Number implements Comparable<BigDecimal> {
 
     @Override

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigDecimal.java
@@ -1,0 +1,5 @@
+package th;
+
+public class BigDecimal {
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
@@ -1,5 +1,29 @@
 package th;
 
-public class BigInteger {
-    
+public class BigInteger extends Number implements Comparable<BigInteger> {
+
+    @Override
+    public int compareTo(BigInteger o) {
+        return 0;
+    }
+
+    @Override
+    public int intValue() {
+        return 0;
+    }
+
+    @Override
+    public long longValue() {
+        return 0;
+    }
+
+    @Override
+    public float floatValue() {
+        return 0;
+    }
+
+    @Override
+    public double doubleValue() {
+        return 0;
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
@@ -1,0 +1,5 @@
+package th;
+
+public class BigInteger {
+    
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/th/BigInteger.java
@@ -1,5 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package th;
 
+/**
+ * This class can be used in testing to impersonate java.math.BigInteger in order to
+ * verify that qualified class names are processed correctly. It is not intended to
+ * be complete or functional.
+ */
 public class BigInteger extends Number implements Comparable<BigInteger> {
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1080

Package mappings:
```
java.lang -> ng
java.math -> th
```

I explicitly chose these package names because they are suffixes of the Java built-in packages. Code which incorrectly matches qualified names using the `String.endsWith()` method can potentially be identified by using these imposter classes in the test application.