### PR TITLE
Detect a SocketTimeoutException and exit the JUnit tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,12 +117,7 @@ jobs:
       - name: 'Run UI integration tests'
         id: run_tests
         working-directory: ./liberty-tools-intellij
-        run: |
-          bash ./src/test/resources/ci/scripts/run.sh
-          rc="$?"
-          if [[ "$rc" == "23" ]]; then
-            bash ./src/test/resources/ci/scripts/run.sh
-          fi
+        run: bash ./src/test/resources/ci/scripts/run.sh
       - name: 'Archive Test logs and reports'
         if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v4.3.4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,7 +117,12 @@ jobs:
       - name: 'Run UI integration tests'
         id: run_tests
         working-directory: ./liberty-tools-intellij
-        run: bash ./src/test/resources/ci/scripts/run.sh
+        run: |
+          bash ./src/test/resources/ci/scripts/run.sh
+          rc="$?"
+          if [[ "$rc" == "23" ]]; then
+            bash ./src/test/resources/ci/scripts/run.sh
+          fi
       - name: 'Archive Test logs and reports'
         if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v4.3.4

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -16,9 +16,13 @@ import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
 import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Scanner;
 
 import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
 
@@ -53,6 +57,7 @@ public abstract class SingleModJakartaLSTestCommon {
     @AfterEach
     public void afterEach(TestInfo info) {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -16,13 +16,9 @@ import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
 import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Scanner;
 
 import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
 

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -53,6 +53,7 @@ public abstract class SingleModLibertyLSTestCommon {
     @AfterEach
     public void afterEach(TestInfo info) {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -54,6 +54,7 @@ public abstract class SingleModMPLSTestCommon {
     @AfterEach
     public void afterEach(TestInfo info) {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -279,6 +279,7 @@ public abstract class SingleModMPProjectTestCommon {
             cleanAndResetTerminal();
         }
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -77,6 +77,7 @@ public abstract class SingleModNLTRestProjectTestCommon {
     @AfterEach
     public void afterEach(TestInfo info) {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -562,4 +562,41 @@ public class TestUtils {
                 });
     }
 
+    /**
+     * Test to see if there has been a fatal error and JUnit should be stopped.
+     * This searches the output of this JUnit run for SocketTimeoutException which
+     * has been identified as a fatal error and occurs during the Mac tests.
+     * It is set up as a static reader so that we do not reread the whole file
+     * after each test.
+     */
+    final static String outputFile = System.getenv("JUNIT_OUTPUT_TXT");
+    final static BufferedReader reader;
+
+    static {
+        try {
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void detectFatalError() {
+        try {
+            // Flush our output and then wait briefly for the process running 'tee' to flush output to the
+            // file that the buffered reader is reading.
+            System.out.flush();
+            Thread.sleep(10);
+            // Continue reading the existing reader
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains("SocketTimeoutException")) {
+                    System.exit(23);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package io.openliberty.tools.intellij.it;
 
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -582,14 +582,16 @@ public class TestUtils {
     final static BufferedReader reader;
 
     static {
+        BufferedReader reader1;
         try {
-            reader = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
+            reader1 = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
         } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
+            reader1 = null;
         }
+        reader = reader1;
     }
 
-    public static void detectFatalError() {
+    public static synchronized void detectFatalError() {
         try {
             // Flush our output and then wait briefly for the process running 'tee' to flush output to the
             // file that the buffered reader is reading.
@@ -599,12 +601,10 @@ public class TestUtils {
             String line = null;
             while ((line = reader.readLine()) != null) {
                 if (line.contains("SocketTimeoutException")) {
-                    System.exit(23);
+                    System.exit(1);
                 }
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException | NullPointerException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -575,24 +575,11 @@ public class TestUtils {
      * Test to see if there has been a fatal error and JUnit should be stopped.
      * This searches the output of this JUnit run for SocketTimeoutException which
      * has been identified as a fatal error and occurs during the Mac tests.
-     * It is set up as a static reader so that we do not reread the whole file
-     * after each test.
      */
-    final static String outputFile = System.getenv("JUNIT_OUTPUT_TXT");
-    final static BufferedReader reader;
-
-    static {
-        BufferedReader reader1;
-        try {
-            reader1 = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
-        } catch (FileNotFoundException e) {
-            reader1 = null;
-        }
-        reader = reader1;
-    }
-
     public static synchronized void detectFatalError() {
+        final String outputFile = System.getenv("JUNIT_OUTPUT_TXT");
         try {
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
             // Flush our output and then wait briefly for the process running 'tee' to flush output to the
             // file that the buffered reader is reading.
             System.out.flush();
@@ -604,7 +591,7 @@ public class TestUtils {
                     System.exit(1);
                 }
             }
-        } catch (IOException | InterruptedException | NullPointerException e) {
+        } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -189,7 +189,7 @@ main() {
         testRC=$?
         set +o pipefail # reset this option
 
-        ROBOT_PID=$(ps -ef | grep -i "Gradle Test Executor" | grep -v grep | awk '{print $2}')
+        ROBOT_PID=$(ps -ef | grep -i "org.gradle.wrapper.GradleWrapperMain test" | grep -v grep | awk '{print $2}')
         echo -e "\n$(${currentTime[@]}): INFO: the Intellij robot pid:" + $ROBOT_PID
         # Look for the unrecoverable error
         grep -i "SocketTimeoutException" "$JUNIT_OUTPUT_TXT"

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -182,10 +182,10 @@ main() {
         # Run the tests
         echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
         set -o pipefail # using tee requires we use this setting to gather the rc of gradlew
-        ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$workingDir"/build/junit.out
+        ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$currentLoc"/build/junit.out
         testRC=$?
         set +o pipefail # reset this option
-        grep -i "SocketTimeoutException" "$workingDir"/build/junit.out
+        grep -i "SocketTimeoutException" "$currentLoc"/build/junit.out
         rc=$?
         if [ "$rc" -ne 0 ]; then
             # rc=1 means the exception string was not found

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -195,7 +195,7 @@ main() {
 
     # If there were any errors, gather some debug data before exiting.
     if [ "$testRC" -ne 0 ]; then
-        echo -e "\n$(${currentTime[@]}): ERROR: Failure while running tests. rc: ${rc}."
+        echo -e "\n$(${currentTime[@]}): ERROR: Failure while running tests. rc: ${$testRC}."
         gatherDebugData "$currentLoc"
         exit -1
     fi

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -177,8 +177,7 @@ main() {
     fi
 
     # Retry the tests if they fail with a SocketTimeoutException up to three times
-    retry=3;
-    while [ $retry -ge 1 ]; do
+    for retry in {1..3}; do
         startIDE();
         # Run the tests
         echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
@@ -189,11 +188,11 @@ main() {
         grep -i "SocketTimeoutException" "$workingDir"/build/junit.out
         rc=$?
         if [ "$rc" -ne 0 ]; then
-            # rc=1 means the string was not found
+            # rc=1 means the exception string was not found
             break
         fi
-        retry=`$retry + 1`
     done
+
     # If there were any errors, gather some debug data before exiting.
     if [ "$testRC" -ne 0 ]; then
         echo -e "\n$(${currentTime[@]}): ERROR: Failure while running tests. rc: ${rc}."

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -189,8 +189,6 @@ main() {
         testRC=$?
         set +o pipefail # reset this option
 
-        ROBOT_PID=$(ps -ef | grep -i "org.gradle.wrapper.GradleWrapperMain test" | grep -v grep | awk '{print $2}')
-        echo -e "\n$(${currentTime[@]}): INFO: the Intellij robot pid:" + $ROBOT_PID
         # Look for the unrecoverable error
         grep -i "SocketTimeoutException" "$JUNIT_OUTPUT_TXT"
         rc=$?
@@ -199,8 +197,9 @@ main() {
             # In this case it is a regular error so we break out of the loop and report the error.
             break
         fi
-        kill -9 $IDE_PID $ROBOT_PID
-        sleep 5 # Wait a few moments for them to shutdown
+        # Shutdown the IDE so that we can retry with a new one
+        kill -9 $IDE_PID
+        sleep 10 # Wait a few moments for IDE to shutdown
     done
 
     # If there were any errors, gather some debug data before exiting.

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -189,7 +189,7 @@ main() {
         testRC=$?
         set +o pipefail # reset this option
 
-        ROBOT_PID=$(ps -ef | grep -i idea.main | grep -v grep | grep -v $IDE_PID | awk '{print $2}')
+        ROBOT_PID=$(ps -ef | grep -i "Gradle Test Executor" | grep -v grep | awk '{print $2}')
         echo -e "\n$(${currentTime[@]}): INFO: the Intellij robot pid:" + $ROBOT_PID
         # Look for the unrecoverable error
         grep -i "SocketTimeoutException" "$JUNIT_OUTPUT_TXT"

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -205,7 +205,7 @@ main() {
 
     # If there were any errors, gather some debug data before exiting.
     if [ "$testRC" -ne 0 ]; then
-        echo -e "\n$(${currentTime[@]}): ERROR: Failure while running tests. rc: ${$testRC}."
+        echo -e "\n$(${currentTime[@]}): ERROR: Failure while running tests. rc: ${testRC}."
         gatherDebugData "$currentLoc"
         exit -1
     fi

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -178,7 +178,7 @@ main() {
 
     # Retry the tests if they fail with a SocketTimeoutException up to three times
     for retry in {1..3}; do
-        startIDE();
+        startIDE
         # Run the tests
         echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
         set -o pipefail # using tee requires we use this setting to gather the rc of gradlew

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -82,6 +82,11 @@ gatherDebugData() {
         cp "$workingDir"/remoteServer.log "$workingDir"/build/reports/.
     fi
 
+    echo -e "DEBUG: Gathering IDE JUnit logs...\n"
+    if [ -f "$workingDir/junit.out" ]; then
+        cp "$workingDir"/junit.out "$workingDir"/build/reports/.
+    fi
+
     echo -e "DEBUG: Gathering videos...\n"
     if [ -d "$workingDir/video" ]; then
         mv "$workingDir"/video "$workingDir"/build/reports/.
@@ -116,26 +121,26 @@ gatherDebugData() {
 # Start the IDE and wait for it to initialize. If the IDE takes too long this routine
 # will exit the script with error code 12.
 startIDE() {
-      # Start the IDE.
-      echo -e "\n$(${currentTime[@]}): INFO: Starting the IntelliJ IDE..."
-      # Have liberty tools debugger wait 480s for Maven or Gradle dev mode to start
-      export LIBERTY_TOOLS_INTELLIJ_DEBUGGER_TIMEOUT=480
-      ./gradlew runIdeForUiTests -PuseLocal=$USE_LOCAL_PLUGIN --info  > remoteServer.log  2>&1 &
+    # Start the IDE.
+    echo -e "\n$(${currentTime[@]}): INFO: Starting the IntelliJ IDE..."
+    # Have liberty tools debugger wait 480s for Maven or Gradle dev mode to start
+    export LIBERTY_TOOLS_INTELLIJ_DEBUGGER_TIMEOUT=480
+    ./gradlew runIdeForUiTests -PuseLocal=$USE_LOCAL_PLUGIN --info  > remoteServer.log  2>&1 &
 
-      # Wait for the IDE to come up.
-      echo -e "\n$(${currentTime[@]}): INFO: Waiting for the Intellij IDE to start..."
-      callLivenessEndpoint=(curl -s http://localhost:8082)
-      count=1
-      while ! ${callLivenessEndpoint[@]} | grep -qF 'Welcome to IntelliJ IDEA'; do
-          if [ $count -eq 24 ]; then
-              echo -e "\n$(${currentTime[@]}): ERROR: Timed out waiting for the Intellij IDE Welcome Page to start. Output:"
-              exit 12
-          fi
-          count=`expr $count + 1`
-          echo -e "\n$(${currentTime[@]}): INFO: Continue waiting for the Intellij IDE to start..." && sleep 5
-      done
-      IDE_PID=$(ps -ef | grep -i idea.main | grep -v grep | awk '{print $2}')
-      echo -e "\n$(${currentTime[@]}): INFO: the Intellij IDE pid:" + $IDE_PID
+    # Wait for the IDE to come up.
+    echo -e "\n$(${currentTime[@]}): INFO: Waiting for the Intellij IDE to start..."
+    callLivenessEndpoint=(curl -s http://localhost:8082)
+    count=1
+    while ! ${callLivenessEndpoint[@]} | grep -qF 'Welcome to IntelliJ IDEA'; do
+        if [ $count -eq 24 ]; then
+            echo -e "\n$(${currentTime[@]}): ERROR: Timed out waiting for the Intellij IDE Welcome Page to start. Output:"
+            exit 12
+        fi
+        count=`expr $count + 1`
+        echo -e "\n$(${currentTime[@]}): INFO: Continue waiting for the Intellij IDE to start..." && sleep 5
+    done
+    IDE_PID=$(ps -ef | grep -i idea.main | grep -v grep | awk '{print $2}')
+    echo -e "\n$(${currentTime[@]}): INFO: the Intellij IDE pid:" + $IDE_PID
 }
 
 # Runs UI tests and collects debug data.
@@ -179,28 +184,13 @@ main() {
     fi
 
     export JUNIT_OUTPUT_TXT="$currentLoc"/build/junit.out
-    # Retry the tests if they fail with a SocketTimeoutException
-    for i in {1..5}; do
-        startIDE
-        # Run the tests
-        echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
-        set -o pipefail # using tee requires we use this setting to gather the rc of gradlew
-        ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$JUNIT_OUTPUT_TXT"
-        testRC=$?
-        set +o pipefail # reset this option
-
-        # Look for the unrecoverable error
-        grep -i "SocketTimeoutException" "$JUNIT_OUTPUT_TXT"
-        rc=$?
-        if [ "$rc" -ne 0 ]; then
-            # rc=1 means the exception string was not found.
-            # In this case it is a regular error so we break out of the loop and report the error.
-            break
-        fi
-        # Shutdown the IDE so that we can retry with a new one
-        kill -9 $IDE_PID
-        sleep 10 # Wait a few moments for IDE to shutdown
-    done
+    startIDE
+    # Run the tests
+    echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
+    set -o pipefail # using tee requires we use this setting to gather the rc of gradlew
+    ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$JUNIT_OUTPUT_TXT"
+    testRC=$?
+    set +o pipefail # reset this option
 
     # If there were any errors, gather some debug data before exiting.
     if [ "$testRC" -ne 0 ]; then

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -83,8 +83,8 @@ gatherDebugData() {
     fi
 
     echo -e "DEBUG: Gathering IDE JUnit logs...\n"
-    if [ -f "$workingDir/junit.out" ]; then
-        cp "$workingDir"/junit.out "$workingDir"/build/reports/.
+    if [ -f "$workingDir/build/junit.out" ]; then
+        cp "$workingDir"/build/junit.out "$workingDir"/build/reports/.
     fi
 
     echo -e "DEBUG: Gathering videos...\n"


### PR DESCRIPTION
Fixes #1121 

When we examine the output logs of tests that experience a SocketTimeoutException we find that every subsequent test fails. Once the connection between the robot and the IDE is broken we cannot reconnect. 

The strategy is to save the JUnit output in a file and after each set of tests scan the file to see if the expected exception occurred. We use a static file reader so that it maintains its place in the file and we do not start scanning from the beginning each time. 

The benefit of detecting this exception is that we can exit the tests as soon as possible so the debugging can begin. 