### PR TITLE
Use Locale.ROOT to avoid the Turkish locale bug.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
@@ -24,10 +24,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class JDTUtils {
@@ -70,7 +67,9 @@ public class JDTUtils {
     public static List<PsiMethod> getFieldAccessors(PsiJavaFile unit, PsiField field) {
         List<PsiMethod> accessors = new ArrayList<PsiMethod>();
         String fieldName = field.getName();
-        String accessorSuffix = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+        // Use Locale.ROOT to avoid the "Turkish locale bug".
+        // See: https://github.com/OpenLiberty/liberty-tools-intellij/issues/1092
+        String accessorSuffix = fieldName.substring(0, 1).toUpperCase(Locale.ROOT) + fieldName.substring(1);
         List<String> accessorNames = ACCESSOR_PREFIXES.stream().map(s -> s + accessorSuffix).collect(Collectors.toList());
 
         for (PsiClass type : unit.getClasses()) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/reactivemessaging/properties/MicroProfileReactiveMessagingProvider.java
@@ -22,6 +22,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4mp.commons.metadata.ItemHint;
 import org.eclipse.lsp4mp.commons.metadata.ValueHint;
 
+import java.util.Locale;
+
 import static io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotationMemberValue;
 import static io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.isMatchAnnotation;
 import static io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils.*;
@@ -353,7 +355,9 @@ public class MicroProfileReactiveMessagingProvider extends AbstractAnnotationTyp
 											 String attributeName) {
 		StringBuilder propertyName = new StringBuilder("mp.messaging");
 		propertyName.append('.');
-		propertyName.append(messageType.name().toLowerCase());
+		// Use Locale.ROOT to avoid the "Turkish locale bug".
+		// See: https://github.com/OpenLiberty/liberty-tools-intellij/issues/1092
+		propertyName.append(messageType.name().toLowerCase(Locale.ROOT));
 		propertyName.append('.');
 		if (dynamic) {
 			propertyName.append("${");

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Locale;
 
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
@@ -313,7 +314,9 @@ public class LibertyMavenUtil {
         File[] files = mavenHomeBootAsFile.listFiles();
         if (files != null) {
             for (File file : files) {
-                if (file.getName().contains("classworlds") && file.getName().toLowerCase().endsWith(".jar")) {
+                // Use Locale.ROOT to avoid the "Turkish locale bug".
+                // See: https://github.com/OpenLiberty/liberty-tools-intellij/issues/1092
+                if (file.getName().contains("classworlds") && file.getName().toLowerCase(Locale.ROOT).endsWith(".jar")) {
                     return file.getAbsolutePath();
                 }
             }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1092

Planning on also submitting a PR back to Quarkus Tools since this touches LSP4MPIJ.