### PR TITLE
Resolved issues with matching qualified names in AbstractDiagnosticsCollector

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -151,54 +151,6 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
     }
 
     /**
-     * Returns true if the given Java class imports the given Java element and false
-     * otherwise.
-     * Must handle "import pkg.MyClass" and "import pkg.*"
-     *
-     * @param unit              Java class.
-     * @param javaElementFQName given Java element fully qualified name.
-     * @return true if the Java class imports the given Java element and false
-     *         otherwise.
-     */
-    protected static boolean isImportedJavaElement(PsiClass unit, String javaElementFQName) {
-        return isImportedJavaElement(unit, new String[] { javaElementFQName });
-    }
-
-    protected static boolean isImportedJavaElement(PsiClass unit, String[] javaElementFQNames) {
-        PsiFile file = unit.getContainingFile();
-        if (file instanceof PsiJavaFile) {
-            PsiJavaFile jFile = (PsiJavaFile) file;
-            PsiClass[] importClasses = jFile.getSingleClassImports(true);
-            for (PsiClass c : importClasses) {
-                for (String name : javaElementFQNames) {
-                    if (name.equals(c.getQualifiedName())) {
-                        return true;
-                    }
-                }
-            }
-            PsiElement[] importOnDemand = jFile.getOnDemandImports(false, true);
-            for (PsiElement e : importOnDemand) {
-                // should be class or package
-                if (e instanceof PsiClass) {
-                    for (String name : javaElementFQNames) {
-                        if (name.equals(((PsiClass) e).getQualifiedName())) {
-                            return true;
-                        }
-                    }
-                }
-                if (e instanceof PsiPackage) {
-                    for (String name : javaElementFQNames) {
-                        if (name.startsWith(((PsiPackage) e).getQualifiedName())) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
      * Returns true if the given Java class implements one of the given interfaces
      * and false otherwise.
      *

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -126,24 +126,9 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
      * @return true if the given annotation matches the given annotation name and
      *         false otherwise.
      */
-    protected static boolean isMatchedAnnotation(PsiClass unit, PsiAnnotation annotation, String annotationFQName) {
+    protected static boolean isMatchedAnnotation(PsiAnnotation annotation, String annotationFQName) {
         String elementName = annotation.getQualifiedName();
-        if (nameEndsWith(annotationFQName, elementName) && unit != null) {
-            // For performance reason, we check if the import of annotation name is
-            // declared
-            if (isImportedJavaElement(unit, annotationFQName))
-                return true;
-            // only check fully qualified annotations
-            if (annotationFQName.equals(elementName)) {
-                PsiReference ref = annotation.getReference();
-                PsiElement def = ref.resolve();
-                if (def instanceof PsiAnnotation) {
-                    String fqName = ((PsiAnnotation)def).getQualifiedName();
-                    return fqName.equals(annotationFQName);
-                }
-            }
-        }
-        return false;
+        return annotationFQName.equals(elementName);
     }
 
     /**
@@ -157,17 +142,10 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
      *         element name and false otherwise.
      */
     protected static boolean isMatchedJavaElement(PsiClass type, String javaElementName, String javaElementFQName) {
-        if (nameEndsWith(javaElementFQName, javaElementName)) {
-            // For performance reason, we check if the import of annotation name is
-            // declared
-            if (isImportedJavaElement(type, javaElementFQName))
-                return true;
-            // only check fully qualified java element
-            if (javaElementFQName.equals(javaElementName)) {
-                JavaPsiFacade facade = JavaPsiFacade.getInstance(type.getProject());
-                Object o = facade.findClass(javaElementFQName, GlobalSearchScope.allScope(type.getProject()));
-                return (o != null);
-            }
+        if (javaElementFQName.equals(javaElementName)) {
+            JavaPsiFacade facade = JavaPsiFacade.getInstance(type.getProject());
+            Object o = facade.findClass(javaElementFQName, GlobalSearchScope.allScope(type.getProject()));
+            return (o != null);
         }
         return false;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -97,9 +97,8 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
             for (Tuple.Two<PsiAnnotation, PsiElement> annotatable : annotatables) {
                 PsiAnnotation annotation = annotatable.getFirst();
                 PsiElement element = annotatable.getSecond();
-                PsiClass topLevel = PsiUtil.getTopLevelClass(element);
 
-                if (isMatchedAnnotation(topLevel, annotation, AnnotationConstants.GENERATED_FQ_NAME)) {
+                if (isMatchedAnnotation(annotation, AnnotationConstants.GENERATED_FQ_NAME)) {
                     for (PsiNameValuePair pair : annotation.getParameterList().getAttributes()) {
                         // If date element exists and is non-empty, it must follow ISO 8601 format.
                         if (pair.getAttributeName().equals("date")) {
@@ -115,7 +114,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                             }
                         }
                     }
-                } else if (isMatchedAnnotation(topLevel, annotation, AnnotationConstants.RESOURCE_FQ_NAME)) {
+                } else if (isMatchedAnnotation(annotation, AnnotationConstants.RESOURCE_FQ_NAME)) {
                     if (element instanceof PsiClass) {
                         PsiClass type = (PsiClass) element;
                         Boolean nameEmpty = true;
@@ -146,7 +145,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                         }
                     }
                 }
-                if (isMatchedAnnotation(topLevel, annotation, AnnotationConstants.POST_CONSTRUCT_FQ_NAME)) {
+                if (isMatchedAnnotation(annotation, AnnotationConstants.POST_CONSTRUCT_FQ_NAME)) {
                     if (element instanceof PsiMethod) {
                         PsiMethod method = (PsiMethod) element;
                         if (method.getParameters().length != 0) {
@@ -173,7 +172,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                                     DiagnosticSeverity.Warning));
                         }
                     }
-                } else if (isMatchedAnnotation(topLevel, annotation, AnnotationConstants.PRE_DESTROY_FQ_NAME)) {
+                } else if (isMatchedAnnotation(annotation, AnnotationConstants.PRE_DESTROY_FQ_NAME)) {
                     if (element instanceof PsiMethod) {
                         PsiMethod method = (PsiMethod) element;
                         if (method.getParameters().length != 0) {


### PR DESCRIPTION
Fixes #1025 

Refactored isMatchedAnnotation() and isMatchedJavaElement() to align the changes with fully qualified names