### PR TITLE
Enable Ui test task 'runIdeForUiTests'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,20 +174,28 @@ test {
         exceptionFormat = 'full'
     }
 }
-downloadRobotServerPlugin {
-    version.set(remoteRobotVersion)
-}
 
-runIdeForUiTests {
-    systemProperty "robot-server.port", "8082"
-    systemProperty "ide.mac.message.dialogs.as.sheets", "false"
-    systemProperty "jb.privacy.policy.text", "<!--999.999-->"
-    systemProperty "jb.consents.confirmation.enabled", "false"
-    systemProperty "idea.trust.all.projects", "true"
-    systemProperty "ide.show.tips.on.startup.default.value", "false"
-    systemProperty "ide.mac.file.chooser.native", "false"
-    systemProperty "jbScreenMenuBar.enabled", "false"
-    systemProperty "apple.laf.useScreenMenuBar", "false"
+intellijPlatformTesting.runIde {
+    runIdeForUiTests {
+        task {
+            jvmArgumentProviders.add({
+                [
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                        "-Didea.trust.all.projects=true",
+                        "-Dide.show.tips.on.startup.default.value=false",
+                        "-Dide.mac.file.chooser.native=false",
+                        "-DjbScreenMenuBar.enabled=false",
+                        "-Dapple.laf.useScreenMenuBar=false",
+                ]
+            } as CommandLineArgumentProvider)
+        }
+        plugins {
+            robotServerPlugin(remoteRobotVersion)
+        }
+    }
 }
 
 intellijPlatform {


### PR DESCRIPTION
Fixes #885 

I enabled the UI test task `runIdeForUiTests`, and as a result, the UI tests are currently running on IntelliJ version `2024.1.7`.