### PR TITLE
Removed unused java target version and added import for kotlinCompile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 plugins {
     id 'java'
@@ -65,7 +66,7 @@ configurations {
     }
 
     // Ensures that the JVM target is set to 17 for all Kotlin compilation tasks, including both main and test sources.
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    tasks.withType(KotlinCompile).all {
         kotlinOptions {
             jvmTarget = javaVersion
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ pluginSinceBuild=241
 pluginUntilBuild=242.*
 
 javaVersion=17
-javaTargetVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC


### PR DESCRIPTION
Part of : https://github.com/OpenLiberty/liberty-tools-intellij/issues/911
 The unused Java target version has been removed from gradle.properties, and the import for kotlinCompile has been added in build.gradle.