### PR TITLE
Issue #1088 - Parameterize the java target and platform target values

### DIFF
--- a/.run/liberty-tools-intellij [runIde].run.xml
+++ b/.run/liberty-tools-intellij [runIde].run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="liberty-tools-intellij [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="liberty-tools-intellij [runIdeLocally]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="runIde" />
+          <option value="runIdeLocally" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -20,7 +20,7 @@ This extension is built using the [gradle-intellij-plugin](https://github.com/Je
 
 1. Clone this repository: `git clone git@github.com:OpenLiberty/liberty-tools-intellij.git`
 2. Import this repository as a Gradle project in IntelliJ IDEA 
-3. Run `./gradlew runIde --stacktrace`. A new IntelliJ IDEA window will launch with the Liberty Tools plugin installed to it. You can connect the IntelliJ IDEA debugger to this process to debug the plugin.
+3. Run `./gradlew runIdeLocally --stacktrace`. A new IntelliJ IDEA window will launch with the Liberty Tools plugin installed to it. You can connect the IntelliJ IDEA debugger to this process to debug the plugin.
 
    OR  
 
@@ -38,7 +38,7 @@ Liberty Tools for IntelliJ consumes the [Liberty Config Language Server](https:/
 
 #### Debugging LemMinX Language Server
 To debug the LemMinX Language Server in IntelliJ, complete the following steps.
-1. Start Liberty Tools for IntelliJ by creating an IntelliJ debug configuration for the `./gradlew runIde command`.
+1. Start Liberty Tools for IntelliJ by creating an IntelliJ debug configuration for the `./gradlew runIdeLocally command`.
 2. Create a new debug configuration: _Remote JVM Debug_ --> specify _localhost_, port _1054_ and command line arguments `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1054`
 3. In `io.openliberty.tools.intellij.liberty.lsp.LibertyXmlServer.LibertyXmlServer()` replace the line ` params.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1054,quiet=y");` with  `params.add("-agentlib:jdwp=transport=dt_socket,server=y,address=1054");`.
 4. Start the debug configuration created in step 2. You can now step through the LemMinX LS code now with the IntelliJ debugger.

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ task copyDeps(type: Copy) {
 
 intellijPlatformTesting.runIde {
     runIdeLocally {
-        version = providers.gradleProperty("runIdeUiversion")
+        version = providers.gradleProperty("ideTargetVersion")
         type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
             jvmArgumentProviders.add({
@@ -184,7 +184,7 @@ test {
 
 intellijPlatformTesting.runIde {
     runIdeForUiTests {
-        version = providers.gradleProperty("runIdeUiversion")
+        version = providers.gradleProperty("ideTargetVersion")
         type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
             jvmArgumentProviders.add({

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,12 @@ test {
 
 intellijPlatformTesting.runIde {
     runIdeForUiTests {
+        version = providers.gradleProperty("runIdeUiversion")
         task {
+            // Java version for this task is set to Java 21
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(21)
+            }
             jvmArgumentProviders.add({
                 [
                         "-Drobot-server.port=8082",

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 plugins {
     id 'java'
     id 'org.jetbrains.intellij.platform' version '2.1.0'
@@ -160,6 +161,7 @@ task copyDeps(type: Copy) {
 intellijPlatformTesting.runIde {
     runIdeLocally {
         version = providers.gradleProperty("runIdeUiversion")
+        type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
             // Java version for this task is set to Java 21
             javaLauncher = javaToolchains.launcherFor {
@@ -187,6 +189,7 @@ test {
 intellijPlatformTesting.runIde {
     runIdeForUiTests {
         version = providers.gradleProperty("runIdeUiversion")
+        type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
             // Java version for this task is set to Java 21
             javaLauncher = javaToolchains.launcherFor {

--- a/build.gradle
+++ b/build.gradle
@@ -163,10 +163,6 @@ intellijPlatformTesting.runIde {
         version = providers.gradleProperty("runIdeUiversion")
         type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
-            // Java version for this task is set to Java 21
-            javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(21)
-            }
             jvmArgumentProviders.add({
                 [
                         "--add-exports",
@@ -191,10 +187,6 @@ intellijPlatformTesting.runIde {
         version = providers.gradleProperty("runIdeUiversion")
         type = IntelliJPlatformType.IntellijIdeaCommunity
         task {
-            // Java version for this task is set to Java 21
-            javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(21)
-            }
             jvmArgumentProviders.add({
                 [
                         "-Drobot-server.port=8082",

--- a/build.gradle
+++ b/build.gradle
@@ -157,13 +157,22 @@ task copyDeps(type: Copy) {
     rename '^(.*)(-[0-9]+[.[0-9]+]+(-SNAPSHOT)?)(.*)$', '$1$4'
 }
 
-runIde {
-    jvmArgumentProviders.add({
-        [
-                "--add-exports",
-                "java.base/jdk.internal.vm=ALL-UNNAMED",
-        ]
-    } as CommandLineArgumentProvider)
+intellijPlatformTesting.runIde {
+    runIdeLocally {
+        version = providers.gradleProperty("runIdeUiversion")
+        task {
+            // Java version for this task is set to Java 21
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(21)
+            }
+            jvmArgumentProviders.add({
+                [
+                        "--add-exports",
+                        "java.base/jdk.internal.vm=ALL-UNNAMED"
+                ]
+            } as CommandLineArgumentProvider)
+        }
+    }
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ javaTargetVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
+runIdeUiversion=2024.2.4
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ javaTargetVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-runIdeUiversion=2024.2.4
+ideTargetVersion=2024.2.4
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties


### PR DESCRIPTION
Fixes #1088 

By default, tasks like runIde use the IntelliJ Platform version specified in the dependencies extension. I implemented a solution by creating a new task called `runIdeLocally`, enabling us to set custom values for the Java and IntelliJ versions. This allows us to use `runIde` with the specified platform version (java 17 ) and Intellij version 2024.1.7 and `runIdeLocally` with the latest version (2024.2.2 in this case) and java 21.

Also updated the places where `runIde` is used in our code to `runIdeLocally`.