### PR TITLE
Terminate the process running the IDE if it crashes

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -576,7 +576,7 @@ public class TestUtils {
      * This searches the output of this JUnit run for SocketTimeoutException which
      * has been identified as a fatal error and occurs during the Mac tests.
      */
-    public static synchronized void detectFatalError() {
+    public static void detectFatalError() {
         final String outputFile = System.getenv("JUNIT_OUTPUT_TXT");
         try {
             final BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -195,11 +195,15 @@ main() {
     grep -iq "SocketTimeoutException" "$JUNIT_OUTPUT_TXT" && testRC=23
     if [ "$testRC" -eq 23 ]; then
         # rc = 23 means SocketTimeoutException detected, kill the IDE and try again
-        kill -1 $IDE_PID # SIGHUP (hang up the phone)
-        sleep 5
-        kill -9 $IDE_PID # SIGKILL, in case the SIGHUP did not work
-        sleep 5
-        ps -f $IDE_PID # display whether the process is still there
+        if [[ $OS == "MINGW64_NT"* ]]; then
+            stop-process -name idea64
+        else
+            kill -1 $IDE_PID # SIGHUP (hang up the phone)
+            sleep 5
+            kill -9 $IDE_PID # SIGKILL, in case the SIGHUP did not work
+            sleep 5
+            ps -f $IDE_PID # display whether the process is still there
+        fi
     fi
 
     # If there were any errors, gather some debug data before exiting.

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -202,6 +202,9 @@ main() {
         # rc = 23 means SocketTimeoutException detected, kill the IDE and try again
         if [[ $OS == "MINGW64_NT"* ]]; then
             kill -n 1 $IDE_PID
+            sleep 5
+            kill -n 9 $IDE_PID
+            sleep 5
             ps -ef # display all user processes
         else
             kill -1 $IDE_PID # SIGHUP (hang up the phone)

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -192,14 +192,14 @@ main() {
     ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$JUNIT_OUTPUT_TXT"
     testRC=$? # gradlew test only returns 0 or 1, not the return code from JUnit
     set +o pipefail # reset this option
-    grep -iq "finished with non-zero exit value 23" "$JUNIT_OUTPUT_TXT" && testRC=23
+    grep -iq "SocketTimeoutException" "$JUNIT_OUTPUT_TXT" && testRC=23
     if [ "$testRC" -eq 23 ]; then
         # rc = 23 means SocketTimeoutException detected, kill the IDE and try again
         kill -1 $IDE_PID # SIGHUP (hang up the phone)
         sleep 5
         kill -9 $IDE_PID # SIGKILL, in case the SIGHUP did not work
         sleep 5
-        ps -f $IDE_PID # display whether it is still there in the log
+        ps -f $IDE_PID # display whether the process is still there
     fi
 
     # If there were any errors, gather some debug data before exiting.

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -134,6 +134,7 @@ startIDE() {
     while ! ${callLivenessEndpoint[@]} | grep -qF 'Welcome to IntelliJ IDEA'; do
         if [ $count -eq 24 ]; then
             echo -e "\n$(${currentTime[@]}): ERROR: Timed out waiting for the Intellij IDE Welcome Page to start. Output:"
+            gatherDebugData $(pwd)
             exit 12
         fi
         count=`expr $count + 1`
@@ -189,8 +190,17 @@ main() {
     echo -e "\n$(${currentTime[@]}): INFO: Running tests..."
     set -o pipefail # using tee requires we use this setting to gather the rc of gradlew
     ./gradlew test -PuseLocal=$USE_LOCAL_PLUGIN | tee "$JUNIT_OUTPUT_TXT"
-    testRC=$?
+    testRC=$? # gradlew test only returns 0 or 1, not the return code from JUnit
     set +o pipefail # reset this option
+    grep -iq "finished with non-zero exit value 23" "$JUNIT_OUTPUT_TXT" && testRC=23
+    if [ "$testRC" -eq 23 ]; then
+        # rc = 23 means SocketTimeoutException detected, kill the IDE and try again
+        kill -1 $IDE_PID # SIGHUP (hang up the phone)
+        sleep 5
+        kill -9 $IDE_PID # SIGKILL, in case the SIGHUP did not work
+        sleep 5
+        ps -f $IDE_PID # display whether it is still there in the log
+    fi
 
     # If there were any errors, gather some debug data before exiting.
     if [ "$testRC" -ne 0 ]; then


### PR DESCRIPTION
Fixes #1122

Fix to detect the process id on Windows. I use `kill -1` and `kill -9` and `sleep 5` in an attempt to avoid the defunct process I've seen in the past.

Log showing how the Windows code works for those not familiar with Windows:
```
+ '[' 23 -eq 23 ']'
+ [[ MINGW64_NT-10.0-20348 == \M\I\N\G\W\6\4\_\N\T* ]]
+ kill -n 1 1823
+ sleep 5
./src/test/resources/ci/scripts/run.sh: line 195:  1823 Hangup                  ./gradlew runIdeForUiTests -PuseLocal=$USE_LOCAL_PLUGIN --info > remoteServer.log 2>&1
+ kill -n 9 1823
./src/test/resources/ci/scripts/run.sh: line 209: kill: (1823) - No such process
+ sleep 5
+ ps -ef
     UID     PID    PPID  TTY        STIME COMMAND
runnerad    1869    1716 ?        00:08:10 /usr/bin/ps
runnerad    1716       1 ?        23:48:37 /usr/bin/bash
```
Log from Mac (largely the same as Linux)
```
+ '[' 23 -eq 23 ']'
+ [[ Darwin == \M\I\N\G\W\6\4\_\N\T* ]]
+ kill -1 9176
+ sleep 5
+ kill -9 9176
./src/test/resources/ci/scripts/run.sh: line 215: kill: (9176) - No such process
+ sleep 5
+ ps -f 9176
  UID   PID  PPID   C STIME   TTY           TIME CMD
```
Another log from Mac where it appears the `kill -1` did not work
```
+ '[' 23 -eq 23 ']'
+ [[ Darwin == \M\I\N\G\W\6\4\_\N\T* ]]
+ kill -1 9412
+ sleep 5
+ kill -9 9412
+ sleep 5
+ ps -f 9412
  UID   PID  PPID   C STIME   TTY           TIME CMD
```