### PR TITLE
When the SocketTimeoutException is detected, restart testing

### DIFF
--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -131,9 +131,9 @@ startIDE() {
     echo -e "\n$(${currentTime[@]}): INFO: Waiting for the Intellij IDE to start..."
     callLivenessEndpoint=(curl -s http://localhost:8082)
     count=1
-    while ! ${callLivenessEndpoint[@]} | grep -qF 'Welcome to IntelliJ IDEA'; do
+    while ! ${callLivenessEndpoint[@]} | grep -qF 'div'; do # search for any amount of html from the IDE
         if [ $count -eq 24 ]; then
-            echo -e "\n$(${currentTime[@]}): ERROR: Timed out waiting for the Intellij IDE Welcome Page to start. Output:"
+            echo -e "\n$(${currentTime[@]}): ERROR: Timed out waiting for the Intellij IDE to start. Output:"
             gatherDebugData $(pwd)
             exit 12
         fi


### PR DESCRIPTION
Fixes #1123 

In the last pull request we terminated the running IDE after detecting the error. In this one we need to restart the IDE and restart the testing. I chose to try up to 5 times before stopping. 