### PR TITLE
Get back to the Welcome screen at start up of UI test

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModJakartaLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModJakartaLSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,11 +10,8 @@
 package io.openliberty.tools.intellij.it;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
-
 
 public class GradleSingleModJakartaLSTest extends SingleModJakartaLSTestCommon {
 

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModLSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,11 +10,8 @@
 package io.openliberty.tools.intellij.it;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
-
 
 public class GradleSingleModLSTest extends SingleModLibertyLSTestCommon {
 

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPLSTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPLSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,11 +9,7 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.it;
 
-import com.automation.remarks.junit5.Video;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Paths;
 

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -185,7 +185,7 @@ public abstract class SingleModJakartaLSTestCommon {
 
     public static void prepareEnv(String projectPath, String projectName) {
         waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
-        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,6 @@ import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.RemoteRobot;
 import com.intellij.remoterobot.fixtures.JTreeFixture;
 import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
-import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
 import java.nio.file.Path;
@@ -28,7 +27,6 @@ public abstract class SingleModJakartaLSTestCommon {
 
     String projectName;
     String projectsPath;
-
 
     public SingleModJakartaLSTestCommon(String projectName, String projectsPath) {
         this.projectName = projectName;

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -397,7 +397,7 @@ public abstract class SingleModLibertyLSTestCommon {
      */
     public static void prepareEnv(String projectPath, String projectName) {
         waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
-        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,6 @@ import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.RemoteRobot;
 import com.intellij.remoterobot.fixtures.JTreeFixture;
 import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
-import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
 import java.nio.file.Path;
@@ -28,7 +27,6 @@ public abstract class SingleModLibertyLSTestCommon {
 
     String projectName;
     String projectsPath;
-
 
     public SingleModLibertyLSTestCommon(String projectName, String projectsPath) {
         this.projectName = projectName;

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -326,9 +326,8 @@ public abstract class SingleModMPLSTestCommon {
      */
 
     public static void prepareEnv(String projectPath, String projectName) {
-
         waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
-        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation.
+ * Copyright (c) 2023, 2024 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,6 @@ import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.RemoteRobot;
 import com.intellij.remoterobot.fixtures.JTreeFixture;
 import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
-import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
 import java.nio.file.Path;
@@ -22,14 +21,12 @@ import java.time.Duration;
 
 import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
 
-
 public abstract class SingleModMPLSTestCommon {
     public static final String REMOTEBOT_URL = "http://localhost:8082";
     public static final RemoteRobot remoteRobot = new RemoteRobot(REMOTEBOT_URL);
 
     String projectName;
     String projectsPath;
-
 
     public SingleModMPLSTestCommon(String projectName, String projectsPath) {
         this.projectName = projectName;

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -1132,7 +1132,7 @@ public abstract class SingleModMPProjectTestCommon {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
                 "prepareEnv. Entry. ProjectPath: " + projectPath + ". ProjectName: " + projectName);
         waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
-        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
         // IntelliJ does not start building and indexing until the Project View is open

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -14,7 +14,6 @@ import com.intellij.remoterobot.RemoteRobot;
 import com.intellij.remoterobot.fixtures.ComponentFixture;
 import com.intellij.remoterobot.utils.Keyboard;
 import io.openliberty.tools.intellij.it.fixtures.ProjectFrameFixture;
-import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -296,7 +296,7 @@ public abstract class SingleModNLTRestProjectTestCommon {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
                 "prepareEnv. Entry. ProjectPath: " + projectPath + ". ProjectName: " + projectName);
         waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
-        remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
         // IntelliJ does not start building and indexing until the Project View is open

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -11,7 +11,6 @@ package io.openliberty.tools.intellij.it;
 
 import com.automation.remarks.junit5.Video;
 import com.intellij.remoterobot.RemoteRobot;
-import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.junit.jupiter.api.*;
 
 import java.nio.file.Files;

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-
 /**
  * Test utilities.
  */

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -2533,4 +2533,17 @@ public class UIBotTestUtils {
             // The Terminal tab is most likely closed.
         }
     }
+
+    public static void findWelcomeFrame(RemoteRobot remoteRobot) {
+        try {
+            remoteRobot.find(WelcomeFrameFixture.class, Duration.ofMinutes(2));
+        } catch (WaitForConditionTimeoutException e) {
+            // If the welcome frame is not found then there is a project loaded.
+            // Close the editor files and close the project to get back to the welcome frame.
+            UIBotTestUtils.closeAllEditorTabs(remoteRobot);
+            UIBotTestUtils.closeProjectView(remoteRobot);
+            UIBotTestUtils.closeProjectFrame(remoteRobot);
+            UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
+        }
+    }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -2432,7 +2432,7 @@ public class UIBotTestUtils {
     public static boolean inWelcomeFrame(RemoteRobot remoteRobot) {
         boolean inWelcomeFrame = false;
         try {
-            remoteRobot.find(WelcomeFrameFixture.class, Duration.ofSeconds(2));
+            remoteRobot.find(WelcomeFrameFixture.class, Duration.ofSeconds(5));
             inWelcomeFrame = true;
         } catch (Exception e) {
             // Not in welcome frame.
@@ -2450,7 +2450,7 @@ public class UIBotTestUtils {
     public static boolean inProjectFrame(RemoteRobot remoteRobot) {
         boolean inProjectFrame = false;
         try {
-            remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(2));
+            remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(5));
             inProjectFrame = true;
         } catch (Exception e) {
             // Not in project frame.
@@ -2543,6 +2543,7 @@ public class UIBotTestUtils {
             UIBotTestUtils.closeAllEditorTabs(remoteRobot);
             UIBotTestUtils.closeProjectView(remoteRobot);
             UIBotTestUtils.closeProjectFrame(remoteRobot);
+            TestUtils.sleepAndIgnoreException(30); // takes about 15s to render the whole Welcome page including the Open button on Mac.
             UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
         }
     }

--- a/src/test/resources/ci/scripts/run.sh
+++ b/src/test/resources/ci/scripts/run.sh
@@ -190,6 +190,9 @@ main() {
     fi
 
     export JUNIT_OUTPUT_TXT="$currentLoc"/build/junit.out
+    # Run the tests up to 5 times. "SocketTimeoutException" seems to be rare so hopefully 5
+    # repetitions are enough. Also a failure takes about 1 hour and the github time limit is
+    # 6 hours so it is unlikely we could run more than 5 times in one build.
     for restartCount in {1..5}; do
         startIDE
         # Run the tests


### PR DESCRIPTION
Fixes #1124 

Introduce a new method to find the Welcome screen of IntelliJ. This is needed when we start IntelliJ after a crash. In this case IntelliJ will start and load the last project that was used. This is not expected by the UI robot because it always closes files and projects after each test. So the fix is to close all files and lose the current project to get back to the Welcome screen when we detect that the Welcome screen is not up. 

I also noticed that there were some unused imports so I did a sweep through all the files in the directory and updated the copyrights, removed unused imports and also extra blank lines. 