### PR TITLE
Enable test to the new feature branch intellij-2024.2-support-backup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, intellij-2024.2-support ]
+    branches: [ main, intellij-2024.2-support-backup ]
 
 jobs:
   build:


### PR DESCRIPTION
Enabled test to the new feature branch `intellij-2024.2-support-backup`