### PR TITLE
LSP4Jakarta: Reduce code duplication. Use getSimpleName() utility method for computing short names.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -232,20 +232,6 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
     }
 
     /**
-     * Returns simple name for the given fully qualified name.
-     *
-     * @param fqName a fully qualified name or simple name
-     * @return simple name for given fully qualified name
-     */
-    public static String getSimpleName(String fqName) {
-        int idx = fqName.lastIndexOf('.');
-        if (idx != -1 && idx != fqName.length() - 1) {
-            return fqName.substring(idx + 1);
-        }
-        return fqName;
-    }
-
-    /**
      * Returns true if the given method is a constructor and false otherwise.
      *
      * @param m method

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
@@ -117,7 +117,7 @@ public class JDTUtils {
      * @return simple name for given fully qualified name
      */
     public static String getSimpleName(String fqName) {
-        int idx = fqName.lastIndexOf('.');
+        final int idx = fqName.lastIndexOf('.');
         if (idx != -1 && idx != fqName.length() - 1) {
             return fqName.substring(idx + 1);
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/JDTUtils.java
@@ -109,4 +109,18 @@ public class JDTUtils {
                                               String quickFixMessage, String participantId) {
         return createCodeAction(context, diagnostic, quickFixMessage, participantId, null);
     }
+
+    /**
+     * Returns simple name for the given fully qualified name.
+     *
+     * @param fqName a fully qualified name or simple name
+     * @return simple name for given fully qualified name
+     */
+    public static String getSimpleName(String fqName) {
+        int idx = fqName.lastIndexOf('.');
+        if (idx != -1 && idx != fqName.length() - 1) {
+            return fqName.substring(idx + 1);
+        }
+        return fqName;
+    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -15,11 +15,11 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation;
 
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationConstants.*;
 
 import java.util.List;
@@ -90,8 +90,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
 
                 if (matchedAnnotation.equals(ASSERT_FALSE) || matchedAnnotation.equals(ASSERT_TRUE)) {
                     String source = isMethod ?
-                            Messages.getMessage("AnnotationBooleanMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                            Messages.getMessage("AnnotationBooleanFields", "@" + JDTUtils.getSimpleName(annotationName));
+                            Messages.getMessage("AnnotationBooleanMethods", "@" + getSimpleName(annotationName)) :
+                            Messages.getMessage("AnnotationBooleanFields", "@" + getSimpleName(annotationName));
                     if (!type.equals(PsiTypes.booleanType())) {
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
@@ -106,8 +106,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.intType())
                             && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationBigDecimalMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationBigDecimalFields", "@" + JDTUtils.getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationBigDecimalMethods", "@" + getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationBigDecimalFields", "@" + getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(), source,
                                 DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -125,8 +125,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             SET_OF_DATE_TYPES.toArray(new String[0]));
                     if (dataTypeFQName == null) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationDateMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationDateFields", "@" + JDTUtils.getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationDateMethods", "@" + getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationDateFields", "@" + getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -138,8 +138,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.intType())
                             && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationMinMaxMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationMinMaxFields", "@" + JDTUtils.getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationMinMaxMethods", "@" + getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationMinMaxFields", "@" + getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -154,8 +154,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.floatType())
                             && !type.equals(PsiTypes.doubleType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationPositiveMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationPositiveFields", "@" + JDTUtils.getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationPositiveMethods", "@" + getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationPositiveFields", "@" + getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -197,8 +197,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
         if (!type.getCanonicalText().equals(STRING)
                 && !type.getCanonicalText().equals(CHAR_SEQUENCE)) {
             String source = isMethod ?
-                    Messages.getMessage("AnnotationStringMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
-                    Messages.getMessage("AnnotationStringFields", "@" + JDTUtils.getSimpleName(annotationName));
+                    Messages.getMessage("AnnotationStringMethods", "@" + getSimpleName(annotationName)) :
+                    Messages.getMessage("AnnotationStringFields", "@" + getSimpleName(annotationName));
             diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                     source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation;
 
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -89,8 +90,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
 
                 if (matchedAnnotation.equals(ASSERT_FALSE) || matchedAnnotation.equals(ASSERT_TRUE)) {
                     String source = isMethod ?
-                            Messages.getMessage("AnnotationBooleanMethods", "@" + getSimpleName(annotationName)) :
-                            Messages.getMessage("AnnotationBooleanFields", "@" + getSimpleName(annotationName));
+                            Messages.getMessage("AnnotationBooleanMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                            Messages.getMessage("AnnotationBooleanFields", "@" + JDTUtils.getSimpleName(annotationName));
                     if (!type.equals(PsiTypes.booleanType())) {
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
@@ -105,8 +106,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.intType())
                             && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationBigDecimalMethods", "@" + getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationBigDecimalFields", "@" + getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationBigDecimalMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationBigDecimalFields", "@" + JDTUtils.getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(), source,
                                 DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -124,8 +125,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             SET_OF_DATE_TYPES.toArray(new String[0]));
                     if (dataTypeFQName == null) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationDateMethods", "@" + getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationDateFields", "@" + getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationDateMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationDateFields", "@" + JDTUtils.getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -137,8 +138,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.intType())
                             && !type.equals(PsiTypes.longType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationMinMaxMethods", "@" + getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationMinMaxFields", "@" + getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationMinMaxMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationMinMaxFields", "@" + JDTUtils.getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -153,8 +154,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                             && !type.equals(PsiTypes.floatType())
                             && !type.equals(PsiTypes.doubleType())) {
                         String source = isMethod ?
-                                Messages.getMessage("AnnotationPositiveMethods", "@" + getSimpleName(annotationName)) :
-                                Messages.getMessage("AnnotationPositiveFields", "@" + getSimpleName(annotationName));
+                                Messages.getMessage("AnnotationPositiveMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                                Messages.getMessage("AnnotationPositiveFields", "@" + JDTUtils.getSimpleName(annotationName));
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
@@ -196,8 +197,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
         if (!type.getCanonicalText().equals(STRING)
                 && !type.getCanonicalText().equals(CHAR_SEQUENCE)) {
             String source = isMethod ?
-                    Messages.getMessage("AnnotationStringMethods", "@" + getSimpleName(annotationName)) :
-                    Messages.getMessage("AnnotationStringFields", "@" + getSimpleName(annotationName));
+                    Messages.getMessage("AnnotationStringMethods", "@" + JDTUtils.getSimpleName(annotationName)) :
+                    Messages.getMessage("AnnotationStringFields", "@" + JDTUtils.getSimpleName(annotationName));
             diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                     source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.ModifyModifiersProposal;
@@ -82,7 +81,7 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
     private void removeConstraintAnnotationsCodeActions(Diagnostic diagnostic, JavaCodeActionContext context, List<CodeAction> codeActions) {
 
         final String annotationName = diagnostic.getData().toString().replace("\"", "");
-        final String name = Messages.getMessage("RemoveConstraintAnnotation", AbstractDiagnosticsCollector.getSimpleName(annotationName));
+        final String name = Messages.getMessage("RemoveConstraintAnnotation", JDTUtils.getSimpleName(annotationName));
         Map<String, Object> extendedData = new HashMap<>();
         extendedData.put(ANNOTATION_NAME, annotationName);
         codeActions.add(JDTUtils.createCodeAction(context, diagnostic, name, getParticipantId(), extendedData));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationQuickFix.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * Quickfix for fixing {@link BeanValidationConstants#DIAGNOSTIC_CODE_STATIC} error by either action
  * 1. Removing constraint annotation on static field or method
@@ -81,7 +83,7 @@ public class BeanValidationQuickFix implements IJavaCodeActionParticipant {
     private void removeConstraintAnnotationsCodeActions(Diagnostic diagnostic, JavaCodeActionContext context, List<CodeAction> codeActions) {
 
         final String annotationName = diagnostic.getData().toString().replace("\"", "");
-        final String name = Messages.getMessage("RemoveConstraintAnnotation", JDTUtils.getSimpleName(annotationName));
+        final String name = Messages.getMessage("RemoveConstraintAnnotation", getSimpleName(annotationName));
         Map<String, Object> extendedData = new HashMap<>();
         extendedData.put(ANNOTATION_NAME, annotationName);
         codeActions.add(JDTUtils.createCodeAction(context, diagnostic, name, getParticipantId(), extendedData));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -17,11 +17,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -333,7 +333,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                                 .map(annotation -> annotation.getQualifiedName()).toArray(String[]::new),
                         INVALID_INJECT_PARAMS_FQ);
                 for (String annotation : paramScopes) {
-                    invalidAnnotations.add("@" + getSimpleName(annotation));
+                    invalidAnnotations.add("@" + JDTUtils.getSimpleName(annotation));
                 }
             }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -29,6 +28,7 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants.*;
 
 public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollector {
@@ -333,7 +333,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                                 .map(annotation -> annotation.getQualifiedName()).toArray(String[]::new),
                         INVALID_INJECT_PARAMS_FQ);
                 for (String annotation : paramScopes) {
-                    invalidAnnotations.add("@" + JDTUtils.getSimpleName(annotation));
+                    invalidAnnotations.add("@" + getSimpleName(annotation));
                 }
             }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanQuickFix.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants.SCOPE_FQ_NAMES;
 
 public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
@@ -88,7 +89,7 @@ public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
     }
 
     private static String getLabel(String annotation) {
-        String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+        String annotationName = getSimpleName(annotation);
         return Messages.getMessage("ReplaceCurrentScope", "@" + annotationName);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -34,6 +34,8 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * QuickFix for inserting annotations.
  * Reused from https://github.com/eclipse/lsp4mp/blob/6f2d700a88a3262e39cc2ba04beedb429e162246/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -139,7 +141,7 @@ public abstract class InsertAnnotationMissingQuickFix implements IJavaCodeAction
         StringBuilder list = new StringBuilder();
         for (int i = 0; i < annotations.length; i++) {
             String annotation = annotations[i];
-            String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+            String annotationName = getSimpleName(annotation);
             if (i > 0) {
                 list.append(", "); // assume comma list is ok: @A, @B, @C
             }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -46,6 +46,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * QuickFix for removing annotations. Modified from
  * https://github.com/eclipse/lsp4mp/blob/6f2d700a88a3262e39cc2ba04beedb429e162246/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -172,7 +174,7 @@ public abstract class RemoveAnnotationConflictQuickFix implements IJavaCodeActio
         StringBuilder list = new StringBuilder();
         for (int i = 0; i < annotations.length; i++) {
             String annotation = annotations[i];
-            String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+            String annotationName = getSimpleName(annotation);
             if (i > 0) {
                 list.append(", "); // assume comma list is ok: @A, @B, @C
             }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/codeAction/proposal/quickfix/RemoveParamAnnotationQuickFix.java
@@ -32,6 +32,8 @@
  import java.util.logging.Logger;
  import java.util.logging.Level;
 
+ import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
  /**
   * QuickFix for removing parameter annotations
   */
@@ -80,9 +82,9 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
     private String getLabel(PsiParameter parameter,List<String> annotationsToRemove) {
         final StringBuilder sb = new StringBuilder();
         // Java annotations in comma delimited list, assume that is ok.
-        sb.append("@").append(getShortName(annotationsToRemove.get(0)));
+        sb.append("@").append(getSimpleName(annotationsToRemove.get(0)));
         for (int j = 1; j < annotationsToRemove.size(); ++j) {
-            sb.append(", @").append(getShortName(annotationsToRemove.get(j)));
+            sb.append(", @").append(getSimpleName(annotationsToRemove.get(j)));
         }
         return Messages.getMessage("RemoveTheModifierFromParameter", sb.toString(), parameter.getName().toString());
     }
@@ -134,13 +136,5 @@ public abstract class RemoveParamAnnotationQuickFix implements IJavaCodeActionPa
 
     protected PsiClass getBinding(PsiElement node) {
         return PsiTreeUtil.getParentOfType(node, PsiClass.class);
-    }
-
-    protected static String getShortName(String qualifiedName) {
-        final int i = qualifiedName.lastIndexOf('.');
-        if (i != -1) {
-            return qualifiedName.substring(i+1);
-        }
-        return qualifiedName;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteFilterAnnotationQuickFix.java
@@ -40,6 +40,8 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * QuickFix for fixing {@link ServletConstants#DIAGNOSTIC_CODE_FILTER_MISSING_ATTRIBUTE} error
  * and {@link ServletConstants#DIAGNOSTIC_CODE_FILTER_MISSING_ATTRIBUTE} error
@@ -168,7 +170,7 @@ public class CompleteFilterAnnotationQuickFix extends InsertAnnotationMissingQui
     }
 
     private static String getLabel(String annotation, String attribute, String labelType) {
-        String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+        String annotationName = getSimpleName(annotation);
         annotationName = "@" + annotationName;
         if (labelType.equals("Remove")) {
             return Messages.getMessage("RemoveTheAttributeFrom", attribute, annotationName);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/CompleteServletAnnotationQuickFix.java
@@ -40,6 +40,8 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * QuickFix for fixing
  * {@link ServletConstants#DIAGNOSTIC_CODE_MISSING_ATTRIBUTE} error and
@@ -163,7 +165,7 @@ public class CompleteServletAnnotationQuickFix extends InsertAnnotationMissingQu
     }
 
     private static String getLabel(String annotation, String attribute, String labelType) {
-        String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+        String annotationName = getSimpleName(annotation);
         annotationName = "@" + annotationName;
         if (labelType.equals("Remove")) {
             return Messages.getMessage("RemoveTheAttributeFrom", attribute, annotationName);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/servlet/ListenerImplementationQuickFix.java
@@ -40,6 +40,8 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpleName;
+
 /**
  * QuickFix for fixing HttpServlet extension error by providing the code actions
  * which implements IJavaCodeActionParticipant
@@ -115,7 +117,7 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
     }
 
     private static String getLabel(String fqAnnotation, PsiClass parentType) {
-        String annotationName = fqAnnotation.substring(fqAnnotation.lastIndexOf('.') + 1, fqAnnotation.length());
+        String annotationName = getSimpleName(fqAnnotation);
         return Messages.getMessage("LetClassImplement", parentType.getName(), annotationName);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1095