### PR TITLE
LSP4Jakarta: Remove obsolete comments from unit tests

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -60,8 +60,6 @@ public class ResourceAnnotationTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
-        //TODO: uncomment this if condition, once refactoring is done for all the quick fixes.
-//        if (CHECK_CODE_ACTIONS) {
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d1);
         String newText = "package io.openliberty.sample.jakarta.annotations;\n\nimport jakarta.annotation.Resource;" +
                 "\n\n@Resource(type = Object.class, name = \"aa\")\npublic class ResourceAnnotation " +
@@ -92,6 +90,5 @@ public class ResourceAnnotationTest extends BaseJakartaTest {
         TextEdit te1 = te(0, 0, 45, 0, newText);
         CodeAction ca1 = ca(uri, "Add name to jakarta.annotation.Resource", d2, te1);
         assertJavaCodeAction(codeActionParams1, utils, ca1);
-//        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/ResourceAnnotationTest.java
@@ -26,7 +26,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -119,8 +119,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        //TODO: Uncomment this line of code once all the quickfix changes are done.
-//        if (CHECK_CODE_ACTIONS) {
         // Assert for the diagnostic d1
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
         String newText = "package io.openliberty.sample.jakarta.cdi;\n\nimport java.util.Collections;" +
@@ -187,7 +185,6 @@ public class ManagedBeanTest extends BaseJakartaTest {
         CodeAction ca5 = ca(uri, "Remove @RequestScoped", d3, te5);
         CodeAction ca6 = ca(uri, "Remove @ApplicationScoped", d3, te6);
         assertJavaCodeAction(codeActionParams3, utils, ca6, ca5);
-//        }
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/di/DependencyInjectionTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -91,7 +91,6 @@ public class ResourceMethodTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        //if (CHECK_CODE_ACTIONS) {
         // Test for quick-fix code action
         JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
         String newText1 = "/*******************************************************************************\n" +
@@ -131,7 +130,6 @@ public class ResourceMethodTest extends BaseJakartaTest {
         CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d, te2);
 
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
-        //}
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -174,8 +174,6 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8);
 
-        //TODO: Uncomment this line of code once all the quickfix changes are done.
-//        if (CHECK_CODE_ACTIONS) {
         // Test code actions
         // Quick fix for the field "id"
         JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, d1);
@@ -440,6 +438,5 @@ public class JsonbDiagnosticsCollectorTest extends BaseJakartaTest {
         TextEdit te8 = JakartaForJavaAssert.te(0, 0, 77, 1, newText);
         CodeAction ca8 = JakartaForJavaAssert.ca(uri, "Remove @JsonbAnnotation", d6, te8);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, ca8);
-//        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonb/JsonbDiagnosticsCollectorTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -24,7 +24,6 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSIm
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -57,8 +57,6 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        //TODO: this condition will be enabled when all quickfixes are refactored.
-        // if (CHECK_CODE_ACTIONS) {
         // test associated quick-fix code action
         JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
         String newText = "package io.openliberty.sample.jakarta.servlet;\n\n" +
@@ -69,7 +67,6 @@ public class JakartaServletTest extends BaseJakartaTest {
         TextEdit te = JakartaForJavaAssert.te(0, 0, 7, 1, newText);
         CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontExtendHttpServlet' extend 'HttpServlet'", d, te);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
-        // }
     }
 
     @Test
@@ -237,8 +234,7 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        //TODO: this condition will be enabled when all quickfixes are refactored.
-//        if (CHECK_CODE_ACTIONS) {
+
             // test associated quick-fix code action
             JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
             String newText = "package io.openliberty.sample.jakarta.servlet;" +
@@ -249,7 +245,6 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontImplementFilter' implement 'Filter'", d, te);
             JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca);
-//        }
     }
 
     @Test
@@ -269,8 +264,6 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-        //TODO: this condition will be enabled when all quickfixes are refactored.
-//        if (CHECK_CODE_ACTIONS) {
         // test associated quick-fix code action
         JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
 
@@ -318,5 +311,4 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2, ca3, ca4, ca5, ca6, ca7);
     }
-//    }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/servlet/JakartaServletTest.java
@@ -234,13 +234,12 @@ public class JakartaServletTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
 
-
-            // test associated quick-fix code action
-            JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
-            String newText = "package io.openliberty.sample.jakarta.servlet;" +
-                    "\n\nimport jakarta.servlet.Filter;\nimport jakarta.servlet.annotation.WebFilter;" +
-                    "\n\n@WebFilter(urlPatterns = {\"/filter\"})\npublic class DontImplementFilter implements " +
-                    "Filter {\n\n}";
+        // test associated quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
+        String newText = "package io.openliberty.sample.jakarta.servlet;" +
+                "\n\nimport jakarta.servlet.Filter;\nimport jakarta.servlet.annotation.WebFilter;" +
+                "\n\n@WebFilter(urlPatterns = {\"/filter\"})\npublic class DontImplementFilter implements " +
+                "Filter {\n\n}";
         TextEdit te = JakartaForJavaAssert.te(0, 0, 7, 1, newText);
 
         CodeAction ca = JakartaForJavaAssert.ca(uri, "Let 'DontImplementFilter' implement 'Filter'", d, te);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -71,8 +71,6 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         );
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        //TODO: uncomment this if condition, once refactoring is done for all the quick fixes.
-//        if (CHECK_CODE_ACTIONS) {
         // Expected code actions
         JakartaJavaCodeActionParams codeActionsParams = createCodeActionParams(uri, d1);
         String newText = "package io.openliberty.sample.jakarta.websocket;\n\nimport java.io.IOException;" +
@@ -91,7 +89,6 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         TextEdit te = te(0, 0, 28, 0, newText);
         CodeAction ca = ca(uri, "Insert @jakarta.websocket.server.PathParam", d1, te);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionsParams, utils, ca);
-//        }
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1142

Also took the opportunity to clean up unused imports and to fix the indentation of code in one of the test methods.