### PR TITLE
Reformat messages concerning missing test report files

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -64,10 +64,9 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
         }
 
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
-            String displayNames = reportNameNo1 + " or " + reportNameNo2;
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("integration.test.report.does.not.exist.notification.title"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", displayNames),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist.multiple.locations", reportNameNo1, reportNameNo2),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
             Notifications.Bus.notify(notif, project);

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -53,21 +53,22 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
 
         // Dev mode runs the tests and it may have selected a report generator that uses one location and filename or another depending on the version number
         // Maven plugin maven-surefire-report-plugin v3.5 and above use this location and filename
+        String reportNameNo1 = "", reportNameNo2 = "";
         File failsafeReportFile = getReportFile(parentFile, "reports", "failsafe.html");
-        List<String> reportNames = new ArrayList<>();
-        reportNames.add(parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString());
+        reportNameNo1 = parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString();
         VirtualFile failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
             // Maven plugin maven-surefire-report-plugin v3.4 and below use this location and filename
             failsafeReportFile = getReportFile(parentFile, "site", "failsafe-report.html");
-            reportNames.add(parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString());
+            reportNameNo2 = parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString();
             failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
         }
 
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
+            String displayNames = reportNameNo1 + " or " + reportNameNo2;
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("integration.test.report.does.not.exist.notification.title"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", reportNames),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", displayNames),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
             Notifications.Bus.notify(notif, project);

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ViewIntegrationTestReport extends LibertyGeneralAction {

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ViewIntegrationTestReport extends LibertyGeneralAction {
@@ -53,17 +54,20 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
         // Dev mode runs the tests and it may have selected a report generator that uses one location and filename or another depending on the version number
         // Maven plugin maven-surefire-report-plugin v3.5 and above use this location and filename
         File failsafeReportFile = getReportFile(parentFile, "reports", "failsafe.html");
+        List<String> reportNames = new ArrayList<>();
+        reportNames.add(parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString());
         VirtualFile failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
             // Maven plugin maven-surefire-report-plugin v3.4 and below use this location and filename
             failsafeReportFile = getReportFile(parentFile, "site", "failsafe-report.html");
+            reportNames.add(parentFile.toNioPath().relativize(failsafeReportFile.toPath()).toString());
             failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
         }
 
         if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("integration.test.report.does.not.exist.notification.title"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", failsafeReportFile.getAbsolutePath()),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", reportNames),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
             Notifications.Bus.notify(notif, project);

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -87,9 +87,10 @@ public class ViewTestReport extends LibertyGeneralAction {
 
         VirtualFile testReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(testReportFile);
         if (testReportVirtualFile == null || !testReportVirtualFile.exists()) {
+            String displayName = parentFile.toNioPath().relativize(testReportFile.toPath()).toString();
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("gradle.test.report.does.not.exist"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", testReportFile.getAbsolutePath()),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", displayName),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -64,10 +64,9 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
         }
 
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
-            String displayNames = reportNameNo1 + " or " + reportNameNo2;
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("unit.test.report.does.not.exist"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", displayNames),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist.multiple.locations", reportNameNo1, reportNameNo2),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ViewUnitTestReport extends LibertyGeneralAction {

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ViewUnitTestReport extends LibertyGeneralAction {
@@ -53,17 +54,20 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
         // Dev mode runs the tests and it may have selected a report generator that uses one location or another depending on the version number
         // Maven plugin maven-surefire-report-plugin v3.5 and above use this location
         File surefireReportFile = getReportFile(parentFile, "reports", "surefire.html");
+        List<String> reportNames = new ArrayList<>();
+        reportNames.add(parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString());
         VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
             // Maven plugin maven-surefire-report-plugin v3.4 and below use this location
             surefireReportFile = getReportFile(parentFile,"site", "surefire-report.html");
+            reportNames.add(parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString());
             surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
         }
 
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("unit.test.report.does.not.exist"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", surefireReportFile.getAbsolutePath()),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", reportNames),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -53,21 +53,22 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
 
         // Dev mode runs the tests and it may have selected a report generator that uses one location or another depending on the version number
         // Maven plugin maven-surefire-report-plugin v3.5 and above use this location
+        String reportNameNo1 = "", reportNameNo2 = "";
         File surefireReportFile = getReportFile(parentFile, "reports", "surefire.html");
-        List<String> reportNames = new ArrayList<>();
-        reportNames.add(parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString());
+        reportNameNo1 = parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString();
         VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
             // Maven plugin maven-surefire-report-plugin v3.4 and below use this location
             surefireReportFile = getReportFile(parentFile,"site", "surefire-report.html");
-            reportNames.add(parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString());
+            reportNameNo2 = parentFile.toNioPath().relativize(surefireReportFile.toPath()).toString();
             surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
         }
 
         if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
+            String displayNames = reportNameNo1 + " or " + reportNameNo2;
             Notification notif = new Notification(Constants.LIBERTY_DEV_DASHBOARD_ID,
                     LocalizedResourceUtil.getMessage("unit.test.report.does.not.exist"),
-                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", reportNames),
+                    LocalizedResourceUtil.getMessage("test.report.does.not.exist", displayNames),
                     NotificationType.ERROR);
             notif.setIcon(LibertyPluginIcons.libertyIcon);
 

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -100,7 +100,7 @@ view.gradle.config.file=view Gradle configuration file
 liberty.tool.window.display.name=Projects
 
 # Test report actions
-test.report.does.not.exist= The ({0}) test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location.
+test.report.does.not.exist= The test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location.  ({0})
 
 # View integration test report action
 view.integration.test.report=view integration test report

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -101,6 +101,7 @@ liberty.tool.window.display.name=Projects
 
 # Test report actions
 test.report.does.not.exist= The test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location: {0}
+test.report.does.not.exist.multiple.locations= The test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location: {0} or {1}
 
 # View integration test report action
 view.integration.test.report=view integration test report

--- a/src/main/resources/messages/LibertyBundles.properties
+++ b/src/main/resources/messages/LibertyBundles.properties
@@ -100,7 +100,7 @@ view.gradle.config.file=view Gradle configuration file
 liberty.tool.window.display.name=Projects
 
 # Test report actions
-test.report.does.not.exist= The test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location.  ({0})
+test.report.does.not.exist= The test report does not exist. Run tests to generate a test report. Ensure that your test report is generating at the correct location: {0}
 
 # View integration test report action
 view.integration.test.report=view integration test report


### PR DESCRIPTION
Fixes #978

The absolute path is so long you can barely understand what the good part is and what the bad part is. These file names are now relative to the project base directory so you can review them and navigate to the directory in your project to investigate.