### PR TITLE
Disable the native launcher warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,7 @@ intellijPlatformTesting.runIde {
                         "-Dapple.laf.useScreenMenuBar=false",
                 ]
             } as CommandLineArgumentProvider)
+            systemProperty("ide.native.launcher", "true")
         }
         plugins {
             robotServerPlugin(remoteRobotVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,7 @@ intellijPlatformTesting.runIde {
                         "java.base/jdk.internal.vm=ALL-UNNAMED"
                 ]
             } as CommandLineArgumentProvider)
+            systemProperty("ide.native.launcher", "true")
         }
     }
 }


### PR DESCRIPTION
Fixes #1087

Disabled the native launcher warning that appears in the Windows and Linux Welcome frames. Once this fix is merged, it will prevent UI test failures caused by this warning.