### PR TITLE
#1127 mac UI test integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
         options.fork = true
-        options.forkOptions.memoryMaximumSize = "4g"
+        options.forkOptions.memoryMaximumSize = "2g"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,11 @@ def lsp4ijVersion = '0.7.0'
 allprojects {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
-    tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+        options.fork = true
+        options.forkOptions.memoryMaximumSize = "4g"
+    }
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=2024.2.5
+ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=2024.3
+ideTargetVersion=2024.2.5
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -62,7 +62,9 @@ public abstract class SingleModLibertyLSTestCommon {
         UIBotTestUtils.closeFileEditorTab(remoteRobot, "server.xml", "5");
         UIBotTestUtils.closeFileEditorTab(remoteRobot, "server.env", "5");
         UIBotTestUtils.closeFileEditorTab(remoteRobot, "bootstrap.properties", "5");
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         UIBotTestUtils.closeProjectView(remoteRobot);
         UIBotTestUtils.closeProjectFrame(remoteRobot);
         UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
@@ -400,7 +402,9 @@ public abstract class SingleModLibertyLSTestCommon {
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -66,7 +66,9 @@ public abstract class SingleModMPLSTestCommon {
 
         UIBotTestUtils.closeFileEditorTab(remoteRobot, "ServiceLiveHealthCheck.java", "5");
         UIBotTestUtils.closeFileEditorTab(remoteRobot, "microprofile-config.properties", "5");
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         UIBotTestUtils.closeProjectView(remoteRobot);
         UIBotTestUtils.closeProjectFrame(remoteRobot);
         UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
@@ -329,7 +331,9 @@ public abstract class SingleModMPLSTestCommon {
 
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -1149,7 +1149,12 @@ public abstract class SingleModMPProjectTestCommon {
         // Closing the build file editor here prevents it from opening automatically when the project
         // in the Liberty tool window is clicked or right-clicked again. This is done on purpose to
         // prevent false negative tests related to the build file editor tab.
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
+        if (remoteRobot.isMac()) {
+            UIBotTestUtils.closeAllEditorTabs(remoteRobot);
+        }
+        else {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
+        }
 
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
                 "prepareEnv. Exit. ProjectName: " + projectName);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -294,7 +294,9 @@ public abstract class SingleModMPProjectTestCommon {
      */
     protected static void closeProjectView() {
         UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);
         UIBotTestUtils.closeProjectView(remoteRobot);
         UIBotTestUtils.closeProjectFrame(remoteRobot);
@@ -1136,7 +1138,9 @@ public abstract class SingleModMPProjectTestCommon {
         UIBotTestUtils.findWelcomeFrame(remoteRobot);
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openAndValidateLibertyToolWindow(remoteRobot, projectName);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -293,8 +293,8 @@ public abstract class SingleModMPProjectTestCommon {
      * Close project.
      */
     protected static void closeProjectView() {
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
         if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
             UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
         }
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModNLTRestProjectTestCommon.java
@@ -84,7 +84,9 @@ public abstract class SingleModNLTRestProjectTestCommon {
      */
     @AfterAll
     public static void cleanup() {
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         UIBotTestUtils.closeLibertyToolWindow(remoteRobot);
         UIBotTestUtils.closeProjectView(remoteRobot);
         UIBotTestUtils.closeProjectFrame(remoteRobot);
@@ -299,7 +301,9 @@ public abstract class SingleModNLTRestProjectTestCommon {
         UIBotTestUtils.findWelcomeFrame(remoteRobot);
         UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
         UIBotTestUtils.openProjectView(remoteRobot);
-        UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
         // IntelliJ does not start building and indexing until the Project View is open
         UIBotTestUtils.waitForIndexing(remoteRobot);
         UIBotTestUtils.openLibertyToolWindow(remoteRobot);

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -577,6 +577,10 @@ public class TestUtils {
      */
     public static void detectFatalError() {
         final String outputFile = System.getenv("JUNIT_OUTPUT_TXT");
+        if (outputFile == null) {
+            System.err.println("ERROR: Environment variable 'JUNIT_OUTPUT_TXT' is not set.");
+            return; // Exit the method gracefully or handle the missing file scenario
+        }
         try {
             final BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(outputFile)));
             // Flush our output and then wait briefly for the process running 'tee' to flush output to the

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -124,14 +124,16 @@ public class UIBotTestUtils {
             // From the project frame.
             ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
             commonFixture = projectFrame;
-
+            String openAction = null;
             if (remoteRobot.isMac()) {
-                handleMenuBasedOnVersion(remoteRobot, "File", "Open...", "Open…");
+                openAction = handleMenuBasedOnVersion(remoteRobot, "Open...", "Open…");
+                projectFrame.clickOnMainMenuWithActions(remoteRobot, "File", openAction);
             } else {
                 clickOnMainMenu(remoteRobot);
                 ComponentFixture fileMenuEntry = projectFrame.getActionMenu("File", "10");
                 fileMenuEntry.moveMouse();
-                ComponentFixture openFixture = projectFrame.getActionMenuItem("Open...");
+                openAction = handleMenuBasedOnVersion(remoteRobot, "Open...", "Open…");
+                ComponentFixture openFixture = projectFrame.getActionMenuItem(openAction);
                 openFixture.click(new Point());
             }
         }
@@ -1451,6 +1453,7 @@ public class UIBotTestUtils {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         if (remoteRobot.isMac()) {
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
+            projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Copy");
         }
         else {
             clickOnMainMenu(remoteRobot);
@@ -1458,13 +1461,7 @@ public class UIBotTestUtils {
             editMenuEntry.moveMouse();
             ComponentFixture slectAllEntry = projectFrame.getActionMenuItem("Select All");
             slectAllEntry.click();
-        }
 
-        // Copy the content.
-        if (remoteRobot.isMac()) {
-            projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Copy");
-        }
-        else {
             clickOnMainMenu(remoteRobot);
             ComponentFixture editMenuEntryNew = projectFrame.getActionMenu("Edit", "10");
             editMenuEntryNew.moveMouse();
@@ -1938,14 +1935,17 @@ public class UIBotTestUtils {
      */
     public static void createLibertyConfiguration(RemoteRobot remoteRobot, String cfgName) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
+        String editConfigurationAction= null;
         if (remoteRobot.isMac()) {
-            handleMenuBasedOnVersion(remoteRobot, "Run", "Edit Configurations...", "Edit Configurations…");
+            editConfigurationAction = handleMenuBasedOnVersion(remoteRobot, "Edit Configurations...", "Edit Configurations…");
+            projectFrame.clickOnMainMenuWithActions(remoteRobot, "Run", editConfigurationAction);
         }
         else {
             clickOnMainMenu(remoteRobot);
             ComponentFixture runMenu = projectFrame.getActionMenu("Run", "10");
             runMenu.moveMouse();
-            ComponentFixture editCfgsMenuEntry = projectFrame.getActionMenuItem("Edit Configurations…");
+            editConfigurationAction = handleMenuBasedOnVersion(remoteRobot, "Edit Configurations...", "Edit Configurations…");
+            ComponentFixture editCfgsMenuEntry = projectFrame.getActionMenuItem(editConfigurationAction);
             editCfgsMenuEntry.click();
         }
 
@@ -2198,10 +2198,12 @@ public class UIBotTestUtils {
      */
     public static void selectConfigUsingMenu(RemoteRobot remoteRobot, String cfgName, ExecMode execMode) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
+        String debugOrRunAction = null;
         if (remoteRobot.isMac()) {
             for (int attempt = 0; attempt < 5; attempt++) { // Retry up to 5 times
                 try {
-                    handleMenuBasedOnVersion(remoteRobot, "Run", execMode == ExecMode.DEBUG ? "Debug..." : "Run...", execMode == ExecMode.DEBUG ? "Debug…" : "Run…");
+                    debugOrRunAction = handleMenuBasedOnVersion(remoteRobot,  execMode == ExecMode.DEBUG ? "Debug..." : "Run...", execMode == ExecMode.DEBUG ? "Debug…" : "Run…");
+                    projectFrame.clickOnMainMenuWithActions(remoteRobot, "Run", debugOrRunAction);
                     // Exit loop if successful
                     break;
                 } catch (WaitForConditionTimeoutException e) {
@@ -2219,9 +2221,11 @@ public class UIBotTestUtils {
             clickOnMainMenu(remoteRobot);
             ComponentFixture menuOption = projectFrame.getActionMenu("Run", "10");
             menuOption.moveMouse();
-            ComponentFixture menuCfgExecOption = projectFrame.getActionMenuItem("Run…");
+            debugOrRunAction= handleMenuBasedOnVersion(remoteRobot, "Run...", "Run…");
+            ComponentFixture menuCfgExecOption = projectFrame.getActionMenuItem(debugOrRunAction);
             if (execMode == ExecMode.DEBUG) {
-                menuCfgExecOption = projectFrame.getActionMenuItem("Debug…");
+                debugOrRunAction = handleMenuBasedOnVersion(remoteRobot, "Debug...", "Debug…");
+                menuCfgExecOption = projectFrame.getActionMenuItem(debugOrRunAction);
             }
 
             menuCfgExecOption.click();
@@ -2271,14 +2275,17 @@ public class UIBotTestUtils {
      */
     public static void deleteLibertyRunConfigurations(RemoteRobot remoteRobot) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
+        String editConfigurationAction = null;
         if (remoteRobot.isMac()) {
-            handleMenuBasedOnVersion(remoteRobot, "Run", "Edit Configurations...", "Edit Configurations…");
+            editConfigurationAction = handleMenuBasedOnVersion(remoteRobot, "Edit Configurations...", "Edit Configurations…");
+            projectFrame.clickOnMainMenuWithActions(remoteRobot, "Run", editConfigurationAction);
         }
         else {
             clickOnMainMenu(remoteRobot);
             ComponentFixture runMenu = projectFrame.getActionMenu("Run", "10");
             runMenu.moveMouse();
-            ComponentFixture editCfgsMenuEntry = projectFrame.getActionMenuItem("Edit Configurations…");
+            editConfigurationAction = handleMenuBasedOnVersion(remoteRobot, "Edit Configurations...", "Edit Configurations…");
+            ComponentFixture editCfgsMenuEntry = projectFrame.getActionMenuItem(editConfigurationAction);
             editCfgsMenuEntry.click();
         }
 
@@ -2702,12 +2709,11 @@ public class UIBotTestUtils {
      * Handles version-specific menu actions based on the IntelliJ IDEA version.
      *
      * @param remoteRobot        Instance of the RemoteRobot to interact with the IntelliJ UI.
-     * @param menuAction1        The name of the menu item (e.g., "Run").
      * @param menuAction2024_2   The submenu option for IntelliJ version 2024.2.
      * @param menuAction2024_3   The submenu option for IntelliJ version 2024.3.
      * @throws UnsupportedOperationException if the IntelliJ version is not supported.
      */
-    public static void handleMenuBasedOnVersion(RemoteRobot remoteRobot, String menuAction1, String menuAction2024_2, String menuAction2024_3) {
+    public static String handleMenuBasedOnVersion(RemoteRobot remoteRobot, String menuAction2024_2, String menuAction2024_3) {
         // Using Remote robot's javascript API Retrieve the IntelliJ version
         String intellijVersion = remoteRobot.callJs("com.intellij.openapi.application.ApplicationInfo.getInstance().getFullVersion();");
 
@@ -2721,9 +2727,7 @@ public class UIBotTestUtils {
             throw new UnsupportedOperationException("Unsupported IntelliJ version: " + intellijVersion);
         }
 
-        // Perform the menu navigation ny locating project frame using the determined submenu option.
-        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
-        projectFrame.clickOnMainMenuWithActions(remoteRobot, menuAction1, menuAction2);
+        return menuAction2;
     }
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -215,11 +215,13 @@ public class UIBotTestUtils {
      */
     public static void closeProjectFrame(RemoteRobot remoteRobot) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
-        // minimize windows os intellij ide to default state
+
         if (remoteRobot.isMac()) {
+            // Click on File on the Menu bar.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "File", "Close Project");
         }
         else {
+            // minimize windows os intellij ide to default state
             if (remoteRobot.isWin()) {
                 minimizeWindow(remoteRobot);
             }

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -49,8 +49,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class UIBotTestUtils {
 
-    private static final Logger log = LoggerFactory.getLogger(UIBotTestUtils.class);
-
     /**
      * Print destination types.
      */

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1447,17 +1447,21 @@ public class UIBotTestUtils {
     public static void copyWindowContent(RemoteRobot remoteRobot) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         if (remoteRobot.isMac()) {
+            // Select the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
+            // Copy the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Copy");
         }
         else {
             clickOnMainMenu(remoteRobot);
+            // Select the content.
             ComponentFixture editMenuEntry = projectFrame.getActionMenu("Edit", "10");
             editMenuEntry.moveMouse();
             ComponentFixture slectAllEntry = projectFrame.getActionMenuItem("Select All");
             slectAllEntry.click();
 
             clickOnMainMenu(remoteRobot);
+            // Copy the content.
             ComponentFixture editMenuEntryNew = projectFrame.getActionMenu("Edit", "10");
             editMenuEntryNew.moveMouse();
             ComponentFixture copyEntry = projectFrame.getActionMenuItem("Copy");
@@ -1475,16 +1479,20 @@ public class UIBotTestUtils {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
 
         if (remoteRobot.isMac()) {
+            // Select the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
+            // Delete/Clear the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Delete");
         }
         else {
             clickOnMainMenu(remoteRobot);
+            // Select the content.
             ComponentFixture editMenuEntry = projectFrame.getActionMenu("Edit", "10");
             editMenuEntry.moveMouse();
             ComponentFixture selectAllEntry = projectFrame.getActionMenuItem("Select All");
             selectAllEntry.click();
             clickOnMainMenu(remoteRobot);
+            // Delete/Clear the content.
             ComponentFixture editMenuEntryNew = projectFrame.getActionMenu("Edit", "10");
             editMenuEntryNew.moveMouse();
             ComponentFixture deleteEntry = projectFrame.getActionMenuItem("Delete");
@@ -1511,17 +1519,22 @@ public class UIBotTestUtils {
         }
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         if (remoteRobot.isMac()) {
+            // Select the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
+            // Paste the content.
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Paste", "Paste");
+            //Save
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "File", "Save All");
         }
         else {
             clickOnMainMenu(remoteRobot);
+            // Select the content.
             ComponentFixture editMenuEntry = projectFrame.getActionMenu("Edit", "10");
             editMenuEntry.moveMouse();
             ComponentFixture selectAllEntry = projectFrame.getActionMenuItem("Select All");
             selectAllEntry.click();
             clickOnMainMenu(remoteRobot);
+            // Paste the content.
             editMenuEntry = projectFrame.getActionMenu("Edit", "10");
             editMenuEntry.moveMouse();
             ComponentFixture pasteFixture = projectFrame.getChildActionMenu("Edit", "Paste");
@@ -1529,6 +1542,7 @@ public class UIBotTestUtils {
             ComponentFixture pasteChildEntry = projectFrame.getChildActionMenuItem("Edit", "Paste");
             pasteChildEntry.click();
             clickOnMainMenu(remoteRobot);
+            //Save
             ComponentFixture fileMenuEntry = projectFrame.getActionMenu("File", "10");
             fileMenuEntry.moveMouse();
             ComponentFixture saveAllEntry = projectFrame.getActionMenuItem("Save All");

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1445,7 +1445,6 @@ public class UIBotTestUtils {
      * @param remoteRobot The RemoteRobot instance.
      */
     public static void copyWindowContent(RemoteRobot remoteRobot) {
-        // Select the content.
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         if (remoteRobot.isMac()) {
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
@@ -1474,7 +1473,7 @@ public class UIBotTestUtils {
      */
     public static void clearWindowContent(RemoteRobot remoteRobot) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
-        // Select the content.
+
         if (remoteRobot.isMac()) {
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Delete");
@@ -1510,7 +1509,6 @@ public class UIBotTestUtils {
         if (homeCursor) {
             goToLineAndColumn(remoteRobot, new Keyboard(remoteRobot), 1, 1);
         }
-        // Select the content.
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         if (remoteRobot.isMac()) {
             projectFrame.clickOnMainMenuWithActions(remoteRobot, "Edit", "Select All");
@@ -2173,14 +2171,38 @@ public class UIBotTestUtils {
     public static void selectConfigUsingToolbar(RemoteRobot remoteRobot, String cfgName) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
         ComponentFixture cfgSelectBox = projectFrame.getRunConfigurationsComboBoxButton();
-        cfgSelectBox.click();
-        ComponentFixture cfgSelectPaneList = projectFrame.getMyList();
-        List<RemoteText> configs = cfgSelectPaneList.getData().getAll();
-        for (RemoteText cfg : configs) {
-            if (cfg.getText().equals(cfgName)) {
-                cfg.click();
-                break;
+
+        boolean configFound = false;
+        int retryCount = 0;
+        int maxRetries = 5;
+
+        while (!configFound && retryCount < maxRetries) {
+            cfgSelectBox.click();
+
+            ComponentFixture cfgSelectPaneList = projectFrame.getMyList();
+            List<RemoteText> configs = cfgSelectPaneList.getData().getAll();
+
+            if (configs != null && !configs.isEmpty()) {
+                for (RemoteText cfg : configs) {
+                    if (cfg.getText().equals(cfgName)) {
+                        cfg.click();
+                        configFound = true;
+                        break;
+                    }
+                }
             }
+            if (!configFound) {
+                retryCount++;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Thread interrupted while waiting for configuration list", e);
+                }
+            }
+        }
+        if (!configFound) {
+            throw new RuntimeException("Configuration '" + cfgName + "' not found after " + maxRetries + " attempts.");
         }
     }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -22,8 +22,6 @@ import io.openliberty.tools.intellij.it.fixtures.WelcomeFrameFixture;
 import org.assertj.swing.core.MouseButton;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -223,7 +223,7 @@ public class ProjectFrameFixture extends CommonContainerFixture {
      * Right-clicks on the terminal tab.
      */
     public static void rightClickOnTerminalTab(ProjectFrameFixture projectFrame) {
-        String terminalLabelXPath = "//div[@class='TabPanel'][.//div[@class='BaseLabel']]//div[@text='Terminal:']";
+        String terminalLabelXPath = "//div[@class='TabPanel'][.//div[@class='BaseLabel']]//div[@text='Terminal']";
         ComponentFixture terminalLabel = projectFrame.getActionButton(terminalLabelXPath, "10");
         terminalLabel.rightClick();
     }

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -14,7 +14,9 @@ import com.intellij.remoterobot.data.RemoteComponent;
 import com.intellij.remoterobot.fixtures.*;
 import com.intellij.remoterobot.search.locators.Locator;
 import com.intellij.remoterobot.utils.RepeatUtilsKt;
+import com.intellij.remoterobot.utils.WaitForConditionTimeoutException;
 import com.intellij.ui.HyperlinkLabel;
+import io.openliberty.tools.intellij.it.TestUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -353,5 +355,72 @@ public class ProjectFrameFixture extends CommonContainerFixture {
      */
     public boolean isComponentEnabled(ComponentFixture component) {
         return component.callJs("component.isEnabled();", false);
+    }
+    /**
+     * Attempts to find and click the "Main Menu" button in the project frame.
+     * If the button is not found within the timeout, an error message is logged.
+     * @param remoteRobot the instance used to interact with the UI.
+     *
+     */
+    public void clickOnMainMenu(RemoteRobot remoteRobot) {
+        ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
+        try {
+            var menuButton = projectFrame.find(ComponentFixture.class, byXpath("//div[@tooltiptext='Main Menu']"), Duration.ofSeconds(30));
+            menuButton.click();
+        } catch (WaitForConditionTimeoutException e) {
+            System.err.println("ERROR: Main menu button not found within the given timeout.");
+
+        }
+    }
+    /**
+     * Clicks on the main menu and navigates through a sequence of menu actions.
+     *
+     * @param remoteRobot the instance used to interact with the UI.
+     * @param actions      the sequence of actions to be performed in the menu hierarchy.
+     */
+    public void clickOnMainMenuWithActions(RemoteRobot remoteRobot, String... actions) {
+        boolean actionPerformed = false; // Flag to indicate success
+
+        for (int attempt = 0; attempt < 5; attempt++) {
+            try {
+                clickOnMainMenu(remoteRobot);
+
+                List<ContainerFixture> currentMenuPopup = findAll(ContainerFixture.class, byXpath("//div[@class='HeavyWeightWindow']"));
+                for (int i = 0; i < actions.length; i++) {
+                    // Wait for the menu to be displayed
+                    List<ContainerFixture> finalCurrentMenuPopup = currentMenuPopup;
+                    RepeatUtilsKt.waitFor(
+                            Duration.ofSeconds(30),
+                            Duration.ofSeconds(1),
+                            "Waiting for menu " + (i + 1) + " to get displayed",
+                            "Timeout while trying to find or interact with menu " + (i + 1) + " items.",
+                            () -> !finalCurrentMenuPopup.isEmpty());
+
+                    // Move the mouse or click on the desired menu item
+                    if (i < actions.length - 1) {
+                        currentMenuPopup.get(0).findText(actions[i]).moveMouse();
+                    } else {
+                        currentMenuPopup.get(0).findText(actions[i]).click();
+                    }
+
+                    TestUtils.sleepAndIgnoreException(3);
+
+                    // Find the next menu popup for further actions
+                    if (i < actions.length - 1) {
+                        currentMenuPopup = currentMenuPopup.get(0).findAll(ContainerFixture.class, byXpath("//div[@class='HeavyWeightWindow']"));
+                    }
+                }
+                actionPerformed = true; // Mark as successful
+                break; // Exit loop if successful
+            } catch (WaitForConditionTimeoutException e) {
+                System.err.println("Attempt " + (attempt + 1) + " failed: Timeout while trying to find or interact with menu items.");
+            } catch (Exception e) {
+                System.err.println("Attempt " + (attempt + 1) + " failed: " + e.getMessage());
+            }
+        }
+
+        if (!actionPerformed) {
+            throw new IllegalStateException("Failed to perform the menu actions after multiple attempts.");
+        }
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -379,7 +379,7 @@ public class ProjectFrameFixture extends CommonContainerFixture {
      * @param actions      the sequence of actions to be performed in the menu hierarchy.
      */
     public void clickOnMainMenuWithActions(RemoteRobot remoteRobot, String... actions) {
-        boolean actionPerformed = false; // Flag to indicate success
+        boolean actionPerformed = false;
 
         for (int attempt = 0; attempt < 5; attempt++) {
             try {
@@ -404,14 +404,12 @@ public class ProjectFrameFixture extends CommonContainerFixture {
                     }
 
                     TestUtils.sleepAndIgnoreException(3);
-
-                    // Find the next menu popup for further actions
                     if (i < actions.length - 1) {
                         currentMenuPopup = currentMenuPopup.get(0).findAll(ContainerFixture.class, byXpath("//div[@class='HeavyWeightWindow']"));
                     }
                 }
-                actionPerformed = true; // Mark as successful
-                break; // Exit loop if successful
+                actionPerformed = true;
+                break;
             } catch (WaitForConditionTimeoutException e) {
                 System.err.println("Attempt " + (attempt + 1) + " failed: Timeout while trying to find or interact with menu items.");
             } catch (Exception e) {


### PR DESCRIPTION
Fixes [#1066](https://github.com/OpenLiberty/liberty-tools-intellij/issues/1066) and [#1127](https://github.com/OpenLiberty/liberty-tools-intellij/issues/1127)
UI Code Modifications for Mac:
* Updated the UI code to support IntelliJ versions 2024.3 and 2024.2.
* Introduced conditional logic to handle UI differences between these versions, ensuring compatibility with both.
* Added conditional checks to handle differences in the UI between Mac and Windows/Linux platforms.
Issue Resolutions During Integration:
* NullPointerException in detectFatalError Method:
    * While integrating changes from the main and intellij-2024.2-support-backup branches into the updated UI code, encountered a NullPointerException when running individual UI tests locally.
    * Root Cause: The detectFatalError method relies on the presence of the junit.out file in the build folder, which is generated during CI/CD pipeline execution via the ./gradlew test command (configured using export JUNIT_OUTPUT_TXT).
    * Resolution: Added a null check to handle cases where this file is not generated during local test execution.
* Heap OutOfMemoryError in GHA:
    * Encountered a Heap OutOfMemoryError while integrating the latest JDK changes in GitHub Actions (GHA) builds.
    * Resolution: Increased memory allocation to address the issue, ensuring successful builds in GHA.