### PR TITLE
Added comment in build.gradle and developing.md for heap size

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -95,3 +95,7 @@ All translatable text should be included in the message file(s). Message paramet
 
 ### Test Videos
 To record videos for all tests, not just the failed ones, you can create a `video.properties` file in the `src/test/resources` directory and add `video.save.mode=ALL` to that file.
+### Handling Out of Memory Errors in Build or Tests
+If you encounter an "OutOfMemoryError" during compilation or running tests, it may be due to insufficient heap space for the Java process. To resolve this:
+1. Open the `build.gradle` file.
+2. Increase the `memoryMaximumSize` in the `JavaCompile` task. For example: tasks.withType(JavaCompile) { options.forkOptions.memoryMaximumSize = "4g" // Increase to 4GB or more if needed }

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -98,4 +98,4 @@ To record videos for all tests, not just the failed ones, you can create a `vide
 ### Handling Out of Memory Errors in Build or Tests
 If you encounter an "OutOfMemoryError" during compilation or running tests, it may be due to insufficient heap space for the Java process. To resolve this:
 1. Open the `build.gradle` file.
-2. Increase the `memoryMaximumSize` in the `JavaCompile` task. For example: tasks.withType(JavaCompile) { options.forkOptions.memoryMaximumSize = "4g" // Increase to 4GB or more if needed }
+2. Increase the `memoryMaximumSize` in the `JavaCompile` task. For example: `tasks.withType(JavaCompile) { options.forkOptions.memoryMaximumSize = "4g" // Increase to 4GB or more if needed }`

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ allprojects {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
         options.fork = true
+        // Increase Java heap size to avoid OutOfMemoryError during compilation or tests.
+        // This setting addresses issues where the JVM runs out of memory, particularly during
+        // large builds or tests. The '2g' value specifies a maximum heap size of 2GB
+        // (-Xmx2g), which should be enough to prevent memory exhaustion in most cases.
         options.forkOptions.memoryMaximumSize = "2g"
     }
 }


### PR DESCRIPTION
Fixes #1157 
Updated build.gradle to include a comment explaining the purpose of setting memoryMaximumSize = "2g" in JavaCompile tasks. This change addresses out-of-memory errors encountered during test compilation by setting the maximum Java heap size using the -Xmx option, ensuring sufficient heap space.
Added a note to DEVELOPING.md to guide developers on resolving potential out-of-memory errors in the future by increasing the memoryMaximumSize option in build.gradle.