### PR TITLE
Add condition check to determine if the IntelliJ window is currently full screen

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -13,6 +13,7 @@ import com.intellij.remoterobot.RemoteRobot;
 import com.intellij.remoterobot.fixtures.*;
 import com.intellij.remoterobot.fixtures.dataExtractor.RemoteText;
 import com.intellij.remoterobot.search.locators.Locator;
+import com.intellij.remoterobot.search.locators.Locators;
 import com.intellij.remoterobot.utils.Keyboard;
 import com.intellij.remoterobot.utils.RepeatUtilsKt;
 import com.intellij.remoterobot.utils.WaitForConditionTimeoutException;
@@ -2721,24 +2722,62 @@ public class UIBotTestUtils {
     /**
      * Maximizes the Intellij ProjectFrame window in Windows.
      *
+     * This method simulates pressing the Windows key + Up arrow to maximize the window,
+     * but only if the window is not already maximized.
+     *
      * @param remoteRobot The RemoteRobot instance.
      */
     public static void maximizeWindow(RemoteRobot remoteRobot) {
-        Keyboard keyboard = new Keyboard(remoteRobot);
-        keyboard.hotKey(VK_WINDOWS, VK_UP);
-        keyboard.enter();
+        if (!isFullScreen(remoteRobot)) {
+            Keyboard keyboard = new Keyboard(remoteRobot);
+            keyboard.hotKey(VK_WINDOWS, VK_UP);
+            keyboard.enter();
+        }
     }
 
     /**
      * Minimizes the Intellij ProjectFrame window in Windows.
      *
+     * This method simulates pressing the Windows key + Down arrow to minimize the window,
+     * but only if the window is currently maximized.
+     *
      * @param remoteRobot The RemoteRobot instance.
      */
     public static void minimizeWindow(RemoteRobot remoteRobot) {
-        Keyboard keyboard = new Keyboard(remoteRobot);
-        keyboard.hotKey(VK_WINDOWS, VK_DOWN);
-        keyboard.enter();
+        if (isFullScreen(remoteRobot)) {
+            Keyboard keyboard = new Keyboard(remoteRobot);
+            keyboard.hotKey(VK_WINDOWS, VK_DOWN);
+            keyboard.enter();
+        }
     }
+
+    /**
+     * Determines if the IntelliJ window is currently full screen.
+     *
+     * This method checks the size of the IntelliJ window against the screen size to
+     * decide if the window is maximized or not. If the window's width or height is
+     * greater than or equal to the screen size, it is considered full screen.
+     *
+     * @param remoteRobot The RemoteRobot instance.
+     * @return true if the IntelliJ window is full screen, false otherwise.
+     */
+    public static boolean isFullScreen(RemoteRobot remoteRobot) {
+        // Locate the IntelliJ IDEA main window
+        ComponentFixture mainWindow = remoteRobot.find(
+                ComponentFixture.class,
+                Locators.byXpath("//div[@class='IdeFrameImpl']")
+        );
+
+        // Get the screen size
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+
+        // Get the current dimensions (height and width) of the IntelliJ window.
+        int intellijWindowHeight = mainWindow.getRemoteComponent().getHeight();
+        int intellijWindowWidth = mainWindow.getRemoteComponent().getWidth();
+
+        return intellijWindowWidth >= screenSize.width || intellijWindowHeight >= screenSize.height;
+    }
+
     /**
      * Handles version-specific menu actions based on the IntelliJ IDEA version.
      *


### PR DESCRIPTION
Fixes #1165

Updated the UI test to check whether the IntelliJ IDE is already in a `maximized` or `minimized` state before performing the `maximize` or `minimize` actions on the IntelliJ IDE window. 

This fix checks the size of the IntelliJ window against the screen size to decide if the window is maximized or not. If the window's width or height is greater than or equal to the screen size, it is considered full screen.

The reason for checking whether the window's width or height is greater than or equal to the screen size is that sometimes the IntelliJ window size exceeds the screen size. In such cases, it can be considered as full screen. It is not necessary for both the width and height of the IntelliJ IDE window to be greater than or equal to the screen size; if at least one dimension exceeds the screen size, the window can be considered as full screen.

If both the width and height of the IntelliJ IDE window are less than the screen size, then the window is not in full screen.

In the below screenshot:

During Maximization Method Call:

Dimension of the Windows OS screen: 1536x864
Dimension of the IntelliJ IDE window: 1550x830
In this case, the IntelliJ IDE width is greater than the screen size, so this is considered full screen.

During Minimization Method Call:

Dimension of the Windows OS screen: 1536x864
Dimension of the IntelliJ IDE window: 1400x776
In this case, both the width and height of the IntelliJ IDE window are less than the screen size, so the IDE is not in full screen.

I tested multiple scenarios by running the same and different tests without performing a cleanup. Everything worked as expected, even though maximizing the window was not performed. Minimizing the window worked correctly and vice versa.

![Screenshot 2024-12-18 182613](https://github.com/user-attachments/assets/f44e90e3-2cac-4851-9e34-a74eb032476c)

