### PR TITLE
Add automated UI tests for case insensitive matching of completion items 

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -163,11 +163,12 @@ public abstract class SingleModLibertyLSTestCommon {
 
     /**
      * Tests liberty-ls type ahead support in server.env for a
-     * Liberty Server Configuration Stanza
+     * Liberty Server Configuration Stanza and
+     * providing completion suggestions in uppercase letters.
      */
     @Test
     @Video
-    public void testInsertLibertyConfigIntoServerEnv() {
+    public void testInsertLibertyConfigIntoServerEnvForCapitalCase() {
         String envCfgSnippet = "WLP_LOGGING_CON";
         String envCfgNameChooserSnippet = "FORMAT";
         String envCfgValueSnippet = "SIM";
@@ -247,11 +248,12 @@ public abstract class SingleModLibertyLSTestCommon {
 
     /**
      * Tests liberty-ls type ahead support in bootstrap.properties for a
-     * Liberty Server Configuration booststrap.properties entry
+     * Liberty Server Configuration bootstrap.properties entry and
+     * providing completion suggestions in lowercase letters.
      */
     @Test
     @Video
-    public void testInsertLibertyConfigIntoBootstrapProps() {
+    public void testInsertLibertyConfigIntoBootstrapPropsForLowerCase() {
         String configNameSnippet = "com.ibm.ws.logging.con";
         String configNameChooserSnippet = "format";
         String configValueSnippet = "TBA";

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -243,7 +243,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -272,7 +271,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -301,7 +299,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -330,7 +327,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -402,7 +398,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -440,8 +435,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot, true);
         }
-
-
     }
 
     /**
@@ -472,7 +465,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**
@@ -503,7 +495,6 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
-
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -190,6 +190,63 @@ public abstract class SingleModLibertyLSTestCommon {
     }
 
     /**
+     * Tests Liberty-LS support in server.env for
+     * providing completion suggestions in lowercase letters.
+     */
+    @Test
+    @Video
+    public void testInsertLibertyConfigIntoServerEnvForLowerCase() {
+        String envCfgSnippetLowerCase = "wlp_logging_con";
+        String envCfgNameChooserSnippet = "FORMAT";
+        String envCfgValueSnippet = "sim";
+        String expectedServerEnvString = "WLP_LOGGING_CONSOLE_FORMAT=SIMPLE";
+
+        // get focus on server.env tab prior to copy
+        UIBotTestUtils.clickOnFileTab(remoteRobot, "server.env");
+
+        // Save the current server.env content.
+        UIBotTestUtils.copyWindowContent(remoteRobot);
+
+        try {
+            UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "server.env", envCfgSnippetLowerCase, envCfgNameChooserSnippet, envCfgValueSnippet, true);
+            Path pathToServerEnv = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "server.env");
+            TestUtils.validateStringInFile(pathToServerEnv.toString(), expectedServerEnvString);
+        } finally {
+            // Replace server.xml content with the original content
+            UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
+        }
+    }
+
+    /**
+     * Tests Liberty-LS support in server.env for providing completion
+     * suggestions in a mix of uppercase and lowercase letters.
+     */
+    @Test
+    @Video
+    public void testInsertLibertyConfigIntoServerEnvForMixOfCases() {
+        String envCfgSnippetMixCase = "wLp_LOgginG_coN";
+        String envCfgNameChooserSnippet = "FORMAT";
+        String envCfgValueSnippet = "sIM";
+        String expectedServerEnvString = "WLP_LOGGING_CONSOLE_FORMAT=SIMPLE";
+
+        // get focus on server.env tab prior to copy
+        UIBotTestUtils.clickOnFileTab(remoteRobot, "server.env");
+
+        // Save the current server.env content.
+        UIBotTestUtils.copyWindowContent(remoteRobot);
+
+        try {
+            UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "server.env", envCfgSnippetMixCase, envCfgNameChooserSnippet, envCfgValueSnippet, true);
+            Path pathToServerEnv = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "server.env");
+            TestUtils.validateStringInFile(pathToServerEnv.toString(), expectedServerEnvString);
+        } finally {
+            // Replace server.xml content with the original content
+            UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
+        }
+
+    }
+
+    /**
      * Tests liberty-ls type ahead support in bootstrap.properties for a
      * Liberty Server Configuration booststrap.properties entry
      */
@@ -215,6 +272,65 @@ public abstract class SingleModLibertyLSTestCommon {
             // Replace server.xml content with the original content
             UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
         }
+
+    }
+
+    /**
+     * Tests Liberty-LS support in bootstrap.properties for
+     * providing completion suggestions in capital case letters.
+     */
+    @Test
+    @Video
+    public void testInsertLibertyConfigIntoBootstrapPropsForCapitalCase() {
+        String configNameSnippetUpperCase = "COM.IBM.WS.LOGGING.CON";
+        String configNameChooserSnippet = "format";
+        String configValueSnippet = "tba";
+        String expectedBootstrapPropsString = "com.ibm.ws.logging.console.format=TBASIC";
+
+        // get focus on bootstrap.properties tab prior to copy
+        UIBotTestUtils.clickOnFileTab(remoteRobot, "bootstrap.properties");
+
+        // Save the current bootstrap.properties content.
+        UIBotTestUtils.copyWindowContent(remoteRobot);
+
+        try {
+            UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "bootstrap.properties", configNameSnippetUpperCase, configNameChooserSnippet, configValueSnippet, true);
+            Path pathToBootstrapProps = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "bootstrap.properties");
+            TestUtils.validateStringInFile(pathToBootstrapProps.toString(), expectedBootstrapPropsString);
+        } finally {
+            // Replace server.xml content with the original content
+            UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
+        }
+
+    }
+
+    /**
+     * Tests Liberty-LS support in bootstrap.properties for providing completion
+     * suggestions in a mix of uppercase and lowercase letters.
+     */
+    @Test
+    @Video
+    public void testInsertLibertyConfigIntoBootstrapPropsForMixOfCases() {
+        String configNameSnippetMixCase = "CoM.Ibm.wS.LoGginG.cON";
+        String configNameChooserSnippet = "format";
+        String configValueSnippet = "Tba";
+        String expectedBootstrapPropsString = "com.ibm.ws.logging.console.format=TBASIC";
+
+        // get focus on bootstrap.properties tab prior to copy
+        UIBotTestUtils.clickOnFileTab(remoteRobot, "bootstrap.properties");
+
+        // Save the current bootstrap.properties content.
+        UIBotTestUtils.copyWindowContent(remoteRobot);
+
+        try {
+            UIBotTestUtils.insertConfigIntoConfigFile(remoteRobot, "bootstrap.properties", configNameSnippetMixCase, configNameChooserSnippet, configValueSnippet, true);
+            Path pathToBootstrapProps = Paths.get(projectsPath, projectName, "src", "main", "liberty", "config", "bootstrap.properties");
+            TestUtils.validateStringInFile(pathToBootstrapProps.toString(), expectedBootstrapPropsString);
+        } finally {
+            // Replace server.xml content with the original content
+            UIBotTestUtils.pasteOnActiveWindow(remoteRobot);
+        }
+
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation.
+ * Copyright (c) 2023, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1109,15 +1109,15 @@ public class UIBotTestUtils {
 
         String configNameSnippet = "";
         if (fileName.equals("server.env")) {
-            configNameSnippet = configNameSnippetCaseSpecific.toUpperCase();
+            configNameSnippet = configNameSnippetCaseSpecific.toUpperCase(java.util.Locale.ROOT);
         }
         else if (fileName.equals("bootstrap.properties")) {
-            configNameSnippet = configNameSnippetCaseSpecific.toLowerCase();
+            configNameSnippet = configNameSnippetCaseSpecific.toLowerCase(java.util.Locale.ROOT);
         }
         else {
             configNameSnippet = configNameSnippetCaseSpecific;
         }
-        String configValueSnippetUpperCase = configValueSnippet.toUpperCase();
+        String configValueSnippetUpperCase = configValueSnippet.toUpperCase(java.util.Locale.ROOT);
 
         for (int i = 0; i < 10; i++) {
             error = null;

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1096,18 +1096,30 @@ public class UIBotTestUtils {
      *
      * @param remoteRobot              The RemoteRobot instance.
      * @param fileName                 The string path to the config file
-     * @param configNameSnippet        the portion of the name to type
+     * @param configNameSnippetCaseSpecific        the portion of the name to type
      * @param configNameChooserSnippet the portion of the name to use for selecting from popup menu
      * @param configValueSnippet       the value to type into keyboard - could be a snippet or a whole word
      * @param completeWithPopup        use popup to complete value selection or type in an entire provided value string
      */
-    public static void insertConfigIntoConfigFile(RemoteRobot remoteRobot, String fileName, String configNameSnippet, String configNameChooserSnippet, String configValueSnippet, boolean completeWithPopup) {
+    public static void insertConfigIntoConfigFile(RemoteRobot remoteRobot, String fileName, String configNameSnippetCaseSpecific, String configNameChooserSnippet, String configValueSnippet, boolean completeWithPopup) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));
         clickOnFileTab(remoteRobot, fileName);
         EditorFixture editorNew = remoteRobot.find(EditorFixture.class, EditorFixture.Companion.getLocator());
         Exception error = null;
 
-        for (int i = 0; i < 10; i++) {
+        String configNameSnippet = "";
+        if (fileName.equals("server.env")) {
+            configNameSnippet = configNameSnippetCaseSpecific.toUpperCase();
+        }
+        else if (fileName.equals("bootstrap.properties")) {
+            configNameSnippet = configNameSnippetCaseSpecific.toLowerCase();
+        }
+        else {
+            configNameSnippet = configNameSnippetCaseSpecific;
+        }
+        String configValueSnippetUpperCase = configValueSnippet.toUpperCase();
+
+        for (int i = 0; i < 2; i++) {
             error = null;
             try {
                 editorNew.click();
@@ -1118,7 +1130,7 @@ public class UIBotTestUtils {
                 keyboard.hotKey(VK_CONTROL, VK_END);
                 keyboard.enter();
 
-                keyboard.enterText(configNameSnippet);
+                keyboard.enterText(configNameSnippetCaseSpecific);
                 // After typing it can take 1 or 2s for IntelliJ to render diagnostics etc. Must wait before continuing.
                 TestUtils.sleepAndIgnoreException(5);
 
@@ -1126,11 +1138,12 @@ public class UIBotTestUtils {
                 // opened as text is typed based on the value of configNameSnippet. Avoid hitting ctrl + space as it has the side effect of selecting
                 // and entry automatically if the completion suggestion windows has one entry only.
                 ComponentFixture namePopupWindow = projectFrame.getLookupList();
+                String finalConfigNameSnippet = configNameSnippet;
                 RepeatUtilsKt.waitFor(Duration.ofSeconds(5),
                         Duration.ofSeconds(1),
                         "Waiting for text " + configNameSnippet + " to appear in the completion suggestion pop-up window",
                         "Text " + configNameSnippet + " did not appear in the completion suggestion pop-up window",
-                        () -> namePopupWindow.hasText(configNameSnippet));
+                        () -> namePopupWindow.hasText(finalConfigNameSnippet));
 
                 // now choose the specific item based on the chooser string
                 namePopupWindow.findText(contains(configNameChooserSnippet)).doubleClick();
@@ -1150,11 +1163,11 @@ public class UIBotTestUtils {
                     ComponentFixture valuePopupWindow = projectFrame.getLookupList();
                     RepeatUtilsKt.waitFor(Duration.ofSeconds(5),
                             Duration.ofSeconds(1),
-                            "Waiting for text " + configValueSnippet + " to appear in the completion suggestion pop-up window",
-                            "Text " + configValueSnippet + " did not appear in the completion suggestion pop-up window",
-                            () -> valuePopupWindow.hasText(configValueSnippet));
+                            "Waiting for text " + configValueSnippetUpperCase + " to appear in the completion suggestion pop-up window",
+                            "Text " + configValueSnippetUpperCase + " did not appear in the completion suggestion pop-up window",
+                            () -> valuePopupWindow.hasText(configValueSnippetUpperCase));
 
-                    valuePopupWindow.findText(contains(configValueSnippet)).doubleClick();
+                    valuePopupWindow.findText(contains(configValueSnippetUpperCase)).doubleClick();
                 }
                 // let the auto-save function of intellij save the file before testing it
                 if (remoteRobot.isMac()) {
@@ -1175,7 +1188,7 @@ public class UIBotTestUtils {
 
         // Report the last error if there is one.
         if (error != null) {
-            throw new RuntimeException("Unable to insert entry in config file : " + fileName + " using text: " + configNameSnippet, error);
+            throw new RuntimeException("Unable to insert entry in config file : " + fileName + " using text: " + configNameSnippetCaseSpecific, error);
         }
     }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1119,7 +1119,7 @@ public class UIBotTestUtils {
         }
         String configValueSnippetUpperCase = configValueSnippet.toUpperCase();
 
-        for (int i = 0; i < 2; i++) {
+        for (int i = 0; i < 10; i++) {
             error = null;
             try {
                 editorNew.click();

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation.
+ * Copyright (c) 2023, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -1094,12 +1094,12 @@ public class UIBotTestUtils {
      * Inserts a configuration name value pair into a config file via text typing
      * and popup menu completion (if required)
      *
-     * @param remoteRobot              The RemoteRobot instance.
-     * @param fileName                 The string path to the config file
-     * @param configNameSnippetCaseSpecific        the portion of the name to type
-     * @param configNameChooserSnippet the portion of the name to use for selecting from popup menu
-     * @param configValueSnippet       the value to type into keyboard - could be a snippet or a whole word
-     * @param completeWithPopup        use popup to complete value selection or type in an entire provided value string
+     * @param remoteRobot                   The RemoteRobot instance.
+     * @param fileName                      The string path to the config file
+     * @param configNameSnippetCaseSpecific the portion of the name to type
+     * @param configNameChooserSnippet      the portion of the name to use for selecting from popup menu
+     * @param configValueSnippet            the value to type into keyboard - could be a snippet or a whole word
+     * @param completeWithPopup             use popup to complete value selection or type in an entire provided value string
      */
     public static void insertConfigIntoConfigFile(RemoteRobot remoteRobot, String fileName, String configNameSnippetCaseSpecific, String configNameChooserSnippet, String configValueSnippet, boolean completeWithPopup) {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(30));


### PR DESCRIPTION
Fixes #953
Added four more automated UI tests to verify matching completion items in the server.env and bootstrap.properties files.


Current Scenarios we have right now:

- Full capital case letters insert into server.env
- Full lowercase letters insert into bootstrap.properties

I have added 4 more scenarios. Below are the 4 scenarios, and I have added tests for them, so they are included in this PR.

1.  Full lowercase letters insert into server.env
2.  A mix of lowercase and capital case letters insert into server.env
3.  Full capital case letters insert into bootstrap.properties
4.  A mix of lowercase and capital case letters insert into bootstrap.properties