### PR TITLE
Replaced the usage of deprecated method DumbService.runReadActionInSmartMode(Computable)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 useLocal=false
-pluginSinceBuild=242
+pluginSinceBuild=241
 pluginUntilBuild=243.*
 
 javaVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.1
+platformVersion=2024.1.7
 ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 useLocal=false
-pluginSinceBuild=241
+pluginSinceBuild=242
 pluginUntilBuild=243.*
 
 javaVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.1.7
+platformVersion=2024.2.1
 ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -21,7 +21,6 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
 import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
-import com.intellij.openapi.application.NonBlockingReadAction;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -96,7 +95,6 @@ public class ProjectLabelManager {
 			if (module == null) {
 				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 			}
-			//return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> getProjectLabelInfo(module, params.getTypes(), utils));
 			Project project = module.getProject();
 			return ReadAction.nonBlocking(() -> getProjectLabelInfo(module, params.getTypes(), utils))
 					.inSmartMode(project)

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -11,18 +11,17 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
 import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
+import com.intellij.openapi.application.NonBlockingReadAction;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -97,7 +96,11 @@ public class ProjectLabelManager {
 			if (module == null) {
 				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 			}
-			return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> getProjectLabelInfo(module, params.getTypes(), utils));
+			//return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> getProjectLabelInfo(module, params.getTypes(), utils));
+			Project project = module.getProject();
+			return ReadAction.nonBlocking(() -> getProjectLabelInfo(module, params.getTypes(), utils))
+					.inSmartMode(project)
+					.executeSynchronously();
 		} catch (IOException e) {
 			return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 		}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019-2020 Red Hat Inc. and others.
+* Copyright (c) 2019-2025 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -95,10 +95,7 @@ public class ProjectLabelManager {
 			if (module == null) {
 				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 			}
-			Project project = module.getProject();
-			return ReadAction.nonBlocking(() -> getProjectLabelInfo(module, params.getTypes(), utils))
-					.inSmartMode(project)
-					.executeSynchronously();
+			return getProjectLabelInfo(module, params.getTypes(), utils);
 		} catch (IOException e) {
 			return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 		}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -11,7 +11,6 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -220,21 +220,18 @@ public class PropertiesManager {
     }
 
     public Location findPropertyLocation(Module module, String sourceType, String sourceField, String sourceMethod, IPsiUtils utils) {
-        Project project = module.getProject();
-        return ReadAction.nonBlocking(() -> {
-            PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
-            if (fieldOrMethod != null) {
-                PsiFile classFile = fieldOrMethod.getContainingFile();
-                if (classFile != null) {
-                    // Try to download source if required
-                    if (utils != null) {
-                        utils.discoverSource(classFile);
-                    }
+        PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
+        if (fieldOrMethod != null) {
+            PsiFile classFile = fieldOrMethod.getContainingFile();
+            if (classFile != null) {
+                // Try to download source if required
+                if (utils != null) {
+                    utils.discoverSource(classFile);
                 }
-                return utils.toLocation(fieldOrMethod);
             }
-            return null;
-        }).inSmartMode(project).executeSynchronously();
+            return utils.toLocation(fieldOrMethod);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -10,9 +10,11 @@
  ******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core;
 
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
@@ -219,7 +221,8 @@ public class PropertiesManager {
     }
 
     public Location findPropertyLocation(Module module, String sourceType, String sourceField, String sourceMethod, IPsiUtils utils) {
-        return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
+        Project project = module.getProject();
+        return ReadAction.nonBlocking(() -> {
             PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
             if (fieldOrMethod != null) {
                 PsiFile classFile = fieldOrMethod.getContainingFile();
@@ -232,7 +235,8 @@ public class PropertiesManager {
                 return utils.toLocation(fieldOrMethod);
             }
             return null;
-        });
+        }).inSmartMode(project)
+          .executeSynchronously();
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -13,7 +13,6 @@ package io.openliberty.tools.intellij.lsp4mp4ij.psi.core;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2019, 2025 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -235,8 +235,7 @@ public class PropertiesManager {
                 return utils.toLocation(fieldOrMethod);
             }
             return null;
-        }).inSmartMode(project)
-          .executeSynchronously();
+        }).inSmartMode(project).executeSynchronously();
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -10,10 +10,8 @@
  ******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2025 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-v20.html

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -13,9 +13,7 @@
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.psi.PsiFile;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -15,7 +15,6 @@ package io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.diagnostics;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.ThrowableComputable;
@@ -34,7 +33,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class DiagnosticsHandler {
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -79,7 +79,7 @@ public final class DiagnosticsHandler {
                         .filter(definition -> definition.isAdaptedForDiagnostics(context))
                         .toList();
                 if (definitions.isEmpty()) {
-                    return;
+                    return null; // Explicit return for Callable<Void>
                 }
 
                 // Begin, collect, end participants
@@ -91,6 +91,7 @@ public final class DiagnosticsHandler {
                     }
                 });
                 definitions.forEach(definition -> definition.endDiagnostics(context));
+                return null; // Explicit return for Callable<Void>
             }).inSmartMode(project).executeSynchronously();
         } catch (IOException e) {
             LOGGER.warn(e.getLocalizedMessage(), e);

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/diagnostics/DiagnosticsHandler.java
@@ -93,8 +93,7 @@ public final class DiagnosticsHandler {
                     }
                 });
                 definitions.forEach(definition -> definition.endDiagnostics(context));
-            }).inSmartMode(project)
-                    .executeSynchronously();
+            }).inSmartMode(project).executeSynchronously();
         } catch (IOException e) {
             LOGGER.warn(e.getLocalizedMessage(), e);
         }


### PR DESCRIPTION
Fixes #1176 

The deprecated method `DumbService.runReadActionInSmartMode(Computable)` has been removed. 
Its replacement, `ReadAction.nonBlocking(...).inSmartMode(project).executeSynchronously()`, is not explicitly required here because the methods `ProjectLabelManager.getProjectLabelInfo()`, `PropertiesManager.findPropertyLocation()`, and `DiagnosticsHandler.collectDiagnostics()` are already executed within a NonBlocking ReadAction.