### PR TITLE
Bring focus to Liberty toolbar before selecting Config

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -2188,6 +2188,10 @@ public class UIBotTestUtils {
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofSeconds(10));
         ComponentFixture cfgSelectBox = projectFrame.getRunConfigurationsComboBoxButton();
 
+        // Click on the Liberty toolbar to give it focus.
+        ComponentFixture libertyTWBar = projectFrame.getBaseLabel("Liberty", "10");
+        libertyTWBar.click();
+
         boolean configFound = false;
         int retryCount = 0;
         int maxRetries = 5;


### PR DESCRIPTION
Fixes #1173 

I was not able to reproduce this locally. But From some of the videos, I observed that the configuration is already in a selected state. Clicking elsewhere and then returning to the configuration seems to resolve the issue. 
So I have added the changes to first click on the liberty toolbar and then click on the config toolbar.






