### PR TITLE
Include LSP4IJ 0.9.0 in the list of versions tested with LTI 24.0.12.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -60,7 +60,7 @@ If you prefer to use an older version of LSP4IJ (e.g., a specific version that w
 | Liberty Tools version | LSP4IJ version(s) tested   |
 |-----------------------|----------------------------|
 | 24.0.9                | 0.5.0, 0.6.0, 0.7.0, 0.8.1 |
-| 24.0.12               | 0.8.1                      |
+| 24.0.12               | 0.8.1, 0.9.0               |
 
 
 Steps to install an older version of LSP4IJ:


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1214