### PR TITLE
Found a possibility of limiting the Linux build only for the 24.0.9 LTI version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,8 @@ jobs:
           - runtime: linux
             os: ubuntu-latest
             reportName: linux-test-report
-            # Adding a check on macOS and Windows to identify refLTITag is equal to 24.0.9 , The value of 'excludeFromBuild' is use to run the steps
+            # Adding a check on macOS and Windows to verify if 'refLTITag' is equal to '24.0.9'. The value of 'excludeFromBuild' is used to determine whether the steps below need to be executed.
+            # This 'excludeFromBuild' variable can be removed once the '24.0.9' version is removed from the 'tag' array of the cron job build.
           - runtime: mac
             os: macOS-latest
             reportName: mac-test-report

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,12 +55,15 @@ jobs:
           - runtime: linux
             os: ubuntu-latest
             reportName: linux-test-report
+            # Adding a check on macOS and Windows to identify refLTITag is equal to 24.0.9 , The value of 'excludeFromBuild' is use to run the steps
           - runtime: mac
             os: macOS-latest
             reportName: mac-test-report
+            excludeFromBuild: ${{ inputs.refLTITag == '24.0.9' }}
           - runtime: windows
             os: windows-latest
             reportName: windows-test-report
+            excludeFromBuild: ${{ inputs.refLTITag == '24.0.9' }}
     env:
       USE_LOCAL_PLUGIN: ${{ inputs.useLocalPlugin || false }}
       REF_LSP4IJ: ${{ inputs.refLsp4ij }}
@@ -68,44 +71,47 @@ jobs:
       REF_LTI_TAG: ${{ inputs.refLTITag }}
     steps:
       - name: Configure pagefile
-        if: contains(matrix.os, 'windows')
+        if: ${{ contains(matrix.os, 'windows') && !matrix.excludeFromBuild }}
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB
           maximum-size: 10GB
           disk-root: "C:"
       - name: 'Checkout liberty-tools-intellij'
+        if: ${{ !matrix.excludeFromBuild }}
         uses: actions/checkout@v4
         with:
           path: liberty-tools-intellij
           ref: ${{ env.REF_LTI_TAG }}
       - name: 'Install required integration test software'
+        if: ${{ !matrix.excludeFromBuild }}
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/setup.sh
 
       # Checkout and build lsp4ij only if USE_LOCAL_PLUGIN is true
       - name: 'Checkout lsp4ij'
-        if: ${{ inputs.useLocalPlugin == true }}
+        if: ${{ inputs.useLocalPlugin == true && !matrix.excludeFromBuild }}
         uses: actions/checkout@v4
         with:
           repository: redhat-developer/lsp4ij
           path: lsp4ij
           ref: ${{ env.REF_LSP4IJ }}
       - name: 'Build Lsp4ij'
-        if: ${{ inputs.useLocalPlugin == true }}
+        if: ${{ inputs.useLocalPlugin == true && !matrix.excludeFromBuild }}
         working-directory: ./lsp4ij
         run: bash ./gradlew buildPlugin
       - name: 'Unzip lsp4ij file'
-        if: ${{ inputs.useLocalPlugin == true }}
+        if: ${{ inputs.useLocalPlugin == true && !matrix.excludeFromBuild }}
         working-directory: ./lsp4ij/build/distributions
         run: |
           unzip -o '*.zip' -d .
 
       - name: 'Build Liberty-Tools-Intellij'
+        if: ${{ !matrix.excludeFromBuild }}
         working-directory: ./liberty-tools-intellij
         run: bash ./gradlew buildPlugin -PuseLocal=${{ env.USE_LOCAL_PLUGIN }}
       - name: 'Archive artifacts'
-        if: ${{ runner.os == 'Linux' && !failure() }}
+        if: ${{ (runner.os == 'Linux' && !failure()) && !matrix.excludeFromBuild }}
         uses: actions/upload-artifact@v4.3.4
         with:
           name: liberty-tools-intellij-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}
@@ -115,11 +121,12 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
       - name: 'Run UI integration tests'
+        if: ${{ !matrix.excludeFromBuild }}
         id: run_tests
         working-directory: ./liberty-tools-intellij
         run: bash ./src/test/resources/ci/scripts/run.sh
       - name: 'Archive Test logs and reports'
-        if: ${{ failure() && steps.run_tests.conclusion == 'failure' }}
+        if: ${{ (failure() && steps.run_tests.conclusion == 'failure') && !matrix.excludeFromBuild }}
         uses: actions/upload-artifact@v4.3.4
         with:
           name: ${{ matrix.reportName }}-LTI-${{ env.REF_LTI_TAG || 'default' }}-LSP4IJ-${{ env.LSP4IJ_BRANCH }}


### PR DESCRIPTION
Fixes #1217

This fix added a check (based on the value 'excludeFromBuild') on macOS and Windows to verify if 'refLTITag' is equal to '24.0.9'. The value of 'excludeFromBuild' is used to determine whether the steps below (Steps in Job `build`) need to be executed. This 'excludeFromBuild' variable can be removed once the '24.0.9' version is removed from the 'tag' array of the cron job build.

 I checked other approaches and I found that, there is no direct way to limit the OS (Linux only) for running the cron job builds specifically to a particular LTI version. We are just passing the tag array from cron job builds and calling build.yaml from cronjob.yaml file. So we can't change anything in cronjob.yaml file. So I tried this solution to make the changes in build.yaml file.
 
 Below are the Github documentations that I referred  as part of investigation.
 
 https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude
 
 https://docs.github.com/en/enterprise-cloud@latest/actions/sharing-automations/reusing-workflows#using-a-matrix-strategy-with-a-reusable-workflow
 
 
I checked other approaches as well to avoid adding an if condition for all the steps, but they didn't work. I tried adding a single step with code to skip all the remaining steps, but that didn't work either. I also checked GitHub documentation but didn't find anything related to this.