### PR TITLE
Upgrade sampleGradleMPLSApp from Gradle 7.6 to 7.6.1

### DIFF
--- a/src/test/resources/projects/gradle/sampleGradleMPLSApp/gradle/wrapper/gradle-wrapper.properties
+++ b/src/test/resources/projects/gradle/sampleGradleMPLSApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In case testing times out unexpectedly one day.

Fixes #1221