### PR TITLE
Do not erase liberty modules when scanning in the constructor

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -103,7 +103,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
      */
     public static Tree buildTree(Project project, Color backgroundColor) {
         LibertyModules libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
-        if (libertyModules == null) {
+        if (libertyModules.isEmpty()) {
             return null;
         }
         DefaultMutableTreeNode top = new DefaultMutableTreeNode("Root node");

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,7 +20,6 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.DoubleClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.components.JBScrollPane;
@@ -30,18 +29,15 @@ import io.openliberty.tools.intellij.actions.LibertyGeneralAction;
 import io.openliberty.tools.intellij.actions.LibertyToolbarActionGroup;
 import io.openliberty.tools.intellij.util.*;
 import org.jetbrains.annotations.NotNull;
-import org.xml.sax.SAXException;
 
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreePath;
-import javax.xml.parsers.ParserConfigurationException;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -106,115 +102,39 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
      * @return Tree object of all valid Liberty Gradle and Liberty Maven projects
      */
     public static Tree buildTree(Project project, Color backgroundColor) {
-        LibertyModules libertyModules = LibertyModules.getInstance();
-        // clear all stored Liberty modules for current project
-        libertyModules.removeForProject(project);
+        LibertyModules libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
+        if (libertyModules == null) {
+            return null;
+        }
         DefaultMutableTreeNode top = new DefaultMutableTreeNode("Root node");
+        HashMap<String, ArrayList<Object>> projectMap = new HashMap<>();
 
-        ArrayList<BuildFile> mavenBuildFiles;
-        ArrayList<BuildFile> gradleBuildFiles;
-        HashMap<String, ArrayList<Object>> map = new HashMap<>();
-        try {
-            mavenBuildFiles = LibertyProjectUtil.getMavenBuildFiles(project);
-            gradleBuildFiles = LibertyProjectUtil.getGradleBuildFiles(project);
-        } catch (IOException | SAXException | ParserConfigurationException e) {
-            LOGGER.warn("Could not find Liberty Maven or Gradle projects in workspace",
-                    e);
-            return null;
-        }
-
-        if (mavenBuildFiles.isEmpty() && gradleBuildFiles.isEmpty()) {
-            return null;
-        }
-
-        for (BuildFile buildFile : mavenBuildFiles) {
-            // create a new Liberty project
-            VirtualFile virtualFile = buildFile.getBuildFile();
-            String projectName = null;
-            if (virtualFile == null) {
-                LOGGER.error(String.format("Could not resolve current Maven project %s", virtualFile));
-                break;
-            }
-            LibertyModuleNode node;
-            try {
-                projectName = LibertyMavenUtil.getProjectNameFromPom(virtualFile);
-            } catch (Exception e) {
-                LOGGER.warn(String.format("Could not resolve project name from build file: %s", virtualFile), e);
-            }
-            if (projectName == null) {
-                if (virtualFile.getParent() != null) {
-                    projectName = virtualFile.getParent().getName();
-                } else {
-                    projectName = project.getName();
-                }
-            }
-
-            boolean validContainerVersion = buildFile.isValidContainerVersion();
-            LibertyModule module = libertyModules.addLibertyModule(new LibertyModule(project, virtualFile, projectName, Constants.LIBERTY_MAVEN_PROJECT, validContainerVersion));
-            node = new LibertyModuleNode(module);
+        for (LibertyModule libertyModule : libertyModules.getLibertyModules(project)) {
+            LibertyModuleNode node = new LibertyModuleNode(libertyModule);
 
             top.add(node);
             ArrayList<Object> settings = new ArrayList<Object>();
-            settings.add(virtualFile);
-            settings.add(Constants.LIBERTY_MAVEN_PROJECT);
-            map.put(projectName, settings);
+            settings.add(libertyModule.getBuildFile());
+            settings.add(libertyModule.getProjectType());
+            projectMap.put(libertyModule.getName(), settings);
 
             // ordered to align with IntelliJ's right-click menu
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START, module));
-            // check if Liberty Maven Plugin is 3.3-M1+
+            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START, libertyModule));
+            // check if Liberty Maven Plugin is 3.3-M1+ or Liberty Gradle Plugin is 3.1-M1+
             // if version is not specified in pom, assume latest version as downloaded from maven central
+            boolean validContainerVersion = libertyModule.isValidContainerVersion();
             if (validContainerVersion) {
-                node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START_CONTAINER, module));
+                node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START_CONTAINER, libertyModule));
             }
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_CUSTOM_START, module));
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_STOP, module));
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_TESTS, module));
-            node.add(new LibertyActionNode(Constants.VIEW_INTEGRATION_TEST_REPORT, module));
-            node.add(new LibertyActionNode(Constants.VIEW_UNIT_TEST_REPORT, module));
-        }
-
-        for (BuildFile buildFile : gradleBuildFiles) {
-            VirtualFile virtualFile = buildFile.getBuildFile();
-            String projectName = null;
-            if (virtualFile == null) {
-                LOGGER.error(String.format("Could not resolve current Gradle project %s", buildFile));
-                break;
+            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_CUSTOM_START, libertyModule));
+            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_STOP, libertyModule));
+            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_TESTS, libertyModule));
+            if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+                node.add(new LibertyActionNode(Constants.VIEW_INTEGRATION_TEST_REPORT, libertyModule));
+                node.add(new LibertyActionNode(Constants.VIEW_UNIT_TEST_REPORT, libertyModule));
+            } else if (libertyModule.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
+                node.add(new LibertyActionNode(Constants.VIEW_GRADLE_TEST_REPORT, libertyModule));
             }
-            LibertyModuleNode node;
-            try {
-                projectName = LibertyGradleUtil.getProjectName(virtualFile);
-            } catch (Exception e) {
-                LOGGER.warn(String.format("Could not resolve project name for project %s", virtualFile), e);
-            }
-            if (projectName == null) {
-                if (virtualFile.getParent() != null) {
-                    projectName = virtualFile.getParent().getName();
-                } else {
-                    projectName = project.getName();
-                }
-            }
-
-            boolean validContainerVersion = buildFile.isValidContainerVersion();
-            LibertyModule module = libertyModules.addLibertyModule(new LibertyModule(project, virtualFile, projectName, Constants.LIBERTY_GRADLE_PROJECT, validContainerVersion));
-            node = new LibertyModuleNode(module);
-
-            top.add(node);
-            ArrayList<Object> settings = new ArrayList<Object>();
-            settings.add(virtualFile);
-            settings.add(Constants.LIBERTY_GRADLE_PROJECT);
-            map.put(projectName, settings);
-
-            // ordered to align with IntelliJ's right-click menu
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START, module));
-            // check if Liberty Gradle Plugin is 3.1-M1+
-            // TODO: handle version specified in a gradle.settings file
-            if (buildFile.isValidContainerVersion()) {
-                node.add(new LibertyActionNode(Constants.LIBERTY_DEV_START_CONTAINER, module));
-            }
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_CUSTOM_START, module));
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_STOP, module));
-            node.add(new LibertyActionNode(Constants.LIBERTY_DEV_TESTS, module));
-            node.add(new LibertyActionNode(Constants.VIEW_GRADLE_TEST_REPORT, module));
         }
 
         Tree tree = new Tree(top);
@@ -224,7 +144,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
         DataManager.registerDataProvider(tree, newDataProvider);
         TreeDataProvider treeDataProvider = (TreeDataProvider) DataManager.getDataProvider(tree);
 
-        treeDataProvider.setProjectMap(map);
+        treeDataProvider.setProjectMap(projectMap);
 
         tree.addTreeSelectionListener(e -> {
             Object node = e.getPath().getLastPathComponent();

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -103,7 +103,8 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
      */
     public static Tree buildTree(Project project, Color backgroundColor) {
         LibertyModules libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
-        if (libertyModules.isEmpty()) {
+        // This singleton may contain entries from old projects if you close a project and open another
+        if (libertyModules.getLibertyModules(project).isEmpty()) {
             return null;
         }
         DefaultMutableTreeNode top = new DefaultMutableTreeNode("Root node");

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -72,11 +72,6 @@ public class LibertyModules {
                     LOGGER.error(String.format("Could not resolve current project %s", virtualFile));
                     break;
                 }
-                if (virtualFile.getName().equals("pom.xml")) {
-                    buildFile.setProjectType(Constants.LIBERTY_MAVEN_PROJECT);
-                } else {
-                    buildFile.setProjectType(Constants.LIBERTY_GRADLE_PROJECT);
-                }
                 try {
                     if (buildFile.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
                         projectName = LibertyMavenUtil.getProjectNameFromPom(virtualFile);

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -58,10 +58,13 @@ public class LibertyModules {
             ArrayList<BuildFile> buildFiles = new ArrayList<>();
             try {
                 buildFiles.addAll(LibertyProjectUtil.getMavenBuildFiles(project));
+            } catch (IOException | SAXException | ParserConfigurationException e) {
+                LOGGER.error("I/O error or error parsing Liberty Maven projects in workspace", e);
+            }
+            try { // search for Gradle files even if Maven files experience error
                 buildFiles.addAll(LibertyProjectUtil.getGradleBuildFiles(project));
             } catch (IOException | SAXException | ParserConfigurationException e) {
-                LOGGER.warn("Could not find Liberty Maven or Gradle projects in workspace", e);
-                return null;
+                LOGGER.error("I/O error or error parsing Liberty Gradle projects in workspace", e);
             }
 
             for (BuildFile buildFile : buildFiles) {

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -44,9 +44,6 @@ public class LibertyModules {
         return instance;
     }
 
-    public boolean isEmpty() {
-        return libertyModules.isEmpty();
-    }
     /**
      * Scan the project for the modules that are Liberty apps.
      * @return null if there are no Liberty modules

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -45,13 +45,22 @@ public class LibertyModules {
     }
 
     /**
-     * Scan the project for the modules that are Liberty apps.
-     * @return null if there are no Liberty modules
+     * Remove existing data and scan the project for the modules that are Liberty apps.
+     * @return this singleton, the list will be empty if there are no Liberty modules
      */
     public LibertyModules scanLibertyModules(Project project) {
         synchronized (libertyModules) {
             removeForProject(project); // remove previous data, if any
+            return rescanLibertyModules(project);
+        }
+    }
 
+    /**
+     * Scan the project for the modules that are Liberty apps and update any existing entries.
+     * @return this singleton, the list will be empty if there are no Liberty modules
+     */
+    public LibertyModules rescanLibertyModules(Project project) {
+        synchronized (libertyModules) {
             ArrayList<BuildFile> buildFiles = new ArrayList<>();
             try {
                 buildFiles.addAll(LibertyProjectUtil.getMavenBuildFiles(project));

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -44,6 +44,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
 
     public LibertyRunConfiguration(Project project, ConfigurationFactory factory, String name) {
         super(name, getRunConfigurationModule(project), factory);
+        // Find Liberty modules here to populate config field called "build file" and avoid NPE
         this.libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -45,7 +45,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
     public LibertyRunConfiguration(Project project, ConfigurationFactory factory, String name) {
         super(name, getRunConfigurationModule(project), factory);
         // Find Liberty modules here to populate config field called "build file" and avoid NPE
-        this.libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
+        this.libertyModules = LibertyModules.getInstance().rescanLibertyModules(project);
     }
 
     @NotNull

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -44,7 +44,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
 
     public LibertyRunConfiguration(Project project, ConfigurationFactory factory, String name) {
         super(name, getRunConfigurationModule(project), factory);
-        this.libertyModules = LibertyModules.getInstance();
+        this.libertyModules = LibertyModules.getInstance().scanLibertyModules(project);
     }
 
     @NotNull

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation.
+ * Copyright (c) 2022, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -39,7 +39,6 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
     protected static Logger LOGGER = Logger.getInstance(LibertyRunConfiguration.class);
 
     private final LibertyModules libertyModules;
-    private LibertyModule libertyModule;
     @NonNls
     private static final String RUN_IN_CONTAINER_TAG = "RUN_IN_CONTAINER";
 
@@ -117,6 +116,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
     @Nullable
     @Override
     public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+        LibertyModule libertyModule;
         try {
             libertyModule = libertyModules.getLibertyProjectFromString(getBuildFile());
         } catch (NullPointerException e) {

--- a/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -25,7 +25,14 @@ public class BuildFile {
         return projectType;
     }
 
+    /**
+     * Liberty project type must be Gradle or Maven.
+     * @param projectType
+     */
     public void setProjectType(String projectType) {
+        if (!Constants.LIBERTY_GRADLE_PROJECT.equals(projectType) && !Constants.LIBERTY_MAVEN_PROJECT.equals(projectType)) {
+            throw new IllegalArgumentException("Only Gradle and Maven project types are supported: " + projectType);
+        }
         this.projectType = projectType;
     }
 
@@ -58,6 +65,4 @@ public class BuildFile {
     public void setProjectName(String projectName) {
         this.projectName = projectName;
     }
-
-
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -199,6 +199,7 @@ public class LibertyProjectUtil {
                     // check if valid pom.xml, or if part of Liberty project
                     if (filter.matches(project, buildFile, mavenFile)) {
                         buildFile.setBuildFile(mavenFile);
+                        buildFile.setProjectType(buildFileType);
                         buildFiles.add(buildFile);
                     }
                 }
@@ -212,6 +213,7 @@ public class LibertyProjectUtil {
                         // check if valid build.gradle, or if part of Liberty project
                         if (filter.matches(project, buildFile, gradleFile)) {
                             buildFile.setBuildFile(gradleFile);
+                            buildFile.setProjectType(buildFileType);
                             buildFiles.add(buildFile);
                         }
                     } catch (Exception e) {

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -437,6 +437,7 @@ public class UIBotTestUtils {
      * @param remoteRobot The RemoteRobot instance.
      */
     public static void openLibertyToolWindow(RemoteRobot remoteRobot) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, "UIBotTestUtils.openLibertyToolWindow Entry");
         int maxRetries = 6;
         Exception error = null;
         for (int i = 0; i < maxRetries; i++) {
@@ -466,6 +467,7 @@ public class UIBotTestUtils {
         if (error != null) {
             throw new RuntimeException("Unable to open the Liberty tool window.", error);
         }
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, "UIBotTestUtils.openLibertyToolWindow Exit");
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation.
+ * Copyright (c) 2023, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -2243,9 +2243,9 @@ public class UIBotTestUtils {
                     // Exit loop if successful
                     break;
                 } catch (WaitForConditionTimeoutException e) {
-                    System.err.println("Attempt " + (attempt + 1) + " failed: Timeout while trying to find or interact with menu items.");
+                    TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, "Attempt " + (attempt + 1) + " failed: Timeout while trying to find or interact with menu items. Retrying...");
                 } catch (Exception e) {
-                    System.err.println("Attempt " + (attempt + 1) + " failed: " + e.getMessage());
+                    TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, "Attempt " + (attempt + 1) + " failed: " + e.getMessage() + " Retrying...");
                 }
 
                 if (attempt == 4) { // If the last attempt fails


### PR DESCRIPTION
The constructor is called once per second on another thread (by IntelliJ) so it must not clear the singleton map and recreate it. Instead it rescans and updates certain fields of the Liberty Module objects without changing the terminal widget.

Fixes #1224