### PR TITLE
Deprecated constructor SymbolInformation changed to WorkspaceSymbol

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -399,8 +399,8 @@ public final class PropertiesManagerForJava {
      * @param monitor    the progress monitor
      * @return the workspace symbols for the given java project
      */
-    public List<SymbolInformation> workspaceSymbols(String projectUri, IPsiUtils utils, ProgressIndicator monitor) {
-        List<SymbolInformation> symbols = new ArrayList<>();
+    public List<WorkspaceSymbol> workspaceSymbols(String projectUri, IPsiUtils utils, ProgressIndicator monitor) {
+        List<WorkspaceSymbol> symbols = new ArrayList<>();
         Module module = getModule(projectUri, utils);
         if (module != null) {
             collectWorkspaceSymbols(module, utils, symbols, monitor);
@@ -418,7 +418,7 @@ public final class PropertiesManagerForJava {
         return null;
     }
 
-    private void collectWorkspaceSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols,
+    private void collectWorkspaceSymbols(Module project, IPsiUtils utils, List<WorkspaceSymbol> symbols,
                                          ProgressIndicator monitor) {
         if (monitor.isCanceled()) {
             return;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Red Hat, Inc.
+ * Copyright (c) 2020, 2025 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
@@ -17,7 +17,7 @@ import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProgressIndicator;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
-import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 
 import java.util.List;
 
@@ -37,7 +37,7 @@ public interface IJavaWorkspaceSymbolsParticipant {
      * @param symbols the list of symbols to add to
      * @param monitor the progress monitor
      */
-    void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols,
+    void collectSymbols(Module project, IPsiUtils utils, List<WorkspaceSymbol> symbols,
                         ProgressIndicator monitor);
 
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Red Hat Inc. and others.
+ * Copyright (c) 2024, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2024 Red Hat Inc. and others.
+* Copyright (c) 2024, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -22,10 +22,8 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsContext;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsMethodInfo;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
-import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -44,7 +42,7 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 	private static final Logger LOGGER = Logger.getLogger(JaxRsWorkspaceSymbolParticipant.class.getName());
 
 	@Override
-	public void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols, ProgressIndicator monitor) {
+	public void collectSymbols(Module project, IPsiUtils utils, List<WorkspaceSymbol> symbols, ProgressIndicator monitor) {
 		if (monitor.isCanceled()) {
 			return;
 		}
@@ -106,10 +104,11 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 		return jaxrsTypes;
 	}
 
-	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException {
+	private static WorkspaceSymbol createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException {
 		TextRange sourceRange = methodInfo.getJavaMethod().getNameIdentifier().getTextRange();
 		Range r = utils.toRange(methodInfo.getJavaMethod(), sourceRange.getStartOffset(), sourceRange.getLength());
 		Location location = new Location(methodInfo.getDocumentUri(), r);
+		Either<Location, WorkspaceSymbolLocation> eitherLocation = Either.forLeft(location);
 
 		StringBuilder nameBuilder = new StringBuilder("@");
 		URL url = new URL(methodInfo.getUrl());
@@ -118,10 +117,10 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 		nameBuilder.append(": ");
 		nameBuilder.append(methodInfo.getHttpMethod());
 
-		SymbolInformation symbol = new SymbolInformation();
+		WorkspaceSymbol symbol = new WorkspaceSymbol();
 		symbol.setName(nameBuilder.toString());
 		symbol.setKind(SymbolKind.Method);
-		symbol.setLocation(location);
+		symbol.setLocation(eitherLocation);
 		return symbol;
 	}
 


### PR DESCRIPTION
Fixes #1186 #1182 #1181 #1180 

The SymbolInformation Constructor is Changed to WorkspaceSymbol as per [LSP4 documentation](https://github.com/eclipse-lsp4j/lsp4j/blob/main/CHANGELOG.md#v0130-may-2022)