### PR TITLE
Address usage of deprecated constructor 'VersionedTextDocumentIdentifier'

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
@@ -22,7 +22,6 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -64,7 +63,7 @@ public class ChangeUtil {
 			return;
 		}
 
-		TextEditConverter converter = new TextEditConverter(unit, edit, utils);
+		TextEditConverter converter = new TextEditConverter(unit, edit, uri, utils);
 		if (resourceOperationSupported) {
 			List<Either<TextDocumentEdit, ResourceOperation>> changes = root.getDocumentChanges();
 			if (changes == null) {
@@ -72,9 +71,7 @@ public class ChangeUtil {
 				root.setDocumentChanges(changes);
 			}
 
-			VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, 0);
-			TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, converter.convert());
-			changes.add(Either.forLeft(documentEdit));
+			changes.add(Either.forLeft(converter.convertToTextDocumentEdit(0)));
 		} else {
 
 			Map<String, List<org.eclipse.lsp4j.TextEdit>> changes = root.getChanges();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Red Hat Inc. and others.
+* Copyright (c) 2020, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/ChangeUtil.java
@@ -13,10 +13,8 @@
 *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java;
 
-import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.psi.PsiDocumentManager;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
@@ -66,7 +64,7 @@ public class ChangeUtil {
 			return;
 		}
 
-		TextEditConverter converter = new TextEditConverter(unit, edit, uri, utils);
+		TextEditConverter converter = new TextEditConverter(unit, edit, utils);
 		if (resourceOperationSupported) {
 			List<Either<TextDocumentEdit, ResourceOperation>> changes = root.getDocumentChanges();
 			if (changes == null) {

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -21,7 +21,6 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * Converts an {@link DocumentEvent} to

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -32,8 +32,6 @@ import java.util.logging.Logger;
  */
 public class TextEditConverter {
 
-	private static final Logger LOGGER = Logger.getLogger(TextEditConverter.class.getName());
-
 	private final Change source;
 	protected PsiFile compilationUnit;
 	protected List<org.eclipse.lsp4j.TextEdit> converted;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -16,6 +16,8 @@ import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,15 +38,18 @@ public class TextEditConverter {
 	protected PsiFile compilationUnit;
 	protected List<org.eclipse.lsp4j.TextEdit> converted;
 
+	private final String uri;
+
 	private final IPsiUtils utils;
 
-	public TextEditConverter(PsiFile unit, Change edit, IPsiUtils utils) {
+	public TextEditConverter(PsiFile unit, Change edit, String uri, IPsiUtils utils) {
 		this.source = edit;
 		this.converted = new ArrayList<>();
 		if (unit == null) {
 			throw new IllegalArgumentException("Compilation unit can not be null");
 		}
 		this.compilationUnit = unit;
+		this.uri = uri;
 		this.utils = utils;
 	}
 
@@ -54,5 +59,10 @@ public class TextEditConverter {
 		te.setRange(utils.toRange(source.getSourceDocument(), 0, source.getSourceDocument().getTextLength()));
 		converted.add(te);
 		return converted;
+	}
+
+	public TextDocumentEdit convertToTextDocumentEdit(int version) {
+		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, version);
+		return new TextDocumentEdit(identifier, this.convert());
 	}
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -12,13 +12,10 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.java;
 
-import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.psi.PsiFile;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.Change;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
-import org.eclipse.lsp4j.TextDocumentEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -61,10 +61,4 @@ public class TextEditConverter {
 		converted.add(te);
 		return converted;
 	}
-
-	public TextDocumentEdit convertToTextDocumentEdit(int version) {
-		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(version);
-		identifier.setUri(uri);
-		return new TextDocumentEdit(identifier, this.convert());
-	}
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -36,18 +36,15 @@ public class TextEditConverter {
 	protected PsiFile compilationUnit;
 	protected List<org.eclipse.lsp4j.TextEdit> converted;
 
-	private final String uri;
-
 	private final IPsiUtils utils;
 
-	public TextEditConverter(PsiFile unit, Change edit, String uri, IPsiUtils utils) {
+	public TextEditConverter(PsiFile unit, Change edit, IPsiUtils utils) {
 		this.source = edit;
 		this.converted = new ArrayList<>();
 		if (unit == null) {
 			throw new IllegalArgumentException("Compilation unit can not be null");
 		}
 		this.compilationUnit = unit;
-		this.uri = uri;
 		this.utils = utils;
 	}
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/core/java/TextEditConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2025 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Fixes #1187 
The method convertToTextDocumentEdit(int) has 0 usages in our code . Hence removed the method and made the necessary refactoring