### PR TITLE
Extra rework for issue 1202

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -130,10 +130,10 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_CUSTOM_START, libertyModule));
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_STOP, libertyModule));
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_TESTS, libertyModule));
-            if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            if (libertyModule.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                 node.add(new LibertyActionNode(Constants.VIEW_INTEGRATION_TEST_REPORT, libertyModule));
                 node.add(new LibertyActionNode(Constants.VIEW_UNIT_TEST_REPORT, libertyModule));
-            } else if (libertyModule.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
+            } else {
                 node.add(new LibertyActionNode(Constants.VIEW_GRADLE_TEST_REPORT, libertyModule));
             }
         }
@@ -168,7 +168,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                     Object node = path.getLastPathComponent();
                     if (node instanceof LibertyModuleNode libertyNode) {
                         final DefaultActionGroup group = new DefaultActionGroup();
-                        if (libertyNode.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+                        if (libertyNode.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                             AnAction viewPomXml = ActionManager.getInstance().getAction(Constants.VIEW_POM_XML_ACTION_ID);
                             group.add(viewPomXml);
                             AnAction viewIntegrationReport = ActionManager.getInstance().getAction(Constants.VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
@@ -176,7 +176,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                             AnAction viewUnitTestReport = ActionManager.getInstance().getAction(Constants.VIEW_UNIT_TEST_REPORT_ACTION_ID);
                             group.add(viewUnitTestReport);
                             group.addSeparator();
-                        } else if (libertyNode.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
+                        } else {
                             AnAction viewGradleConfig = ActionManager.getInstance().getAction(Constants.VIEW_GRADLE_CONFIG_ACTION_ID);
                             group.add(viewGradleConfig);
                             AnAction viewTestReport = ActionManager.getInstance().getAction(Constants.VIEW_GRADLE_TEST_REPORT_ACTION_ID);

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation.
+ * Copyright (c) 2022, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,6 +13,7 @@ package io.openliberty.tools.intellij;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.util.BuildFile;
+import io.openliberty.tools.intellij.util.Constants;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 /**
@@ -22,7 +23,7 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 public class LibertyModule {
     private Project project;
     private VirtualFile buildFile;
-    private String projectType;
+    private Constants.ProjectType projectType;
     private String name;
     private boolean validContainerVersion;
 
@@ -40,7 +41,7 @@ public class LibertyModule {
         this.shellWidget = null;
     }
 
-    public LibertyModule(Project project, VirtualFile buildFile, String name, String projectType, boolean validContainerVersion) {
+    public LibertyModule(Project project, VirtualFile buildFile, String name, Constants.ProjectType projectType, boolean validContainerVersion) {
         this(project);
         this.buildFile = buildFile;
         this.name = name;
@@ -64,11 +65,11 @@ public class LibertyModule {
         this.buildFile = buildFile;
     }
 
-    public String getProjectType() {
+    public Constants.ProjectType getProjectType() {
         return projectType;
     }
 
-    public void setProjectType(String projectType) {
+    public void setProjectType(Constants.ProjectType projectType) {
         this.projectType = projectType;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModuleNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,7 @@ public class LibertyModuleNode extends DefaultMutableTreeNode {
         return libertyModule.getProject();
     }
 
-    public String getProjectType() {
+    public Constants.ProjectType getProjectType() {
         return libertyModule.getProjectType();
     }
 
@@ -44,10 +44,10 @@ public class LibertyModuleNode extends DefaultMutableTreeNode {
     }
 
     public boolean isGradleProjectType() {
-        return libertyModule.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT);
+        return libertyModule.getProjectType().equals(Constants.ProjectType.LIBERTY_GRADLE_PROJECT);
     }
 
     public boolean isMavenProjectType() {
-        return libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT);
+        return libertyModule.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -112,19 +112,21 @@ public class LibertyModules {
      * @param module LibertyModule
      */
     public LibertyModule addLibertyModule(LibertyModule module) {
-        if (libertyModules.containsKey(module.getBuildFile())) {
-            // Update existing Liberty project, projectType module, name and validContainerVersion
-            // Do not update the build file (key), debugMode, shellWidget or customStartParams since
-            // they may modify saved run configs.
-            LibertyModule existing = libertyModules.get(module.getBuildFile());
-            existing.setProject(module.getProject());
-            existing.setProjectType(module.getProjectType());
-            existing.setName(module.getName());
-            existing.setValidContainerVersion(module.isValidContainerVersion());
-        } else {
-            libertyModules.put(module.getBuildFile(), module);
+        synchronized (libertyModules) {
+            if (libertyModules.containsKey(module.getBuildFile())) {
+                // Update existing Liberty project, projectType module, name and validContainerVersion
+                // Do not update the build file (key), debugMode, shellWidget or customStartParams since
+                // they may modify saved run configs.
+                LibertyModule existing = libertyModules.get(module.getBuildFile());
+                existing.setProject(module.getProject());
+                existing.setProjectType(module.getProjectType());
+                existing.setName(module.getName());
+                existing.setValidContainerVersion(module.isValidContainerVersion());
+            } else {
+                libertyModules.put(module.getBuildFile(), module);
+            }
+            return libertyModules.get(module.getBuildFile());
         }
-        return libertyModules.get(module.getBuildFile());
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -102,7 +102,7 @@ public class LibertyModules {
                 addLibertyModule(new LibertyModule(project, virtualFile, projectName, buildFile.getProjectType(), validContainerVersion));
             }
         }
-        return getInstance();
+        return this;
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -82,7 +82,7 @@ public class LibertyModules {
                     break;
                 }
                 try {
-                    if (buildFile.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+                    if (buildFile.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                         projectName = LibertyMavenUtil.getProjectNameFromPom(virtualFile);
                     } else {
                         projectName = LibertyGradleUtil.getProjectName(virtualFile);
@@ -194,7 +194,7 @@ public class LibertyModules {
      * @param projectTypes
      * @return Liberty modules with the given project type(s)
      */
-    public List<LibertyModule> getLibertyModules(Project project, List<String> projectTypes) {
+    public List<LibertyModule> getLibertyModules(Project project, List<Constants.ProjectType> projectTypes) {
         ArrayList<LibertyModule> supportedLibertyModules = new ArrayList<>();
         synchronized (libertyModules) {
             libertyModules.values().forEach(libertyModule -> {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,7 +35,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        String projectType = libertyModule.getProjectType();
+        Constants.ProjectType projectType = libertyModule.getProjectType();
         String projectName = project.getName();
 
         String startCmd = null;
@@ -43,7 +43,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         DebugModeHandler debugHandler = new DebugModeHandler();
         String buildSettingsCmd;
         try {
-            if(projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            if(projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                 buildSettingsCmd = LibertyMavenUtil.getMavenSettingsCmd(project, buildFile);
             } else {
                 buildSettingsCmd = LibertyGradleUtil.getGradleSettingsCmd(project, buildFile);
@@ -56,13 +56,13 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             return;
         }
 
-        String start = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CMD;
-        String startInContainer = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
+        String start = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CMD;
+        String startInContainer = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
         startCmd = libertyModule.runInContainer() ? startInContainer : start;
         startCmd += libertyModule.getCustomStartParams();
         if (libertyModule.isDebugMode()) {
             try {
-                String debugParam = projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) ? Constants.LIBERTY_MAVEN_DEBUG_PARAM : Constants.LIBERTY_GRADLE_DEBUG_PARAM;
+                String debugParam = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? Constants.LIBERTY_MAVEN_DEBUG_PARAM : Constants.LIBERTY_GRADLE_DEBUG_PARAM;
                 debugPort = debugHandler.getDebugPort(libertyModule);
                 String debugStr = debugParam + debugPort;
                 // do not append if debug port is already specified as part of start command

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,10 +35,10 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
             return;
         }
 
-        String projectType = libertyModule.getProjectType();
+        Constants.ProjectType projectType = libertyModule.getProjectType();
         String startCmd;
         try {
-            if(projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            if(projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                 startCmd = LibertyMavenUtil.getMavenSettingsCmd(project, buildFile) + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD;
             } else {
                 startCmd = LibertyGradleUtil.getGradleSettingsCmd(project, buildFile) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -110,8 +110,8 @@ public abstract class LibertyGeneralAction extends AnAction {
             return;
         }
 
-        String projectType = libertyModule.getProjectType();
-        if (projectType == null || (!projectType.equals(Constants.LIBERTY_MAVEN_PROJECT) && !projectType.equals(Constants.LIBERTY_GRADLE_PROJECT))) {
+        Constants.ProjectType projectType = libertyModule.getProjectType();
+        if (projectType == null) {
             String msg = LocalizedResourceUtil.getMessage("liberty.project.type.invalid", actionCmd, libertyModule.getName());
             notifyError(msg, project);
             LOGGER.warn(msg);
@@ -122,8 +122,8 @@ public abstract class LibertyGeneralAction extends AnAction {
     }
 
     /* Returns project type(s) applicable to this action. */
-    protected List<String> getSupportedProjectTypes() {
-        return Arrays.asList(Constants.LIBERTY_MAVEN_PROJECT, Constants.LIBERTY_GRADLE_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return Arrays.asList(Constants.ProjectType.LIBERTY_MAVEN_PROJECT, Constants.ProjectType.LIBERTY_GRADLE_PROJECT);
     }
 
     protected final String[] toProjectNames(@NotNull List<LibertyModule> list) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyProjectAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -105,7 +105,7 @@ public abstract class LibertyProjectAction extends LibertyGeneralAction {
             } else {
                 try {
                     mavenBuildFile.setProjectName(LibertyMavenUtil.getProjectNameFromPom(virtualFile));
-                    mavenBuildFile.setProjectType(Constants.LIBERTY_MAVEN_PROJECT);
+                    mavenBuildFile.setProjectType(Constants.ProjectType.LIBERTY_MAVEN_PROJECT);
                     buildFiles.add(mavenBuildFile);
                 } catch (Exception e) {
                     LOGGER.error(String.format("Could not resolve project name from pom.xml: %s", virtualFile), e.getMessage());
@@ -120,7 +120,7 @@ public abstract class LibertyProjectAction extends LibertyGeneralAction {
             } else {
                 try {
                     gradleBuildFile.setProjectName(LibertyGradleUtil.getProjectName(virtualFile));
-                    gradleBuildFile.setProjectType(Constants.LIBERTY_GRADLE_PROJECT);
+                    gradleBuildFile.setProjectType(Constants.ProjectType.LIBERTY_GRADLE_PROJECT);
                     buildFiles.add(gradleBuildFile);
                 } catch (Exception e) {
                     LOGGER.error(String.format("Could not resolve project name from settings.gradle: %s", virtualFile), e.getMessage());

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,8 +31,8 @@ public class ViewGradleConfig extends LibertyGeneralAction {
     }
 
     @Override
-    protected List<String> getSupportedProjectTypes() {
-        return List.of(Constants.LIBERTY_GRADLE_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return List.of(Constants.ProjectType.LIBERTY_GRADLE_PROJECT);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,8 +38,8 @@ public class ViewIntegrationTestReport extends LibertyGeneralAction {
     }
 
     @Override
-    protected List<String> getSupportedProjectTypes() {
-        return List.of(Constants.LIBERTY_MAVEN_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return List.of(Constants.ProjectType.LIBERTY_MAVEN_PROJECT);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewPomXml.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewPomXml.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -31,8 +31,8 @@ public class ViewPomXml extends LibertyGeneralAction {
     }
 
     @Override
-    protected List<String> getSupportedProjectTypes() {
-        return List.of(Constants.LIBERTY_MAVEN_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return List.of(Constants.ProjectType.LIBERTY_MAVEN_PROJECT);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -48,8 +48,8 @@ public class ViewTestReport extends LibertyGeneralAction {
     }
 
     @Override
-    protected List<String> getSupportedProjectTypes() {
-        return List.of(Constants.LIBERTY_GRADLE_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return List.of(Constants.ProjectType.LIBERTY_GRADLE_PROJECT);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,8 +38,8 @@ public class ViewUnitTestReport extends LibertyGeneralAction {
     }
 
     @Override
-    protected List<String> getSupportedProjectTypes() {
-        return List.of(Constants.LIBERTY_MAVEN_PROJECT);
+    protected List<Constants.ProjectType> getSupportedProjectTypes() {
+        return List.of(Constants.ProjectType.LIBERTY_MAVEN_PROJECT);
     }
 
     @Override

--- a/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/BuildFile.java
@@ -21,7 +21,7 @@ public class BuildFile {
 
     private String projectName;
 
-    public String getProjectType() {
+    public Constants.ProjectType getProjectType() {
         return projectType;
     }
 
@@ -29,14 +29,11 @@ public class BuildFile {
      * Liberty project type must be Gradle or Maven.
      * @param projectType
      */
-    public void setProjectType(String projectType) {
-        if (!Constants.LIBERTY_GRADLE_PROJECT.equals(projectType) && !Constants.LIBERTY_MAVEN_PROJECT.equals(projectType)) {
-            throw new IllegalArgumentException("Only Gradle and Maven project types are supported: " + projectType);
-        }
+    public void setProjectType(Constants.ProjectType projectType) {
         this.projectType = projectType;
     }
 
-    private String projectType;
+    private Constants.ProjectType projectType;
 
     public BuildFile(boolean validBuildFile, boolean validContainerVersion) {
         this.validBuildFile = validBuildFile;

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,8 +17,10 @@ import java.util.*;
 public final class Constants {
     public static final int REQUIRED_JAVA_VERSION = 17;
     public static final String LIBERTY_DEV_DASHBOARD_ID = "Liberty";
-    public static final String LIBERTY_GRADLE_PROJECT = "Liberty Gradle Project";
-    public static final String LIBERTY_MAVEN_PROJECT = "Liberty Maven Project";
+    public enum ProjectType {
+        LIBERTY_GRADLE_PROJECT,
+        LIBERTY_MAVEN_PROJECT;
+    }
 
     public static final String LIBERTY_MAVEN_START_CMD = " io.openliberty.tools:liberty-maven-plugin:dev ";
     public static final String LIBERTY_MAVEN_START_CONTAINER_CMD = " io.openliberty.tools:liberty-maven-plugin:devc ";

--- a/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/DebugModeHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation.
+ * Copyright (c) 2022, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -82,7 +82,7 @@ public class DebugModeHandler {
         // 1. Check if debug port was specified as part of start parameters, if so use that port first
         String configParams = libertyModule.getCustomStartParams();
         Matcher m;
-        if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+        if (libertyModule.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
             m = MAVEN_DEBUG_REGEX.matcher(configParams);
         } else {
             m = GRADLE_DEBUG_REGEX.matcher(configParams);
@@ -247,13 +247,10 @@ public class DebugModeHandler {
     private Path getServerEnvPath(LibertyModule libertyModule) throws Exception {
         String projectPath = libertyModule.getBuildFile().getParent().getPath();
         Path basePath = null;
-        if (libertyModule.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+        if (libertyModule.getProjectType().equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
             basePath = Paths.get(projectPath, "target", "liberty", "wlp", "usr", "servers");
-        } else if (libertyModule.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            basePath = Paths.get(projectPath, "build", "wlp", "usr", "servers");
         } else {
-            throw new Exception(String.format("Unexpected project build type: %s. Liberty module %s does not appear to be a Maven or Gradle built project",
-                    libertyModule.getProjectType(), libertyModule.getName()));
+            basePath = Paths.get(projectPath, "build", "wlp", "usr", "servers");
         }
 
         // Make sure the base path exists. If not return null.

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -95,7 +95,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getGradleBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_GRADLE_PROJECT, BuildFileFilter.LIST);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_GRADLE_PROJECT, BuildFileFilter.LIST);
     }
 
     /**
@@ -104,7 +104,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getMavenBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_MAVEN_PROJECT, BuildFileFilter.LIST);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_MAVEN_PROJECT, BuildFileFilter.LIST);
     }
 
     /**
@@ -113,7 +113,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getAddableGradleBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_GRADLE_PROJECT, BuildFileFilter.ADDABLE);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_GRADLE_PROJECT, BuildFileFilter.ADDABLE);
     }
 
     /**
@@ -122,7 +122,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getAddableMavenBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_MAVEN_PROJECT, BuildFileFilter.ADDABLE);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_MAVEN_PROJECT, BuildFileFilter.ADDABLE);
     }
 
     /**
@@ -131,7 +131,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getRemovableGradleBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_GRADLE_PROJECT, BuildFileFilter.REMOVABLE);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_GRADLE_PROJECT, BuildFileFilter.REMOVABLE);
     }
 
     /**
@@ -140,7 +140,7 @@ public class LibertyProjectUtil {
      * @return ArrayList of BuildFiles
      */
     public static ArrayList<BuildFile> getRemovableMavenBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
-        return getBuildFiles(project, Constants.LIBERTY_MAVEN_PROJECT, BuildFileFilter.REMOVABLE);
+        return getBuildFiles(project, Constants.ProjectType.LIBERTY_MAVEN_PROJECT, BuildFileFilter.REMOVABLE);
     }
 
     /**
@@ -188,10 +188,10 @@ public class LibertyProjectUtil {
     }
 
     // Search the filename index to find valid build files (Maven and Gradle) for the current project
-    private static ArrayList<BuildFile> getBuildFiles(Project project, String buildFileType, BuildFileFilter filter) throws ParserConfigurationException, SAXException, IOException {
+    private static ArrayList<BuildFile> getBuildFiles(Project project, Constants.ProjectType buildFileType, BuildFileFilter filter) {
         ArrayList<BuildFile> collectedBuildFiles = new ArrayList<BuildFile>();
         Collection<VirtualFile> indexedVFiles;
-        if (buildFileType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+        if (buildFileType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
             indexedVFiles = readIndex(project, "pom.xml");
         } else {
             indexedVFiles = readIndex(project, "build.gradle");
@@ -200,7 +200,7 @@ public class LibertyProjectUtil {
             for (VirtualFile vFile : indexedVFiles) {
                 try {
                     BuildFile buildFile;
-                    if (buildFileType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+                    if (buildFileType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
                         buildFile = LibertyMavenUtil.validPom(vFile);
                     } else {
                         buildFile = LibertyGradleUtil.validBuildGradle(vFile);

--- a/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation.
+ * Copyright (c) 2020, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -22,7 +22,7 @@ public class TreeDataProvider implements DataProvider {
 
     public VirtualFile currentFile;
     public String projectName;
-    public String projectType;
+    public Constants.ProjectType projectType;
     public HashMap<String, ArrayList<Object>> map = new HashMap<String, ArrayList<Object>>();
 
     @Nullable
@@ -40,7 +40,7 @@ public class TreeDataProvider implements DataProvider {
         return null;
     }
 
-    public void saveData(@NotNull VirtualFile file, @NotNull String projectName, @NotNull String projectType) {
+    public void saveData(@NotNull VirtualFile file, @NotNull String projectName, @NotNull Constants.ProjectType projectType) {
         this.currentFile = file;
         this.projectName = projectName;
         this.projectType = projectType;


### PR DESCRIPTION
Fixes #1234 

Three code improvements were suggested in the review of issue #1202.

1. Return `this` instead of calling `getInstance()`
2. Synchronize access to `libertyModules` in `addLibertyModule()`
3. Use an enum instead of Strings for project type in the area of Liberty actions. Using an enum allows us to remove some string checking code that is no longer required. This affects a lot of files but it makes the code more robust.

