### PR TITLE
Deprecated constructor 'URL.<init>(String)' changed to URI.toURL

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2024 Red Hat Inc. and others.
+* Copyright (c) 2024, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -108,18 +108,13 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 		return jaxrsTypes;
 	}
 
-	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException {
+	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException, URISyntaxException {
 		TextRange sourceRange = methodInfo.getJavaMethod().getNameIdentifier().getTextRange();
 		Range r = utils.toRange(methodInfo.getJavaMethod(), sourceRange.getStartOffset(), sourceRange.getLength());
 		Location location = new Location(methodInfo.getDocumentUri(), r);
 
 		StringBuilder nameBuilder = new StringBuilder("@");
-		URL url;
-		try {
-			url = new URI(methodInfo.getUrl()).toURL();
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
+		URL url = new URI(methodInfo.getUrl()).toURL();
 		String path = url.getPath();
 		nameBuilder.append(path);
 		nameBuilder.append(": ");

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -28,7 +28,9 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -112,7 +114,12 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 		Location location = new Location(methodInfo.getDocumentUri(), r);
 
 		StringBuilder nameBuilder = new StringBuilder("@");
-		URL url = new URL(methodInfo.getUrl());
+		URL url;
+		try {
+			url = new URI(methodInfo.getUrl()).toURL();
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
 		String path = url.getPath();
 		nameBuilder.append(path);
 		nameBuilder.append(": ");


### PR DESCRIPTION
Fixes #1185 
As per Replacement [Doc](https://github.com/openjdk/jdk/blob/ceae2b977dac58a9b2c09e42cb256c94eff9222b/src/java.base/share/classes/java/net/URL.java#L404-L408)