### PR TITLE
Create a new test case for Run/Debug Configurations

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPCfgProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPCfgProjectTest.java
@@ -20,7 +20,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 /**
- * Test Liberty Tools creation of a Run/Debug configuration without a null pointer exception.
+ * Test Liberty Tools creation of a Run/Debug configuration without a null pointer exception
+ * using a single module MicroProfile Gradle project.
  */
 public class GradleSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCommon {
 
@@ -40,7 +41,7 @@ public class GradleSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCo
     private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "gradle").toAbsolutePath().toString();
 
     /**
-     * The path to the folder containing the test projects, including directories with spaces.
+     * The path to the folder containing the copy of the test project.
      */
     private static final String PROJECTS_PATH_NEW = Paths.get("src", "test", "resources", "projects", "gsample2").toAbsolutePath().toString();
 

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPCfgProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPCfgProjectTest.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Test Liberty Tools creation of a Run/Debug configuration without a null pointer exception.
+ */
+public class GradleSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCommon {
+
+    /**
+     * Single module Microprofile project name specified in file settings.gradle.
+     */
+    private static final String SM_MP_PROJECT_NAME = "singleModGradleMP";
+
+    /**
+     * Project name of Microprofile single module in file settings-copy.gradle.
+     */
+    private static final String SM_MP_PROJECT_NAME_NEW = "singleMod GradleMP";
+
+    /**
+     * The path to the folder containing the test projects.
+     */
+    private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "gradle").toAbsolutePath().toString();
+
+    /**
+     * The path to the folder containing the test projects, including directories with spaces.
+     */
+    private static final String PROJECTS_PATH_NEW = Paths.get("src", "test", "resources", "projects", "gsample2").toAbsolutePath().toString();
+
+    /**
+     * Prepares the environment for test execution.
+     */
+    @BeforeAll
+    public static void setup() {
+        try {
+            // Copy the directory to allow renaming.
+            TestUtils.copyDirectory(PROJECTS_PATH, PROJECTS_PATH_NEW);
+
+            Path pathNew = Path.of(PROJECTS_PATH_NEW);
+            Path projectDirPath = pathNew.resolve(SM_MP_PROJECT_NAME);
+
+            // Define paths for the original and copy of settings.gradle
+            Path originalPath = projectDirPath.resolve("settings.gradle");
+            Path originalPathCopy = projectDirPath.resolve("settings-copy.gradle");
+
+            // Rename settings.gradle to settings-duplicate.gradle
+            Files.move(originalPath, originalPath.resolveSibling("settings-duplicate.gradle"));
+            // Rename settings-copy.gradle to settings.gradle
+            Files.move(originalPathCopy, originalPathCopy.resolveSibling("settings.gradle"));
+
+            Path projectDirNewPath = pathNew.resolve(SM_MP_PROJECT_NAME_NEW);
+
+            // Rename the project directory to a new name, replacing it if it already exists
+            Files.move(projectDirPath, projectDirNewPath, StandardCopyOption.REPLACE_EXISTING);
+
+            // Prepare the environment with the new project path and name
+            prepareEnv(PROJECTS_PATH_NEW, SM_MP_PROJECT_NAME_NEW);
+
+        } catch (IOException e) {
+            System.err.println("Setup failed: " + e.getMessage());
+            e.printStackTrace();
+            Assertions.fail("Test setup failed due to an IOException: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Cleanup includes deleting the created project path.
+     */
+    @AfterAll
+    public static void cleanup() {
+        try {
+            closeProjectView();
+        } finally {
+            deleteDirectoryIfExists(PROJECTS_PATH_NEW);
+        }
+    }
+
+    GradleSingleModMPCfgProjectTest() {
+        // set the new locations for the test, not the original locations
+        setProjectsDirPath(PROJECTS_PATH_NEW);
+        setSmMPProjectName(SM_MP_PROJECT_NAME_NEW);
+        setWLPInstallPath("build");
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPSIDProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/GradleSingleModMPSIDProjectTest.java
@@ -25,12 +25,12 @@ import java.nio.file.StandardCopyOption;
 public class GradleSingleModMPSIDProjectTest extends SingleModMPProjectTestCommon {
 
     /**
-     * Single module Microprofile project name.
+     * Single module Microprofile project name specified in file settings.gradle.
      */
     private static final String SM_MP_PROJECT_NAME = "singleModGradleMP";
 
     /**
-     * Single module Microprofile project name with space.
+     * Project name of Microprofile single module in file settings-copy.gradle.
      */
     private static final String SM_MP_PROJECT_NAME_NEW = "singleMod GradleMP";
 

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPCfgProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPCfgProjectTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import com.intellij.remoterobot.stepsProcessing.StepLogger;
+import com.intellij.remoterobot.stepsProcessing.StepWorker;
+import io.openliberty.tools.intellij.it.SingleModMPProjectTestCommon;
+import io.openliberty.tools.intellij.it.TestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests Liberty Tools actions using a single module MicroProfile Maven project.
+ */
+public class MavenSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCommon {
+
+    /**
+     * Single module Microprofile project name.
+     */
+    private static final String SM_MP_PROJECT_NAME = "singleModMavenMP";
+
+    /**
+     * The path to the folder containing the test projects.
+     */
+    private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "maven").toAbsolutePath().toString();
+
+    /**
+     * The path to the folder containing the test projects, including directories with spaces.
+     */
+    private static final String PROJECTS_PATH_NEW = Paths.get("src", "test", "resources", "projects", "msample2").toAbsolutePath().toString();
+
+    /**
+     * Prepares the environment for test execution.
+     */
+    @BeforeAll
+    public static void setup() {
+        try {
+            StepWorker.registerProcessor(new StepLogger());
+            // Copy the directory from PROJECTS_PATH to PROJECTS_PATH_NEW
+            TestUtils.copyDirectory(PROJECTS_PATH, PROJECTS_PATH_NEW);
+            prepareEnv(PROJECTS_PATH_NEW, SM_MP_PROJECT_NAME);
+        } catch (IOException e) {
+            System.err.println("Setup failed: " + e.getMessage());
+            e.printStackTrace();
+            Assertions.fail("Test setup failed due to an IOException: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Cleanup includes deleting the created project path.
+     */
+    @AfterAll
+    public static void cleanup() {
+        try {
+            closeProjectView();
+        } finally {
+            deleteDirectoryIfExists(PROJECTS_PATH_NEW);
+        }
+    }
+
+    MavenSingleModMPCfgProjectTest() {
+        setProjectsDirPath(PROJECTS_PATH_NEW);
+        setSmMPProjectName(SM_MP_PROJECT_NAME);
+        setWLPInstallPath(Paths.get("target", "liberty").toString());
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPCfgProjectTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/MavenSingleModMPCfgProjectTest.java
@@ -22,7 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * Tests Liberty Tools actions using a single module MicroProfile Maven project.
+ * Test Liberty Tools creation of a Run/Debug configuration without a null pointer exception
+ * using a single module MicroProfile Maven project.
  */
 public class MavenSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCommon {
 
@@ -37,7 +38,7 @@ public class MavenSingleModMPCfgProjectTest extends SingleModMPProjectCfgTestCom
     private static final String PROJECTS_PATH = Paths.get("src", "test", "resources", "projects", "maven").toAbsolutePath().toString();
 
     /**
-     * The path to the folder containing the test projects, including directories with spaces.
+     * The path to the folder containing the copy of the test project.
      */
     private static final String PROJECTS_PATH_NEW = Paths.get("src", "test", "resources", "projects", "msample2").toAbsolutePath().toString();
 

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
@@ -150,7 +150,7 @@ public abstract class SingleModMPProjectCfgTestCommon {
         UIBotTestUtils.deleteLibertyRunConfigurations(remoteRobot);
 
         // Add a new Liberty configurations. Throws an exception if there is an error.
-        UIBotTestUtils.createLibertyConfiguration(remoteRobot, "newCfg1");
+        UIBotTestUtils.createLibertyConfiguration(remoteRobot, "newCfg1", false, null);
     }
 
     /**

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
@@ -31,8 +31,6 @@ public abstract class SingleModMPProjectCfgTestCommon {
     // When we create a new Run/Debug configuration, the "Liberty project" field is populated by
     // default with one of the build files from one of the Liberty projects in the workspace. If
     // there is no default build file then there will be a Null Pointer Exception if we press Run.
-    // The following method will throw a NoSuchElementException if there are no Liberty projects
-    // detected when the Edit Liberty Run/Debug Configuration dialog is opened.
 
     /**
      * URL to display the UI Component hierarchy. This is used to obtain xPath related
@@ -150,6 +148,8 @@ public abstract class SingleModMPProjectCfgTestCommon {
         UIBotTestUtils.deleteLibertyRunConfigurations(remoteRobot);
 
         // Add a new Liberty configurations. Throws an exception if there is an error.
+        // Note: the method will throw a NoSuchElementException if there are no Liberty projects
+        // detected when the Edit Liberty Run/Debug Configuration dialog is opened.
         UIBotTestUtils.createLibertyConfiguration(remoteRobot, "newCfg1", false, null);
     }
 

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.tools.intellij.it;
+
+import com.automation.remarks.junit5.Video;
+import com.intellij.remoterobot.RemoteRobot;
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import static com.intellij.remoterobot.utils.RepeatUtilsKt.waitForIgnoringError;
+
+/**
+ * Holds common tests that use a single module MicroProfile project.
+ */
+public abstract class SingleModMPProjectCfgTestCommon {
+
+    // In this test case the environment has been set up so that there is a new project
+    // that has not been used in a previous execution of IntelliJ. Also, the Liberty explorer
+    // or dashboard has not been opened as it is in all other tests. This means the LibertyModules
+    // object is not yet populated.
+    // When we create a new Run/Debug configuration, the "Liberty project" field is populated by
+    // default with one of the build files from one of the Liberty projects in the workspace. If
+    // there is no default build file then there will be a Null Pointer Exception if we press Run.
+    // The following method will throw a NoSuchElementException if there are no Liberty projects
+    // detected when the Edit Liberty Run/Debug Configuration dialog is opened.
+
+    /**
+     * URL to display the UI Component hierarchy. This is used to obtain xPath related
+     * information to find UI components.
+     */
+    public static final String REMOTE_BOT_URL = "http://localhost:8082";
+
+    /**
+     * The remote robot object.
+     */
+    public static final RemoteRobot remoteRobot = new RemoteRobot(REMOTE_BOT_URL);
+
+    /**
+     * Single module Microprofile project name.
+     */
+    private String smMpProjectName = null;
+
+    /**
+     * The path to the folder containing the test projects.
+     */
+    private String projectsPath = null;
+
+    /**
+     * Relative location of the WLP installation.
+     */
+    private String wlpInstallPath = null;
+
+    /**
+     * Returns the path where the Liberty server was installed.
+     *
+     * @return The path where the Liberty server was installed.
+     */
+    public String getWLPInstallPath() {
+        return wlpInstallPath;
+    }
+    public void setWLPInstallPath(String path) {
+        wlpInstallPath = path;
+    }
+
+    /**
+     * Returns the projects directory path.
+     *
+     * @return The projects directory path.
+     */
+    public String getProjectsDirPath() {
+        return projectsPath;
+    }
+    public void setProjectsDirPath(String path) {
+        projectsPath = path;
+    }
+
+    /**
+     * Returns the name of the single module MicroProfile project.
+     *
+     * @return The name of the single module MicroProfile project.
+     */
+    public String getSmMPProjectName() {
+        return smMpProjectName;
+    }
+    public void setSmMPProjectName(String name) {
+        smMpProjectName = name;
+    }
+
+    /**
+     * Processes actions before each test.
+     *
+     * @param info Test information.
+     */
+    @BeforeEach
+    public void beforeEach(TestInfo info) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Entry");
+    }
+
+    /**
+     * Processes actions after each test.
+     *
+     * @param info Test information.
+     */
+    @AfterEach
+    public void afterEach(TestInfo info) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Exit");
+        TestUtils.detectFatalError();
+    }
+
+    /**
+     * Cleanup.
+     */
+    @AfterAll
+    public static void cleanup() {
+        closeProjectView();
+    }
+
+    /**
+     * Close project.
+     */
+    protected static void closeProjectView() {
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Close All Tabs", 3);
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
+        UIBotTestUtils.closeLibertyToolWindow(remoteRobot);
+        UIBotTestUtils.closeProjectView(remoteRobot);
+        UIBotTestUtils.closeProjectFrame(remoteRobot);
+        UIBotTestUtils.validateProjectFrameClosed(remoteRobot);
+    }
+
+    /**
+     * Create a run configuration and see if it caused a null pointer exception
+     */
+    @Test
+    @Video
+    public void testCreateRunConfigAction() {
+        String testName = "testCreateRunConfigAction";
+        // Remove all other configurations first.
+        UIBotTestUtils.deleteLibertyRunConfigurations(remoteRobot);
+
+        // Add a new Liberty configurations. Throws an exception if there is an error.
+        UIBotTestUtils.createLibertyConfiguration(remoteRobot, "newCfg1");
+    }
+
+    /**
+     * Prepares the environment to run the tests.
+     *
+     * @param projectPath The path of the project.
+     * @param projectName The name of the project being used.
+     */
+    public static void prepareEnv(String projectPath, String projectName) {
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
+                "prepareEnv. Entry. ProjectPath: " + projectPath + ". ProjectName: " + projectName);
+        waitForIgnoringError(Duration.ofMinutes(4), Duration.ofSeconds(5), "Wait for IDE to start", "IDE did not start", () -> remoteRobot.callJs("true"));
+        UIBotTestUtils.findWelcomeFrame(remoteRobot);
+        UIBotTestUtils.importProject(remoteRobot, projectPath, projectName);
+        UIBotTestUtils.openProjectView(remoteRobot);
+        if (!remoteRobot.isMac()) {
+            UIBotTestUtils.runActionFromSearchEverywherePanel(remoteRobot, "Compact Mode", 3);
+        }
+        // IntelliJ does not start building and indexing until the Project View is open
+        UIBotTestUtils.waitForIndexing(remoteRobot);
+        TestUtils.printTrace(TestUtils.TraceSevLevel.INFO,
+                "prepareEnv. Exit. ProjectName: " + projectName);
+    }
+
+    /**
+     * Deletes the directory specified by dirPath if it exists.
+     *
+     * @param dirPath The path to the directory that may be deleted.
+     */
+    public static void deleteDirectoryIfExists(String dirPath) {
+        File dir = new File(dirPath);
+        if (dir.exists()) {
+            TestUtils.deleteDirectory(dir);
+        }
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -2091,6 +2091,15 @@ public class UIBotTestUtils {
                     DialogFixture.byTitle("Run/Debug Configurations"),
                     Duration.ofSeconds(10));
 
+            // The new configuration should refer to one of the Liberty projects by default.
+            // If there are no Liberty projects detected in the workspace then the combobox
+            // will have zero values.
+            Locator projectComboLocator = byXpath("//div[@class='ComboBox']");
+            ComboBoxFixture projectCombo = addProjectDialog.comboBox(projectComboLocator);
+            if (projectCombo.listValues().isEmpty()) {
+                throw new NoSuchElementException("Liberty project field contains no elements");
+            }
+
             // Find the new configuration's name text field and give it a name.
             Locator locator = byXpath("//div[@class='JTextField']");
 
@@ -2134,6 +2143,8 @@ public class UIBotTestUtils {
                     "The Apply button on the add config dialog was not enabled",
                     applyButton::isEnabled);
             applyButton.click();
+
+            // Change which button we click to complete the operation
             exitButtonText = "OK";
         } finally {
             // Exit the Run/Debug Configurations dialog.


### PR DESCRIPTION
In order to trigger the bug the Liberty project must not have been loaded by a previous test case. Also the Liberty dashboard must not have been opened since IntelliJ started up. The state of the project will even be persisted if you close the workspace and go back to the Welcome screen and open a different project or the same project. 

So this test case copies an existing project into a new location so that the project will be treated as unique. This is similar to the `GradleSingleModMPSIDProjectTest` project which makes a copy.  This test case also does not open the Liberty dashboard like all the other UI test cases do. Finally there is just one test in this environment. I tested that it fails for 24.0.12 but it passes with the fix for #1202.

I updated some comments in `GradleSingleModMPSIDProjectTest` in order to clarify where some of the names come from i.e. they must match.

Fixes #1236