### PR TITLE
LTI 24.0.12: Retrieve the local Lsp4ij Path correctly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, 24.0.12-lsp4ijFix ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -144,10 +144,14 @@ dependencies {
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
         bundledPlugins providers.gradleProperty("platformBundledPlugins").orElse("").get().split(',').toList()
 
-        def lsp4ij = providers.gradleProperty('useLocal') && providers.gradleProperty('useLocal') == 'true' ?
-                file("../lsp4ij/build/distributions/LSP4IJ/") :
-                'com.redhat.devtools.lsp4ij:' + lsp4ijVersion
-        plugins lsp4ij
+        // Locate the LSP4IJ ZIP file in the distributions directory
+        def lsp4ijZip = file("../lsp4ij/build/distributions").listFiles()?.findAll { it.name.endsWith(".zip") }?.first()
+
+        // If the 'useLocal' Gradle property is set to 'true', use the locally built LSP4IJ plugin;
+        // otherwise, use the specified version in the build.gradle file.
+        providers.gradleProperty("useLocal").get() == 'true' ?
+                localPlugin(lsp4ijZip.absolutePath) :
+                plugin('com.redhat.devtools.lsp4ij', lsp4ijVersion)
         pluginVerifier()
         zipSigner()
         instrumentationTools()


### PR DESCRIPTION
In the current 24.0.12 tag, the condition for retrieving the local LSP4IJ is not working as expected. 
As a result, it defaults to version 0.8.1 specified in the `build.gradle` file. 

To address this, we have created a branch based on 24.0.12 with the necessary changes to correctly retrieve the local LSP4IJ path. This allows the cron job tag to be updated from `24.0.12` to `24.0.12-lsp4ijFix`, ensuring that the correct condition is applied and the local LSP4IJ is used as intended, enabling the cron job to run as expected.