### PR TITLE
When you use the Start action do not use the custom parameters from Start...

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -12,6 +12,7 @@ package io.openliberty.tools.intellij;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.runConfiguration.LibertyRunConfiguration;
 import io.openliberty.tools.intellij.util.BuildFile;
 import io.openliberty.tools.intellij.util.Constants;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
@@ -26,19 +27,17 @@ public class LibertyModule {
     private Constants.ProjectType projectType;
     private String name;
     private boolean validContainerVersion;
-
-    private String customStartParams;
-    private boolean runInContainer;
-
     private boolean debugMode;
     private ShellTerminalWidget shellWidget;
+    private LibertyRunConfiguration customRunConfig;
+    private boolean useCustom;
 
     public LibertyModule(Project project) {
         this.project = project;
-        this.customStartParams = "";
-        this.runInContainer = false;
         this.debugMode = false;
         this.shellWidget = null;
+        this.customRunConfig = null;
+        this.useCustom = false;
     }
 
     public LibertyModule(Project project, VirtualFile buildFile, String name, Constants.ProjectType projectType, boolean validContainerVersion) {
@@ -97,23 +96,34 @@ public class LibertyModule {
         this.project = project;
     }
 
-    public String getCustomStartParams() {
-        return customStartParams;
+    public LibertyRunConfiguration getCustomRunConfig() {
+        return customRunConfig;
     }
 
-    public void setCustomStartParams(String customStartParams) {
-        if (customStartParams == null) {
-            customStartParams = "";
+    public void setCustomRunConfig(LibertyRunConfiguration newCustomRunConfig) {
+        customRunConfig = newCustomRunConfig;
+    }
+
+    public String getCustomStartParams() {
+        if (customRunConfig == null || customRunConfig.getParams() == null) {
+            return "";
         }
-        this.customStartParams = customStartParams;
+        return customRunConfig.getParams();
+    }
+
+    public boolean isCustom() {
+        return useCustom;
+    }
+
+    public void setUseCustom(boolean isCustom) {
+        useCustom = isCustom;
     }
 
     public boolean runInContainer() {
-        return runInContainer;
-    }
-
-    public void setRunInContainer(boolean runInContainer) {
-        this.runInContainer = runInContainer;
+        if (customRunConfig == null) {
+            return false;
+        }
+        return customRunConfig.runInContainer();
     }
 
     public boolean isDebugMode() {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -56,10 +56,15 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             return;
         }
 
+        // Liberty Explorer (dashboard) Start action and Start... action comes through here
         String start = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CMD;
         String startInContainer = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
-        startCmd = libertyModule.runInContainer() ? startInContainer : start;
-        startCmd += libertyModule.getCustomStartParams();
+        if (libertyModule.isCustom()) {
+            startCmd = libertyModule.runInContainer() ? startInContainer : start;
+            startCmd += libertyModule.getCustomStartParams();
+        } else {
+            startCmd = start;
+        }
         if (libertyModule.isDebugMode()) {
             try {
                 String debugParam = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? Constants.LIBERTY_MAVEN_DEBUG_PARAM : Constants.LIBERTY_GRADLE_DEBUG_PARAM;
@@ -81,6 +86,8 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             return;
         }
 
+        // Reset this flag in the case that we got here via the custom start action
+        libertyModule.setUseCustom(false);
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd, startCmd);
         if (libertyModule.isDebugMode() && debugPort != -1) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -13,6 +13,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.*;
+import static io.openliberty.tools.intellij.util.Constants.ProjectType.*;
+import static io.openliberty.tools.intellij.util.Constants.*;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 import java.io.IOException;
@@ -33,17 +35,24 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
 
     @Override
     protected void executeLibertyAction(LibertyModule libertyModule) {
+        runInTerminal(libertyModule, false);
+    }
+
+    protected void runInTerminal(LibertyModule libertyModule, boolean runInContainer) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
         Constants.ProjectType projectType = libertyModule.getProjectType();
-        String projectName = project.getName();
+        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
+        if (widget == null) {
+            return;
+        }
 
-        String startCmd = null;
+        String startCmd;
         int debugPort = -1;
         DebugModeHandler debugHandler = new DebugModeHandler();
         String buildSettingsCmd;
         try {
-            if(projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
+            if(projectType.equals(LIBERTY_MAVEN_PROJECT)) {
                 buildSettingsCmd = LibertyMavenUtil.getMavenSettingsCmd(project, buildFile);
             } else {
                 buildSettingsCmd = LibertyGradleUtil.getGradleSettingsCmd(project, buildFile);
@@ -56,10 +65,13 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
             return;
         }
 
-        // Liberty Explorer (dashboard) Start action and Start... action comes through here
-        String start = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CMD;
-        String startInContainer = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? buildSettingsCmd + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD : buildSettingsCmd + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
-        if (libertyModule.isCustom()) {
+        // Handle Liberty Explorer (dashboard) Start action
+        // Also handle Start... action when LibertyRunConfiguration calls this
+        String start = buildSettingsCmd + (projectType.equals(LIBERTY_MAVEN_PROJECT) ? LIBERTY_MAVEN_START_CMD : LIBERTY_GRADLE_START_CMD);
+        String startInContainer = buildSettingsCmd + (projectType.equals(LIBERTY_MAVEN_PROJECT) ? LIBERTY_MAVEN_START_CONTAINER_CMD : LIBERTY_GRADLE_START_CONTAINER_CMD);
+        if (runInContainer) {
+            startCmd = startInContainer;
+        } else if (libertyModule.isCustom()) {
             startCmd = libertyModule.runInContainer() ? startInContainer : start;
             startCmd += libertyModule.getCustomStartParams();
         } else {
@@ -67,7 +79,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         }
         if (libertyModule.isDebugMode()) {
             try {
-                String debugParam = projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT) ? Constants.LIBERTY_MAVEN_DEBUG_PARAM : Constants.LIBERTY_GRADLE_DEBUG_PARAM;
+                String debugParam = projectType.equals(LIBERTY_MAVEN_PROJECT) ? LIBERTY_MAVEN_DEBUG_PARAM : LIBERTY_GRADLE_DEBUG_PARAM;
                 debugPort = debugHandler.getDebugPort(libertyModule);
                 String debugStr = debugParam + debugPort;
                 // do not append if debug port is already specified as part of start command
@@ -75,18 +87,13 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
                     startCmd += " " + debugParam + debugPort;
                 }
             } catch (IOException e) {
-                String msg = LocalizedResourceUtil.getMessage("liberty.debug.port.unresolved", getActionCommandName(), projectName);
+                String msg = LocalizedResourceUtil.getMessage("liberty.debug.port.unresolved", getActionCommandName(), project.getName());
                 notifyError(msg, project);
                 LOGGER.error(msg);
             }
         }
 
-        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
-        if (widget == null) {
-            return;
-        }
-
-        // Reset this flag in the case that we got here via the custom start action
+        // Do not use the custom parameters in the future unless we get here via the run configuration dialog
         libertyModule.setUseCustom(false);
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd, startCmd);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -43,13 +43,17 @@ public class LibertyDevStartContainerAction extends LibertyGeneralAction {
             } else {
                 startCmd = LibertyGradleUtil.getGradleSettingsCmd(project, buildFile) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
             }
-            startCmd += libertyModule.getCustomStartParams();
+            if (libertyModule.isCustom()) {
+                startCmd += libertyModule.getCustomStartParams();
+            }
         } catch (LibertyException ex) {
             // in this case, the settings specified to mvn or gradle are invalid and an error was launched by getMavenSettingsCmd or getGradleSettingsCmd
             LOGGER.warn(ex.getMessage()); // Logger.error creates an entry on "IDE Internal Errors", which we do not want
             notifyError(ex.getTranslatedMessage(), project);
             return;
         }
+        // Reset this flag in the case that we got here via the custom start action
+        libertyModule.setUseCustom(false);
         String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
         LibertyActionUtil.executeCommand(widget, cdToProjectCmd, startCmd);
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -15,46 +15,20 @@ import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.*;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
-public class LibertyDevStartContainerAction extends LibertyGeneralAction {
+public class LibertyDevStartContainerAction extends LibertyDevStartAction {
 
     /**
      * Returns the name of the action command being processed.
      *
      * @return The name of the action command being processed.
      */
+    @Override
     protected String getActionCommandName() {
         return LocalizedResourceUtil.getMessage("start.liberty.dev.container");
     }
 
     @Override
     protected void executeLibertyAction(LibertyModule libertyModule) {
-        Project project = libertyModule.getProject();
-        VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
-        if (widget == null) {
-            return;
-        }
-
-        Constants.ProjectType projectType = libertyModule.getProjectType();
-        String startCmd;
-        try {
-            if(projectType.equals(Constants.ProjectType.LIBERTY_MAVEN_PROJECT)) {
-                startCmd = LibertyMavenUtil.getMavenSettingsCmd(project, buildFile) + Constants.LIBERTY_MAVEN_START_CONTAINER_CMD;
-            } else {
-                startCmd = LibertyGradleUtil.getGradleSettingsCmd(project, buildFile) + Constants.LIBERTY_GRADLE_START_CONTAINER_CMD;
-            }
-            if (libertyModule.isCustom()) {
-                startCmd += libertyModule.getCustomStartParams();
-            }
-        } catch (LibertyException ex) {
-            // in this case, the settings specified to mvn or gradle are invalid and an error was launched by getMavenSettingsCmd or getGradleSettingsCmd
-            LOGGER.warn(ex.getMessage()); // Logger.error creates an entry on "IDE Internal Errors", which we do not want
-            notifyError(ex.getTranslatedMessage(), project);
-            return;
-        }
-        // Reset this flag in the case that we got here via the custom start action
-        libertyModule.setUseCustom(false);
-        String cdToProjectCmd = "cd \"" + buildFile.getParent().getPath() + "\"";
-        LibertyActionUtil.executeCommand(widget, cdToProjectCmd, startCmd);
+        runInTerminal(libertyModule, true);
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -107,7 +107,7 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
     }
 
     /**
-     * Runs when users select "Run" or "Debug" on a Liberty  run configuration
+     * Runs when users select "Run" or "Debug" on a Liberty run configuration
      *
      * @param executor    the execution mode selected by the user (run, debug, profile etc.)
      * @param environment the environment object containing additional settings for executing the configuration.
@@ -126,14 +126,6 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         }
         // run the start dev mode action
         AnAction action = ActionManager.getInstance().getAction(runInContainer() ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
-
-        // set custom start params
-        if (getParams() != null) {
-            libertyModule.setCustomStartParams(getParams());
-        } else {
-            libertyModule.setCustomStartParams("");
-        }
-        libertyModule.setRunInContainer(runInContainer());
 
         if (executor.getId().equals(DefaultDebugExecutor.EXECUTOR_ID)) {
             libertyModule.setDebugMode(true);

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -120,12 +120,19 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         LibertyModule libertyModule;
         try {
             libertyModule = libertyModules.getLibertyProjectFromString(getBuildFile());
+            libertyModule.setCustomRunConfig(this);
+            libertyModule.setUseCustom(true);
+            // Previous liberty action may have forced the edit dialog to appear, disable now
+            var config = environment.getRunnerAndConfigurationSettings();
+            if (config != null) {
+                config.setEditBeforeRun(false);
+            }
         } catch (NullPointerException e) {
             LOGGER.error(String.format("Could not resolve the Liberty module associated with build file: %s", getBuildFile()));
             throw new ExecutionException(e);
         }
-        // run the start dev mode action
-        AnAction action = ActionManager.getInstance().getAction(runInContainer() ? Constants.LIBERTY_DEV_START_CONTAINER_ACTION_ID : Constants.LIBERTY_DEV_START_ACTION_ID);
+        // run the start dev mode action which also handles runInContainer.
+        AnAction action = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_START_ACTION_ID);
 
         if (executor.getId().equals(DefaultDebugExecutor.EXECUTOR_ID)) {
             libertyModule.setDebugMode(true);

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation.
+ * Copyright (c) 2022, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -28,25 +28,23 @@ public class LibertyRunManagerListener implements RunManagerListener {
     protected static Logger LOGGER = Logger.getInstance(LibertyRunManagerListener.class);
 
     /**
-     * When a Liberty run configuration is removed, clear custom start parameters and run in container
+     * When a Liberty run configuration is removed, clear custom run configuration
      * from Liberty module
      *
-     * @param settings
+     * @param settings an IntelliJ run/debug configuration
      */
     @Override
     public void runConfigurationRemoved(@NotNull RunnerAndConfigurationSettings settings) {
-        if (settings.getConfiguration() instanceof LibertyRunConfiguration) {
-            LibertyRunConfiguration runConfig = (LibertyRunConfiguration) settings.getConfiguration();
+        if (settings.getConfiguration() instanceof LibertyRunConfiguration runConfig) {
             LibertyModules libertyModules = LibertyModules.getInstance();
             try {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
-                if (libertyModule != null && libertyModule.getCustomStartParams().equals(runConfig.getParams())) {
-                        libertyModule.setRunInContainer(false); // clear the run in container setting for the Liberty module.
-                        libertyModule.setCustomStartParams(""); // clear the custom params
+                if (libertyModule != null && libertyModule.getCustomRunConfig().equals(runConfig)) {
+                    libertyModule.setCustomRunConfig(null);
                 }
             } catch (Exception e) {
-                LOGGER.warn(String.format("Unable to clear custom start parameters for Liberty run configuration associated with: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
+                LOGGER.warn(String.format("Unable to clear custom run configuration for Liberty module: %s. Could not resolve build file.", runConfig.getBuildFile()), e);
             }
 
         }

--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunManagerListener.java
@@ -40,7 +40,7 @@ public class LibertyRunManagerListener implements RunManagerListener {
             try {
                 VirtualFile vBuildFile = VfsUtil.findFile(Paths.get(runConfig.getBuildFile()), true);
                 LibertyModule libertyModule = libertyModules.getLibertyModule(vBuildFile);
-                if (libertyModule != null && libertyModule.getCustomRunConfig().equals(runConfig)) {
+                if (libertyModule != null && runConfig.equals(libertyModule.getCustomRunConfig())) {
                     libertyModule.setCustomRunConfig(null);
                 }
             } catch (Exception e) {

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectTestCommon.java
@@ -1162,41 +1162,48 @@ public abstract class SingleModMPProjectTestCommon {
         UIBotTestUtils.runStartParamsConfigDialog(remoteRobot, null, true);
 
         try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+            // Wait for the project to start.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true, false);
+        } catch (RuntimeException r) {
+            // If server fails to start print the message and finally to try to stop it.
+            TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, r.getMessage());
         } finally {
             if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
-                // Stop dev mode.
+                // Stop dev mode in container.
                 UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", true, 3);
 
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+                // Wait for the server to stop so we can continue the test.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath, 40, false);
             }
         }
 
-        // Remove all existing configurations for a clean state.
+        // Remove the configuration added earlier.
         UIBotTestUtils.deleteLibertyRunConfigurations(remoteRobot);
         terminalClearBuffer();
 
-        // Start dev mode.
+        // Start dev mode to see if all the parameters and Run in Container are cleared.
         UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Start", true, 3);
 
         try {
-            // Validate that the project started.
-            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true);
+            // Wait for the project to start.
+            TestUtils.validateProjectStarted(testName, getSmMpProjResURI(), getSmMpProjPort(), getSmMPProjOutput(), absoluteWLPPath, true, false);
+        } catch (RuntimeException r) {
+            // If server fails to start print the message and finally to try to stop it.
+            TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, r.getMessage());
         } finally {
             if (TestUtils.isServerStopNeeded(absoluteWLPPath)) {
                 // Stop dev mode.
                 UIBotTestUtils.runLibertyActionFromLTWDropDownMenu(remoteRobot, "Stop", true, 3);
 
-                // Validate that the server stopped.
-                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath);
+                // Wait for the server to stop so we can continue the test.
+                TestUtils.validateLibertyServerStopped(testName, absoluteWLPPath, 40, false);
             }
         }
         String serverConsole = terminalCopyBuffer();
         if (serverConsole == null || serverConsole.isBlank()) {
             Assertions.fail("Server output terminal is missing or is empty");
         }
+        // The second start server should not have used Run in Container because we deleted the config.
         if (serverConsole.contains(LIBERTY_MAVEN_START_CONTAINER_CMD) ||
            serverConsole.contains(LIBERTY_GRADLE_START_CONTAINER_CMD)) {
             Assertions.fail("Server started in container when it should not have");

--- a/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/TestUtils.java
@@ -122,6 +122,20 @@ public class TestUtils {
      * @param wlpInstallPath   The liberty installation relative path.
      */
     public static void validateProjectStarted(String testName, String resourceURI, int port, String expectedResponse, String wlpInstallPath, boolean findConn) {
+        validateProjectStarted(testName, resourceURI, port, expectedResponse, wlpInstallPath, findConn, true);
+    }
+
+    /**
+     * Validates that the project is started.
+     *
+     * @param testName         The name of the test calling this method.
+     * @param resourceURI      The project resource URI.
+     * @param port             The port number to reach the project
+     * @param expectedResponse The expected resource response payload.
+     * @param wlpInstallPath   The liberty installation relative path.
+     * @param failOnNoStart    The test fails and error message and server log are printed
+     */
+    public static void validateProjectStarted(String testName, String resourceURI, int port, String expectedResponse, String wlpInstallPath, boolean findConn, boolean failOnNoStart) {
         printTrace(TraceSevLevel.INFO, testName + ":validateProjectStarted: Entry. Port: " + port + ", resourceURI: " + resourceURI);
 
         int retryCountLimit = 75;
@@ -165,13 +179,17 @@ public class TestUtils {
             }
         }
 
-        // If we are here, the expected outcome was not found. Print the Liberty server's messages.log and fail.
-        String msg = testName + ":validateProjectStarted: Timed out while waiting for project with resource URI " + resourceURI + "and port " + port + " to become available.";
-        printTrace(TraceSevLevel.ERROR, msg);
-        String wlpMsgLogPath = Paths.get(wlpInstallPath, WLP_MSGLOG_PATH.toString()).toString();
-        String msgHeader = "Message log for failed test: " + testName + ":validateProjectStarted";
-        printLibertyMessagesLogFile(msgHeader, wlpMsgLogPath);
-        Assertions.fail(msg);
+        if (failOnNoStart) {
+            // If we are here, the expected outcome was not found. Print the Liberty server's messages.log and fail.
+            String msg = testName + ":validateProjectStarted: Timed out while waiting for project with resource URI " + resourceURI + "and port " + port + " to become available.";
+            printTrace(TraceSevLevel.ERROR, msg);
+            String wlpMsgLogPath = Paths.get(wlpInstallPath, WLP_MSGLOG_PATH.toString()).toString();
+            String msgHeader = "Message log for failed test: " + testName + ":validateProjectStarted";
+            printLibertyMessagesLogFile(msgHeader, wlpMsgLogPath);
+            Assertions.fail(msg);
+        } else {
+            throw new RuntimeException(testName + ":validateProjectStarted: Timed out while waiting for project with resource URI " + resourceURI + "and port " + port + " to become available.");
+        }
     }
 
     /**


### PR DESCRIPTION
The Liberty config run button used to try to select Start action or Start in container. This is not needed, the Start action can handle both. 
Instead of copying the parameters into the Liberty module object we just store a reference to the Liberty run config. 
The difference in handling between Start and Start in container when you choose Debug looks like a bug. This pull request fixes that. Debugging regular Liberty and Liberty in a container should be the same. 
The test case fails when run on the main branch (without this fix):
```
GradleSingleModMPProjectTest > testStartInContainerParamClearedOnConfigRemoval() FAILED
    org.opentest4j.AssertionFailedError: Server started in container when it should not have
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
        at org.junit.jupiter.api.Assertions.fail(Assertions.java:135)
        at io.openliberty.tools.intellij.it.SingleModMPProjectTestCommon.testStartInContainerParamClearedOnConfigRemoval(SingleModMPProjectTestCommon.java:1202)
        at java.base@17.0.12/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  ...
```

Fixes #977
Fixes #955 
Fixes #424 