### PR TITLE
LibertyGeneralAction: Refactor to*() methods to use a mapping function.

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -144,7 +144,7 @@ public abstract class LibertyGeneralAction extends AnAction {
         return toArray(list, item -> String.valueOf(item.getBuildFile().toNioPath()));
     }
 
-    private String[] toArray(@NotNull List<LibertyModule> list, @NotNull Function<? super LibertyModule, ?> mapper) {
+    private String[] toArray(@NotNull List<LibertyModule> list, @NotNull Function<LibertyModule, String> mapper) {
         return list.stream().map(mapper).toArray(String[]::new);
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -30,6 +30,7 @@ import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 public abstract class LibertyGeneralAction extends AnAction {
     protected static final Logger LOGGER = Logger.getInstance(LibertyGeneralAction.class);
@@ -127,30 +128,24 @@ public abstract class LibertyGeneralAction extends AnAction {
     }
 
     protected final String[] toProjectNames(@NotNull List<LibertyModule> list) {
-        final int size = list.size();
-        final String[] projectNames = new String[size];
-        String[] differentiator = null;
-
-        for (int i = 0; i < size; ++i) {
+        return toArray(list, item -> {
             // We need a differentiator for the Shift-Shift Dialog Chooser in the event two projects have the
             // same name. get the build dir name where the build file resides to be that differentiator.
-            String parentFolderName = list.get(i).getBuildFile().getParent().getName();
+            String parentFolderName = item.getBuildFile().getParent().getName();
 
             // Use the parent folder name as a differntiator - add it to the string entry as
             // part of the project name
             // Entry in list will be of the form: "<app-name> : <buildfile parent folder>"
-            projectNames[i] = list.get(i).getName() + ": " + parentFolderName;
-        }
-        return projectNames;
+            return item.getName() + ": " + parentFolderName;
+        });
     }
 
     protected final String[] toProjectNamesTooltips(@NotNull List<LibertyModule> list) {
-        final int size = list.size();
-        final String[] projectNamesTooltips = new String[size];
-        for (int i = 0; i < size; ++i) {
-            projectNamesTooltips[i] = String.valueOf(list.get(i).getBuildFile().toNioPath());
-        }
-        return projectNamesTooltips;
+        return toArray(list, item -> String.valueOf(item.getBuildFile().toNioPath()));
+    }
+
+    private String[] toArray(@NotNull List<LibertyModule> list, @NotNull Function<? super LibertyModule, ?> mapper) {
+        return list.stream().map(mapper).toArray(String[]::new);
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -77,7 +77,7 @@ public abstract class LibertyGeneralAction extends AnAction {
 
                     // tooltip strings will appear when user hovers over one of the projects in the dialog list
                     // they will display the fully qualified path to the build file so that users can
-                    // differntiate in the case of same named application names in the chooser list
+                    // differentiate in the case of same named application names in the chooser list
                     final String[] projectNamesTooltips = toProjectNamesTooltips(libertyModules);
 
                     // Create a Chooser Dialog for multiple projects. User can select which one they
@@ -133,7 +133,7 @@ public abstract class LibertyGeneralAction extends AnAction {
             // same name. get the build dir name where the build file resides to be that differentiator.
             String parentFolderName = item.getBuildFile().getParent().getName();
 
-            // Use the parent folder name as a differntiator - add it to the string entry as
+            // Use the parent folder name as a differentiator - add it to the string entry as
             // part of the project name
             // Entry in list will be of the form: "<app-name> : <buildfile parent folder>"
             return item.getName() + ": " + parentFolderName;


### PR DESCRIPTION
Resolves https://github.com/OpenLiberty/liberty-tools-intellij/issues/1260

Moved common logic into a shared method. Pass in a mapping function to obtain the `String[]` from the `List`.