### PR TITLE
Override the method suggestedName() used during config creation

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -106,6 +106,19 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         return new LibertyRunSettingsEditor(getProject());
     }
 
+    @Override
+    public @Nullable String suggestedName() {
+        if (!getName().isEmpty()) {
+            // getName() is @notnull
+            // "Suggest" current name in case the user typed a name
+            return getName();
+        } else if (getModule() != null && !getModule().getName().isEmpty()) {
+            // getModule().getName() is @notnull
+            return getModule().getName();
+        }
+        return super.suggestedName();
+    }
+
     /**
      * Runs when users select "Run" or "Debug" on a Liberty  run configuration
      *


### PR DESCRIPTION
The parent class already has a method to suggest a name. The new config mechanism calls this method when creating a config and also when cloning the config to detect changes while you type.

Fixes #180 

This code suggests artifact id for Maven and directory name for Gradle. 
![image](https://github.com/user-attachments/assets/041f0de1-94e3-45fd-bf5e-d9aed4b12cd8)
![image](https://github.com/user-attachments/assets/3a578bc5-4c51-490a-9a54-74dd6a79c234)
