### PR TITLE
Remove intellij-2025.1-support tag from build.yaml file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, intellij-2025.1-support ]
+    branches: [ main ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:


### PR DESCRIPTION
Removed the `intellij-2025.1-support` tag, which was added for running builds in the feature branch, to proceed with merging into the main branch.