### PR TITLE
Add fix for unit test failures when updating the platform version to IntelliJ 2024.2.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ javaVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.5
+platformVersion=2024.1.7
 ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ javaVersion=17
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.1.7
+platformVersion=2024.2.5
 ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/core/BaseJakartaTest.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.roots.LanguageLevelProjectExtension;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IndexingTestUtil;
 import com.intellij.testFramework.builders.JavaModuleFixtureBuilder;
 import com.intellij.testFramework.builders.ModuleFixtureBuilder;
 import com.intellij.testFramework.fixtures.*;
@@ -76,15 +77,12 @@ public abstract class BaseJakartaTest extends MavenImportingTestCase {
             pomFiles.add(pomFile);
 
         }
-        // Make a blocking call to the Kotlin suspend function: importProjectsAsync().
-        BuildersKt.runBlocking(
-                EmptyCoroutineContext.INSTANCE,
-                (scope, continuation) -> importProjectsAsync(pomFiles.toArray(VirtualFile[]::new), continuation)
-        );
+        importProjectsWithErrors(pomFiles.toArray(VirtualFile[]::new));
         Module[] modules = ModuleManager.getInstance(getTestFixture().getProject()).getModules();
         for (Module module : modules) {
             setupJdkForModule(module.getName());
         }
+        IndexingTestUtil.waitUntilIndexesAreReady(project);
         // REVISIT: After calling setupJdkForModule() initialization appears to continue in the background
         // and a may cause a test to intermittently fail if it accesses the module too early. A 10-second wait
         // is hopefully long enough but would be preferable to synchronize on a completion event if one is


### PR DESCRIPTION
Fixes #1048

I haven't changed the platform version as 2024.2 in this PR, but I tested my changes after updating the platform version to IntelliJ versions 2024.1, 2024.2, and 2024.3. In all these versions, the unit tests passed with my changes.