### PR TITLE
Changed into IntelliJ 2025.1 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij.platform' version '2.1.0'
+    id 'org.jetbrains.intellij.platform' version '2.3.0'
     id 'org.jetbrains.kotlin.jvm' version '2.0.20'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.23774.109
+ideTargetVersion=251.23774.200
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.14649.49
+ideTargetVersion=251.22821.72
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.22821.72
+ideTargetVersion=251.23774.16
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.23774.16
+ideTargetVersion=251.23774.109
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.23774.200
+ideTargetVersion=251.23774.318
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ javaVersion=17
 # Target IntelliJ Community by default
 platformType=IC
 platformVersion=2024.1.7
-ideTargetVersion=251.23774.318
+ideTargetVersion=2025.1
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -194,7 +194,7 @@ public abstract class SingleModJakartaLSTestCommon {
 
         // pre-open project tree before attempting to open files needed by testcases
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
-        JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot,projectName);
+        JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot, projectName);
 
         // expand project directories that are specific to this test app being used by these testcases
         // must be expanded here before trying to open specific files

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -194,7 +194,7 @@ public abstract class SingleModJakartaLSTestCommon {
 
         // pre-open project tree before attempting to open files needed by testcases
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
-        JTreeFixture projTree = projectFrame.getProjectViewJTree(projectName);
+        JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot,projectName);
 
         // expand project directories that are specific to this test app being used by these testcases
         // must be expanded here before trying to open specific files

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModLibertyLSTestCommon.java
@@ -590,7 +590,7 @@ public abstract class SingleModLibertyLSTestCommon {
 
         // get a JTreeFixture reference to the file project viewer entry
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
-        JTreeFixture projTree = projectFrame.getProjectViewJTree(projectName);
+        JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot, projectName);
         projTree.expand(projectName, "src", "main", "liberty", "config");
 
         // open server.xml file

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPLSTestCommon.java
@@ -341,7 +341,7 @@ public abstract class SingleModMPLSTestCommon {
 
         // pre-open project tree before attempting to open files needed by testcases
         ProjectFrameFixture projectFrame = remoteRobot.find(ProjectFrameFixture.class, Duration.ofMinutes(2));
-        JTreeFixture projTree = projectFrame.getProjectViewJTree(projectName);
+        JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot, projectName);
 
         UIBotTestUtils.openFile(remoteRobot, projectName, "ServiceLiveHealthCheck", projectName, "src", "main", "java", "io.openliberty.mp.sample", "health");
         UIBotTestUtils.openFile(remoteRobot, projectName, "microprofile-config.properties", projectName, "src", "main", "resources", "META-INF");

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -109,24 +109,16 @@ public class UIBotTestUtils {
 
         remoteRobot.runJs("""
                 importClass(com.intellij.openapi.application.ApplicationManager);
-                importClass(com.intellij.ide.impl.OpenProjectTask);
+                importClass(com.intellij.ide.impl.ProjectUtil);
                 
-                const projectManager = com.intellij.openapi.project.ex.ProjectManagerEx.getInstanceEx();
-                let task;
-                try { 
-                    task = OpenProjectTask.build();
-                } catch(e) {
-                    task = OpenProjectTask.newProject();
-                }
                 const path = new java.io.File("%s").toPath();
+                            const openProject = new Runnable({
+                                run: function() {
+                                    ProjectUtil.openOrImport(path.toString(), null, false);
+                                }
+                            });
                 
-                const openProjectFunction = new Runnable({
-                    run: function() {
-                        projectManager.openProject(path, task);
-                    }
-                });
-                
-                ApplicationManager.getApplication().invokeLater(openProjectFunction);
+                ApplicationManager.getApplication().invokeLater(openProject);
                 """.formatted(projectFullPath));
 
         // Wait for the project frame to open, and make sure a few basic UI items are showing.

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -589,7 +589,7 @@ public class UIBotTestUtils {
                 hideTerminalWindow(remoteRobot);
 
                 // get a JTreeFixture reference to the file project viewer entry
-                JTreeFixture projTree = projectFrame.getProjectViewJTree(projectName);
+                JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot, projectName);
 
                 projTree.findText(fileName).doubleClick();
                 break;
@@ -628,7 +628,7 @@ public class UIBotTestUtils {
                 hideTerminalWindow(remoteRobot);
 
                 // get a JTreeFixture reference to the file project viewer entry
-                JTreeFixture projTree = projectFrame.getProjectViewJTree(projectName);
+                JTreeFixture projTree = projectFrame.getProjectViewJTree(remoteRobot, projectName);
 
                 // expand project directories that are specific to this test app being used by these testcases
                 // must be expanded here before trying to open specific

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -171,11 +171,13 @@ public class ProjectFrameFixture extends CommonContainerFixture {
      * @param xpathVars The Locator custom variables: text
      * @return The ComponentFixture object associated with the ProjectViewTree class.
      */
-    public JTreeFixture getProjectViewJTree(String... xpathVars) {
+    public JTreeFixture getProjectViewJTree(RemoteRobot remoteRobot, String... xpathVars) {
         String visibleText = xpathVars[0];
-        //return find(JTreeFixture.class, JTreeFixture.Companion.byType(), Duration.ofSeconds(10));
+        String intellijVersion = remoteRobot.callJs("com.intellij.openapi.application.ApplicationInfo.getInstance().getFullVersion();");
+        String className = intellijVersion.startsWith("2025.1") ? "MyProjectViewTree" : "ProjectViewTree";
+
         return find(JTreeFixture.class,
-                byXpath("//div[@class='ProjectViewTree' and contains(@visible_text, '" + visibleText + "')]"),
+                byXpath("//div[@class='" + className + "' and contains(@visible_text, '" + visibleText + "')]"),
                 Duration.ofMinutes(1));
     }
 


### PR DESCRIPTION
Fixes #1297 - updated to latest Intellij version 251.23774.16 and IntelliJ Platform Gradle Plugin to version 2.3.0
Fixes #1298 - Added a condition to check if the version is 2025.1—if so, it uses the `MyProjectViewTree` class; otherwise, it defaults to the `ProjectViewTree` class.
Fixes #1299 - With the beta build this issue is resolved.
Fixes #1302 - Modified the runJs script in the importProject function to accommodate to open both directory as well as project