### PR TITLE
Update the Lsp4Jakarta version number to the latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,20 +83,20 @@ configurations {
 
 dependencies {
 
-    implementation ('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.13.0') {
+    implementation ("org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:$lsp4mpVersion") {
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
     }
-    implementation ('org.eclipse.lemminx:org.eclipse.lemminx:0.26.1') {
+    implementation ("org.eclipse.lemminx:org.eclipse.lemminx:$lemminxVersion") {
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
     }
-    implementation 'io.openliberty.tools:liberty-langserver-lemminx:2.2.1'
-    implementation ('io.openliberty.tools:liberty-langserver:2.2.1') {
+    implementation "io.openliberty.tools:liberty-langserver-lemminx:$lclsLemminxVersion"
+    implementation ("io.openliberty.tools:liberty-langserver:$lclsVersion") {
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
     }
-    implementation ('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:' + lsp4JakartaVersion) {
+    implementation ("org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:$lsp4JakartaVersion") {
         exclude group: 'org.eclipse.lsp4mp'
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
@@ -125,19 +125,20 @@ dependencies {
     testImplementation 'com.automation-remarks:video-recorder-junit5:2.0'
 
     // define jars to grab locally (if falling back to mavenLocal() repo)
-    lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:0.13.0:uber') {
+    lsp("org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:$lsp4mpVersion:uber") {
+        //lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:' + lsp4mpVersion + ':uber') {
         transitive = false
     }
-    lsp('org.eclipse.lemminx:org.eclipse.lemminx:0.26.1:uber') {
+    lsp("org.eclipse.lemminx:org.eclipse.lemminx:$lemminxVersion:uber") {
         transitive = false
     }
-    lsp('io.openliberty.tools:liberty-langserver-lemminx:2.2.1:jar-with-dependencies') {
+    lsp("io.openliberty.tools:liberty-langserver-lemminx:$lclsLemminxVersion:jar-with-dependencies") {
         transitive = false
     }
-    lsp('io.openliberty.tools:liberty-langserver:2.2.1:jar-with-dependencies') {
+    lsp("io.openliberty.tools:liberty-langserver:$lclsVersion:jar-with-dependencies") {
         transitive = false
     }
-    lsp('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:' + lsp4JakartaVersion + ':jar-with-dependencies') {
+    lsp("org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:$lsp4JakartaVersion:jar-with-dependencies") {
         transitive = false
     }
     implementation files(new File(buildDir, 'server')) {

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
     }
-    implementation ('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.2.2') {
+    implementation ('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:' + lsp4JakartaVersion) {
         exclude group: 'org.eclipse.lsp4mp'
         exclude group: 'org.eclipse.lsp4j'
         exclude group: 'com.google.code.gson'
@@ -137,7 +137,7 @@ dependencies {
     lsp('io.openliberty.tools:liberty-langserver:2.2.1:jar-with-dependencies') {
         transitive = false
     }
-    lsp('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:0.2.2:jar-with-dependencies') {
+    lsp('org.eclipse.lsp4jakarta:org.eclipse.lsp4jakarta.ls:' + lsp4JakartaVersion + ':jar-with-dependencies') {
         transitive = false
     }
     implementation files(new File(buildDir, 'server')) {

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,6 @@ dependencies {
 
     // define jars to grab locally (if falling back to mavenLocal() repo)
     lsp("org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:$lsp4mpVersion:uber") {
-        //lsp('org.eclipse.lsp4mp:org.eclipse.lsp4mp.ls:' + lsp4mpVersion + ':uber') {
         transitive = false
     }
     lsp("org.eclipse.lemminx:org.eclipse.lemminx:$lemminxVersion:uber") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,6 @@ ideTargetVersion=2024.3
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties
+
+# Version numbers of dependencies
+lsp4JakartaVersion=0.2.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,7 @@ platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij
 
 # Version numbers of dependencies
 lsp4JakartaVersion=0.2.3
+lsp4mpVersion=0.13.0
+lemminxVersion=0.26.1
+lclsLemminxVersion=2.2.1
+lclsVersion=2.2.1


### PR DESCRIPTION
This pull request introduces a new way to specify the version number of language server dependencies. They are needed in two locations so it makes sense to specify the number once in the `gradle.properties` (like some others are) and then to reference that value.

We also update lsp4jakarta from 0.2.2 to 0.2.3.

Fixes #1309