### PR TITLE
Add fix for rechecking the expected hover data

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -121,14 +121,15 @@ public abstract class SingleModJakartaLSTestCommon {
             // validate the method signature is no longer set to public
             TestUtils.validateStringNotInFile(pathToSrc.toString(), publicString);
 
-            //there may be a diagnostic for "private" on method signature - move cursor to hover point
+            // there should be a diagnostic for "private" on method signature - move cursor to hover point
             UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, flaggedString, "SystemResource2.java", UIBotTestUtils.PopupType.DIAGNOSTIC);
 
             String foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);
 
-            // if the LS has not yet poulated the popup data, re-get the popup data
+            // if the LS has not yet populated the popup data, re-get the popup data
             for (int i = 0; i<5; i++){
                 if (foundHoverData.contains("method 'getProperties()' is never used")) {
+                    TestUtils.sleepAndIgnoreException(2);
                     UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, flaggedString, "SystemResource2.java", UIBotTestUtils.PopupType.DIAGNOSTIC);
                     foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);
                 }
@@ -171,7 +172,7 @@ public abstract class SingleModJakartaLSTestCommon {
             // validate public signature no longer found in java part
             TestUtils.validateStringNotInFile(pathToSrc.toString(), publicString);
 
-            //there should be a diagnostic - move cursor to hover point
+            // there should be a diagnostic - move cursor to hover point
             UIBotTestUtils.hoverForQuickFixInAppFile(remoteRobot, flaggedString, "SystemResource2.java", quickfixChooserString);
 
             // trigger and use the quickfix popup attached to the diagnostic

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation.
+ * Copyright (c) 2023, 2025 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -121,10 +121,21 @@ public abstract class SingleModJakartaLSTestCommon {
             // validate the method signature is no longer set to public
             TestUtils.validateStringNotInFile(pathToSrc.toString(), publicString);
 
-            //there should be a diagnostic for "private" on method signature - move cursor to hover point
+            //there may be a diagnostic for "private" on method signature - move cursor to hover point
             UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, flaggedString, "SystemResource2.java", UIBotTestUtils.PopupType.DIAGNOSTIC);
 
             String foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);
+
+            // if the LS has not yet poulated the popup data, re-get the popup data
+            for (int i = 0; i<5; i++){
+                if (foundHoverData.contains("method 'getProperties()' is never used")) {
+                    UIBotTestUtils.hoverInAppServerCfgFile(remoteRobot, flaggedString, "SystemResource2.java", UIBotTestUtils.PopupType.DIAGNOSTIC);
+                    foundHoverData = UIBotTestUtils.getHoverStringData(remoteRobot, UIBotTestUtils.PopupType.DIAGNOSTIC);
+                }
+                else {
+                    break;
+                }
+            }
             TestUtils.validateHoverData(expectedHoverData, foundHoverData);
             UIBotTestUtils.clickOnFileTab(remoteRobot, "SystemResource2.java");
 


### PR DESCRIPTION
Fixes #1307

Our current test checks for hover data only once and immediately validates the expected data. However, in Windows builds, the initially detected `HoverData` was sometimes incorrect, leading to test failures. This issue might be due to machine slowness, causing a delay in hover data reflection. To address this, the test now checks up to `five` times for the expected data. In some cases, three checks were sufficient, so I set the loop iteration value to five for reliability.

This is how the build logs appear when our expected hover data is not found on the first attempt.

<img width="1013" alt="Screenshot 2025-03-13 at 12 04 07 PM" src="https://github.com/user-attachments/assets/1470e94e-647e-455d-9c4c-48f3f209a10f" />
