### PR TITLE
Increase Delay to Obtain the Diagnostic, Leading to Test Pass

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -830,7 +830,6 @@ public class UIBotTestUtils {
 
         Exception error = null;
         for (int i = 0; i < 15; i++) {
-            System.out.println("//////// hover Attempt "+ i +" ------------");
             error = null;
             try {
                 // move the cursor to the origin of the editor
@@ -866,7 +865,7 @@ public class UIBotTestUtils {
                 break;
             } catch (WaitForConditionTimeoutException wftoe) {
                 error = wftoe;
-                TestUtils.sleepAndIgnoreException(5);
+                TestUtils.sleepAndIgnoreException(10);
                 // click on center of editor pane - allow hover to work on next attempt
                 editorNew.click();
             }
@@ -897,7 +896,6 @@ public class UIBotTestUtils {
 
         Exception error = null;
         for (int i = 0; i < 15; i++) {
-            System.out.println("//////// hover Attempt "+ i +" ------------");
             error = null;
             try {
                 // move the cursor to the origin of the editor
@@ -1265,6 +1263,7 @@ public class UIBotTestUtils {
                 }
 
                 // For either a FEATURE or a CONFIG stanza, insert where the cursor is currently located.
+                // In Windows OS, text entry into a file is much faster compared to other operating systems, so adding some delays between each character helps ensure proper LS requests and responses.
                 if (remoteRobot.isWin()) {
                     keyboard.enterText(stanzaSnippet, 200);
                 }

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -829,7 +829,8 @@ public class UIBotTestUtils {
         EditorFixture editorNew = remoteRobot.find(EditorFixture.class, locator, Duration.ofSeconds(20));
 
         Exception error = null;
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 15; i++) {
+            System.out.println("//////// hover Attempt "+ i +" ------------");
             error = null;
             try {
                 // move the cursor to the origin of the editor
@@ -865,7 +866,7 @@ public class UIBotTestUtils {
                 break;
             } catch (WaitForConditionTimeoutException wftoe) {
                 error = wftoe;
-                TestUtils.sleepAndIgnoreException(20);
+                TestUtils.sleepAndIgnoreException(5);
                 // click on center of editor pane - allow hover to work on next attempt
                 editorNew.click();
             }
@@ -895,7 +896,8 @@ public class UIBotTestUtils {
         Point originPt = new Point(1, 1);
 
         Exception error = null;
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 15; i++) {
+            System.out.println("//////// hover Attempt "+ i +" ------------");
             error = null;
             try {
                 // move the cursor to the origin of the editor
@@ -930,7 +932,7 @@ public class UIBotTestUtils {
                 break;
             } catch (WaitForConditionTimeoutException wftoe) {
                 error = wftoe;
-                TestUtils.sleepAndIgnoreException(2);
+                TestUtils.sleepAndIgnoreException(5);
                 // click on upper left corner of editor pane - allow hover to work on next attempt
                 editorNew.click(originPt);
             }
@@ -1263,7 +1265,12 @@ public class UIBotTestUtils {
                 }
 
                 // For either a FEATURE or a CONFIG stanza, insert where the cursor is currently located.
-                keyboard.enterText(stanzaSnippet);
+                if (remoteRobot.isWin()) {
+                    keyboard.enterText(stanzaSnippet, 200);
+                }
+                else {
+                    keyboard.enterText(stanzaSnippet);
+                }
 
                 if (completeWithPopup) {
                     // Select the appropriate completion suggestion in the pop-up window that is automatically


### PR DESCRIPTION
Part of  fix #1204

Since the corresponding tests are failing only on Windows OS, I added a delay between character entries for Windows only. I increased the iteration count from 10 to 15 to provide more delay, reduced the sleep time from 20 to 10 to avoid unnecessary delays between iterations in diagnostic test method, and increased the sleep time for the QuickFix hover data method.

I have set a delay of `200` after multiple checks because if we set it to 500 or above, we may get a timeout exception, and if we set it to 300, we may get a 'List is empty' exception, both of which cause test failures.

<img width="495" alt="Screenshot 2025-03-23 at 12 20 08 PM" src="https://github.com/user-attachments/assets/3a83cd2f-a6cc-495b-a370-731b13ed5b11" />


<img width="518" alt="Screenshot 2025-03-23 at 11 35 21 AM" src="https://github.com/user-attachments/assets/23bd17f4-2973-439d-b72f-1bbee8f241f7" />


 So, I chose the value 200. The default value is 50, which works faster on Windows OS, but on other operating systems, it enters at a normal speed. That's why I added a condition.