### PR TITLE
Updated LSP4IJ version to 0.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ version '25.0.5'
 
 def remoteRobotVersion = "0.11.23"
 // To switch to nightly version, append "@nightly" to the version number (i.e. 0.4.1-20240828-013108@nightly)
-def lsp4ijVersion = '0.13.0'
+def lsp4ijVersion = '0.14.0'
 
 allprojects {
     sourceCompatibility = javaVersion
@@ -247,7 +247,7 @@ intellijPlatform {
             <li> https://github.com/OpenLiberty/liberty-language-server/releases/tag/lemminx-liberty-2.2.1
           </ul>
         <li> Updated the <a href="https://github.com/eclipse/lsp4jakarta">Language Server for Jakarta EE</a> version to 0.2.3. For more information regarding changes for version 0.2.3, refer to the release notes: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/releases/tag/0.2.3
-        <li> Liberty Tools version 25.0.5 has been tested with <a href="https://github.com/redhat-developer/lsp4ij">LSP4IJ</a> version 0.13.0.
+        <li> Liberty Tools version 25.0.5 has been tested with <a href="https://github.com/redhat-developer/lsp4ij">LSP4IJ</a> version 0.14.0.
           <ul>
             <li> For more information regarding tested LSP4IJ versions, refer to the table in <a href="https://github.com/OpenLiberty/liberty-tools-intellij/blob/main/docs/user-guide.md#manually-install-specific-release-of-the-lsp4ij-plugin-from-the-marketplace">this section</a> of the user guide.
           </ul>

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ intellijPlatform {
             <li> https://github.com/OpenLiberty/liberty-language-server/releases/tag/lemminx-liberty-2.2.1
           </ul>
         <li> Updated the <a href="https://github.com/eclipse/lsp4jakarta">Language Server for Jakarta EE</a> version to 0.2.3. For more information regarding changes for version 0.2.3, refer to the release notes: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/releases/tag/0.2.3
-        <li> Liberty Tools version 25.0.5 has been tested with <a href="https://github.com/redhat-developer/lsp4ij">LSP4IJ</a> version 0.14.0.
+        <li> Liberty Tools version 25.0.5 has been tested with <a href="https://github.com/redhat-developer/lsp4ij">LSP4IJ</a> version 0.13.0.
           <ul>
             <li> For more information regarding tested LSP4IJ versions, refer to the table in <a href="https://github.com/OpenLiberty/liberty-tools-intellij/blob/main/docs/user-guide.md#manually-install-specific-release-of-the-lsp4ij-plugin-from-the-marketplace">this section</a> of the user guide.
           </ul>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,7 +61,7 @@ If you prefer to use an older version of LSP4IJ (e.g., a specific version that w
 |-----------------------|----------------------------------------------|
 | 24.0.9                | 0.5.0, 0.6.0, 0.7.0, 0.8.1                   |
 | 24.0.12               | 0.8.1, 0.9.0, 0.10.0, 0.11.0, 0.12.0, 0.13.0 |
-| 25.0.5                | 0.13.0                                       |
+| 25.0.5                | 0.13.0, 0.14.0                               |
 
 
 Steps to install an older version of LSP4IJ:


### PR DESCRIPTION
Updated LSP4IJ version to 0.14.0
Updated change notes as the LTI 25.0.5 has been tested with LSP4IJ 0.14.0