### PR TITLE
Update comments for PersistenceMapKeyDiagnosticsCollector - MapKey and MapKeyClass annotations

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceMapKeyDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceMapKeyDiagnosticsCollector.java
@@ -76,7 +76,10 @@ public class PersistenceMapKeyDiagnosticsCollector extends AbstractDiagnosticsCo
             }
         }
         if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
-            // A single field or property cannot have the same
+            //A single field or property cannot be annotated with both @MapKey and @MapKeyClass
+            //Specification References:
+            //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
+            //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
             diagnostics.add(createDiagnostic(fieldOrProperty, unit,
                     Messages.getMessage("MapKeyAnnotationsNotOnSameField"),
                     PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION, null,


### PR DESCRIPTION
Verify that PersistenceMapKeyDiagnosticsCollector is checking the correct constraint for annotations