### PR TITLE
Replaced the usage of ShellTerminalWidget with TerminalWidget

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModule.java
@@ -15,7 +15,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.runConfiguration.LibertyRunConfiguration;
 import io.openliberty.tools.intellij.util.BuildFile;
 import io.openliberty.tools.intellij.util.Constants;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import com.intellij.terminal.ui.TerminalWidget;
 
 /**
  * Represents a Liberty server module
@@ -28,14 +28,14 @@ public class LibertyModule {
     private String name;
     private boolean validContainerVersion;
     private boolean debugMode;
-    private ShellTerminalWidget shellWidget;
+    private TerminalWidget terminalWidget;
     private LibertyRunConfiguration customRunConfig;
     private boolean useCustom;
 
     public LibertyModule(Project project) {
         this.project = project;
         this.debugMode = false;
-        this.shellWidget = null;
+        this.terminalWidget = null;
         this.customRunConfig = null;
         this.useCustom = false;
     }
@@ -134,11 +134,11 @@ public class LibertyModule {
         this.debugMode = debugMode;
     }
 
-    public ShellTerminalWidget getShellWidget() {
-        return shellWidget;
+    public TerminalWidget getTerminalWidget() {
+        return terminalWidget;
     }
 
-    public void setShellWidget(ShellTerminalWidget shellWidget) {
-        this.shellWidget = shellWidget;
+    public void setTerminalWidget(TerminalWidget shellWidget) {
+        this.terminalWidget = shellWidget;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyModules.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.JBTerminalWidget;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.util.*;
 import org.xml.sax.SAXException;
 
@@ -229,7 +231,8 @@ public class LibertyModules {
             while (it.hasNext()) {
                 LibertyModule libertyModule = (LibertyModule) it.next();
                 // do not remove from list if the corresponding terminal widget has running commands
-                if (project.equals(libertyModule.getProject()) && !(libertyModule.getShellWidget() != null && libertyModule.getShellWidget().hasRunningCommands())) {
+                if (project.equals(libertyModule.getProject()) &&
+                        !(libertyModule.getTerminalWidget() != null && LibertyProjectUtil.isCommandRunningSafe(libertyModule.getTerminalWidget()))) {
                     it.remove();
                 }
             }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -11,10 +11,10 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.LibertyActionUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevRunTestsAction extends LibertyGeneralAction {
 
@@ -31,7 +31,7 @@ public class LibertyDevRunTestsAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
+        TerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -11,11 +11,11 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.*;
 import static io.openliberty.tools.intellij.util.Constants.ProjectType.*;
 import static io.openliberty.tools.intellij.util.Constants.*;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 import java.io.IOException;
 
@@ -42,7 +42,7 @@ public class LibertyDevStartAction extends LibertyGeneralAction {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
         Constants.ProjectType projectType = libertyModule.getProjectType();
-        ShellTerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
+        TerminalWidget widget = getTerminalWidgetWithFocus(true, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -9,11 +9,8 @@
  *******************************************************************************/
 package io.openliberty.tools.intellij.actions;
 
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.*;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStartContainerAction extends LibertyDevStartAction {
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -11,10 +11,10 @@ package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.util.LibertyActionUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStopAction extends LibertyGeneralAction {
 
@@ -31,7 +31,7 @@ public class LibertyDevStopAction extends LibertyGeneralAction {
     protected void executeLibertyAction(LibertyModule libertyModule) {
         Project project = libertyModule.getProject();
         VirtualFile buildFile = libertyModule.getBuildFile();
-        ShellTerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
+        TerminalWidget widget = getTerminalWidgetWithFocus(false, project, buildFile, getActionCommandName());
         if (widget == null) {
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.terminal.ui.TerminalWidget;
 import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyPluginIcons;
@@ -25,7 +26,6 @@ import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import io.openliberty.tools.intellij.util.LocalizedResourceUtil;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 
 import java.util.Arrays;
@@ -164,20 +164,20 @@ public abstract class LibertyGeneralAction extends AnAction {
      * Returns the Terminal widget for the corresponding Liberty module
      *
      * @param createWidget create Terminal widget if it does not already exist
-     * @return ShellTerminalWidget
+     * @return TerminalWidget
      */
-    protected ShellTerminalWidget getTerminalWidgetWithFocus(boolean createWidget, Project project, VirtualFile buildFile, String actionCmd) {
+    protected TerminalWidget getTerminalWidgetWithFocus(boolean createWidget, Project project, VirtualFile buildFile, String actionCmd) {
         LibertyModule libertyModule = LibertyModules.getInstance().getLibertyModule(buildFile);
         TerminalToolWindowManager terminalToolWindowManager = TerminalToolWindowManager.getInstance(project);
         // look for existing terminal tab
-        ShellTerminalWidget existingWidget = LibertyProjectUtil.getTerminalWidget(libertyModule, terminalToolWindowManager);
+        TerminalWidget existingWidget = LibertyProjectUtil.getTerminalWidget(libertyModule, terminalToolWindowManager);
         // look for creating new terminal tab
-        ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget, terminalToolWindowManager, existingWidget);
+        TerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, libertyModule, createWidget, terminalToolWindowManager, existingWidget);
         // Set Focus to existing terminal widget
         LibertyProjectUtil.setFocusToWidget(project, existingWidget);
 
         // Shows error for actions where terminal widget does not exist or action requires a terminal to already exist and expects "Start" to be running
-        if (widget == null || (!createWidget && !widget.hasRunningCommands())) {
+        if (widget == null || (!createWidget && !LibertyProjectUtil.isCommandRunningSafe(libertyModule.getTerminalWidget()))) {
             String msg;
             if (createWidget) {
                 msg = LocalizedResourceUtil.getMessage("liberty.terminal.cannot.resolve", actionCmd, project.getName());


### PR DESCRIPTION
Fixes #1360 

Replaced the usage of ShellTerminalWidget with TerminalWidget as suggested by JetBrains

Related discussion in YouTrack: https://platform.jetbrains.com/t/npe-when-updated-to-intellij-eap-5/734