### PR TITLE
Multiple @BeanParams incorrectly reported as error 

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/Jax_RSConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jax_rs/Jax_RSConstants.java
@@ -26,7 +26,7 @@ public class Jax_RSConstants {
 
     /* Annotations which make a resource method parameter a non entity parameter. */
     public static final ArrayList<String> NON_ENTITY_PARAM_ANNOTATIONS = new ArrayList<String>(
-            List.of("FormParam", "MatrixParam", "QueryParam", "PathParam", "CookieParam", "HeaderParam", "Context"));
+            List.of("FormParam", "MatrixParam", "QueryParam", "PathParam", "CookieParam", "HeaderParam", "Context", "BeanParam"));
 
     public static final String PATH_ANNOTATION = "jakarta.ws.rs.Path";
     public static final String PROVIDER_ANNOTATION = "jakarta.ws.rs.ext.Provider";
@@ -46,7 +46,7 @@ public class Jax_RSConstants {
             "jakarta.ws.rs.OPTIONS" };
     public final static String[] SET_OF_NON_ENTITY_PARAM_ANNOTATIONS = { "jakarta.ws.rs.FormParam",
             "jakarta.ws.rs.MatrixParam", "jakarta.ws.rs.QueryParam", "jakarta.ws.rs.PathParam",
-            "jakarta.ws.rs.CookieParam", "jakarta.ws.rs.HeaderParam", "jakarta.ws.rs.core.Context" };
+            "jakarta.ws.rs.CookieParam", "jakarta.ws.rs.HeaderParam", "jakarta.ws.rs.core.Context", "jakarta.ws.rs.BeanParam" };
     public final static String[] SET_OF_JAXRS_ANNOTATIONS1 = { PATH_ANNOTATION, PROVIDER_ANNOTATION };
 
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jaxrs/ResourceMethodTest.java
@@ -85,49 +85,25 @@ public class ResourceMethodTest extends BaseJakartaTest {
         JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-
-        Diagnostic d = JakartaForJavaAssert.d(21, 13, 46, "Resource methods cannot have more than one entity parameter.",
+        Diagnostic d1 = JakartaForJavaAssert.d(22, 13, 46, "Resource methods cannot have more than one entity parameter.",
                 DiagnosticSeverity.Error, "jakarta-jax_rs", "ResourceMethodMultipleEntityParams");
-
-        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d);
+        Diagnostic d2 = JakartaForJavaAssert.d(32, 13, 55, "Resource methods cannot have more than one entity parameter.",
+                DiagnosticSeverity.Error, "jakarta-jax_rs", "ResourceMethodMultipleEntityParams");
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 
         // Test for quick-fix code action
-        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d);
-        String newText1 = "/*******************************************************************************\n" +
-                "* Copyright (c) 2021 IBM Corporation.\n*\n" +
-                "* This program and the accompanying materials are made available under the\n" +
-                "* terms of the Eclipse Public License v. 2.0 which is available at\n" +
-                "* http://www.eclipse.org/legal/epl-2.0.\n*\n" +
-                "* SPDX-License-Identifier: EPL-2.0\n*\n" +
-                "* Contributors:\n*     Bera Sogut\n" +
-                "*******************************************************************************/\n\n" +
-                "package io.openliberty.sample.jakarta.jax_rs;\n\n" +
-                "import jakarta.ws.rs.DELETE;\n" +
-                "import jakarta.ws.rs.FormParam;\n\n" +
-                "public class MultipleEntityParamsResourceMethod {\n\n	" +
-                "@DELETE\n	" +
-                "public void resourceMethodWithTwoEntityParams(String entityParam1, @FormParam(value = \"\") String nonEntityParam) {\n        " +
-                "\n    }\n}\n";
-        TextEdit te1 = JakartaForJavaAssert.te(0, 0, 25, 0, newText1);
-        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam1", d, te1);
+        JakartaJavaCodeActionParams codeActionParams = JakartaForJavaAssert.createCodeActionParams(uri, d1);
+        String newText1 = "/*******************************************************************************\n*" +
+                " Copyright (c) 2021 IBM Corporation.\n*\n*" +
+                " This program and the accompanying materials are made available under the\n* terms of the Eclipse Public License v. 2.0 which is available at\n* http://www.eclipse.org/legal/epl-2.0.\n*\n* SPDX-License-Identifier: EPL-2.0\n*\n* Contributors:\n*     Bera Sogut\n*******************************************************************************/\n\npackage io.openliberty.sample.jakarta.jax_rs;\n\nimport jakarta.ws.rs.BeanParam;\nimport jakarta.ws.rs.DELETE;\nimport jakarta.ws.rs.FormParam;\n\npublic class MultipleEntityParamsResourceMethod {\n\n\t@DELETE\n\tpublic void resourceMethodWithTwoEntityParams(String entityParam1, @FormParam(value = \"\") String nonEntityParam) {\n        \n    }\n\n\t@DELETE\n\tpublic void resourceMethodWithTwoBeanParams(@BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {\n        \n    }\n\n\t@DELETE\n\tpublic void resourceMethodWithBeanParamsAndEnityParams(String entityString, int entityInt, @BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {\n        \n    }\n}\n";
+        TextEdit te1 = JakartaForJavaAssert.te(0, 0, 36, 0, newText1);
+        CodeAction ca1 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam1", d1, te1);
 
-        String newText2 = "/*******************************************************************************\n" +
-                "* Copyright (c) 2021 IBM Corporation.\n*\n" +
-                "* This program and the accompanying materials are made available under the\n" +
-                "* terms of the Eclipse Public License v. 2.0 which is available at\n" +
-                "* http://www.eclipse.org/legal/epl-2.0.\n*\n" +
-                "* SPDX-License-Identifier: EPL-2.0\n*\n* Contributors:\n" +
-                "*     Bera Sogut\n" +
-                "*******************************************************************************/\n\n" +
-                "package io.openliberty.sample.jakarta.jax_rs;\n\n" +
-                "import jakarta.ws.rs.DELETE;\n" +
-                "import jakarta.ws.rs.FormParam;\n\n" +
-                "public class MultipleEntityParamsResourceMethod {\n\n	" +
-                "@DELETE\n	" +
-                "public void resourceMethodWithTwoEntityParams(@FormParam(value = \"\") String nonEntityParam, int entityParam2) {" +
-                "\n        \n    }\n}\n";
-        TextEdit te2 = JakartaForJavaAssert.te(0, 0, 25, 0, newText2);
-        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d, te2);
+        String newText2 = "/*******************************************************************************\n*" +
+                " Copyright (c) 2021 IBM Corporation.\n*\n*" +
+                " This program and the accompanying materials are made available under the\n* terms of the Eclipse Public License v. 2.0 which is available at\n* http://www.eclipse.org/legal/epl-2.0.\n*\n* SPDX-License-Identifier: EPL-2.0\n*\n* Contributors:\n*     Bera Sogut\n*******************************************************************************/\n\npackage io.openliberty.sample.jakarta.jax_rs;\n\nimport jakarta.ws.rs.BeanParam;\nimport jakarta.ws.rs.DELETE;\nimport jakarta.ws.rs.FormParam;\n\npublic class MultipleEntityParamsResourceMethod {\n\n\t@DELETE\n\tpublic void resourceMethodWithTwoEntityParams(@FormParam(value = \"\") String nonEntityParam, int entityParam2) {\n        \n    }\n\n\t@DELETE\n\tpublic void resourceMethodWithTwoBeanParams(@BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {\n        \n    }\n\n\t@DELETE\n\tpublic void resourceMethodWithBeanParamsAndEnityParams(String entityString, int entityInt, @BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {\n        \n    }\n}\n";
+        TextEdit te2 = JakartaForJavaAssert.te(0, 0, 36, 0, newText2);
+        CodeAction ca2 = JakartaForJavaAssert.ca(uri, "Remove all entity parameters except entityParam2", d1, te2);
 
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
     }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/MultipleEntityParamsResourceMethod.java
@@ -13,6 +13,7 @@
 
 package io.openliberty.sample.jakarta.jax_rs;
 
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.FormParam;
 
@@ -20,6 +21,16 @@ public class MultipleEntityParamsResourceMethod {
 
 	@DELETE
 	public void resourceMethodWithTwoEntityParams(String entityParam1, @FormParam(value = "") String nonEntityParam, int entityParam2) {
+        
+    }
+
+	@DELETE
+	public void resourceMethodWithTwoBeanParams(@BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {
+        
+    }
+
+	@DELETE
+	public void resourceMethodWithBeanParamsAndEnityParams(String entityString, int entityInt, @BeanParam RequestBean requestBean, @BeanParam SessionBean sessionBean) {
         
     }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RequestBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/RequestBean.java
@@ -1,0 +1,14 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.PathParam;
+
+public class RequestBean {
+    @PathParam("userId")
+    private String userId;
+
+    @QueryParam("sort")
+    private String sort;
+
+}
+

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/SessionBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jaxrs/SessionBean.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.jax_rs;
+
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.PathParam;
+
+public class SessionBean {
+    @PathParam("sessionId")
+    private String sessionId;
+
+    @QueryParam("invalidateSession")
+    private boolean invalidateSession;
+
+}


### PR DESCRIPTION
Issue link = https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/522

As per https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0.html#entity_parameters
BeanParam is not an entity parameter as it used to map other resources like @QueryParam and @pathParam etc.
Therefore, it can be excluded from the ‘only one entity parameter’ validation rule.