### PR TITLE
Updated LCLS version to 2.3.1-SNAPSHOT and snapshot url change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ repositories {
     maven {
         url = "https://cache-redirector.jetbrains.com/download-pgp-verifier"
     }
+    maven {
+        url = "https://central.sonatype.com/repository/maven-snapshots/"
+    }
     intellijPlatform {
         defaultRepositories()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@ platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij
 lsp4JakartaVersion=0.2.3
 lsp4mpVersion=0.13.0
 lemminxVersion=0.26.1
-lclsLemminxVersion=2.3
-lclsVersion=2.3
+lclsLemminxVersion=2.3.1-SNAPSHOT
+lclsVersion=2.3.1-SNAPSHOT


### PR DESCRIPTION
Fixes #1359 

Updated LCLS version to 2.3.1-SNAPSHOT 
LCLS snapshot url changed to https://central.sonatype.com/repository/maven-snapshots/