### PR TITLE
Automated approach to change the Terminal Engine to CLASSIC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ javaVersion=21
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.5
-ideTargetVersion=2025.1
+platformVersion=2025.1.3
+ideTargetVersion=2025.1.3
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -28,6 +28,8 @@ import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyProjectSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import org.jetbrains.plugins.terminal.TerminalEngine;
+import org.jetbrains.plugins.terminal.TerminalOptionsProvider;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 import org.xml.sax.SAXException;
 
@@ -154,6 +156,7 @@ public class LibertyProjectUtil {
     public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget,
                                                         TerminalToolWindowManager terminalToolWindowManager, ShellTerminalWidget widget) {
         if (widget == null && createWidget) {
+            TerminalOptionsProvider.getInstance().setTerminalEngine(TerminalEngine.CLASSIC);
             // create a new terminal tab
             ShellTerminalWidget newTerminal = ShellTerminalWidget.toShellJediTermWidgetOrThrow(
                     terminalToolWindowManager.createShellWidget(project.getBasePath(), libertyModule.getName(),


### PR DESCRIPTION
Fixes #1360 

Automated approach to change the Terminal Engine to CLASSIC to resolve NullPointerException

Workaround details: https://youtrack.jetbrains.com/issue/IJSDK-2593/Breaking-change-from-IntelliJ-2025.1.2-causes-NPE-in-plugin-due-to-ShellTerminalWidget-casting#focus=Comments-27-12413451.0-0