### PR TITLE
Resolved NPE and application start failure with LTI during Intellij fresh installs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, 25.0.5-fix-release ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 useLocal=false
-pluginSinceBuild=242
+pluginSinceBuild=251.1
 pluginUntilBuild=251.*
 
 javaVersion=21
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.5
-ideTargetVersion=2025.1
+platformVersion=2025.1.1
+ideTargetVersion=2025.1.4.1
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -28,6 +28,8 @@ import io.openliberty.tools.intellij.LibertyModule;
 import io.openliberty.tools.intellij.LibertyModules;
 import io.openliberty.tools.intellij.LibertyProjectSettings;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import org.jetbrains.plugins.terminal.TerminalEngine;
+import org.jetbrains.plugins.terminal.TerminalOptionsProvider;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 import org.xml.sax.SAXException;
 
@@ -154,6 +156,7 @@ public class LibertyProjectUtil {
     public static ShellTerminalWidget getTerminalWidget(Project project, LibertyModule libertyModule, boolean createWidget,
                                                         TerminalToolWindowManager terminalToolWindowManager, ShellTerminalWidget widget) {
         if (widget == null && createWidget) {
+            TerminalOptionsProvider.getInstance().setTerminalEngine(TerminalEngine.CLASSIC);
             // create a new terminal tab
             ShellTerminalWidget newTerminal = ShellTerminalWidget.toShellJediTermWidgetOrThrow(
                     terminalToolWindowManager.createShellWidget(project.getBasePath(), libertyModule.getName(),


### PR DESCRIPTION
Fixes #1360 

- Changed `pluginSinceBuild` to `2025.1.1`
- Changed `platformVersion` to `2025.1.1`
- Changed `ideTargetVersion` to `2025.1.4.1`
- Set `TerminalEngine` to `CLASSIC`
- Updated `build.yaml` to run build against `25.0.5-fix-release` branch