### PR TITLE
Remove support branch from GitHub workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, intellij-2025.2-support ]
+    branches: [ main ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:


### PR DESCRIPTION
Part of #1344 
Remove support branch(`intellij-2025.2-support`) from GitHub workflow