### PR TITLE
Update IntelliJ version support range

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 useLocal=false
-pluginSinceBuild=242
+pluginSinceBuild=243
 pluginUntilBuild=252.*
 
 javaVersion=21
 
 # Target IntelliJ Community by default
 platformType=IC
-platformVersion=2024.2.5
-ideTargetVersion=2025.2
+platformVersion=2024.3.6
+ideTargetVersion=2025.2.1
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties


### PR DESCRIPTION
- Updated low end of IntelliJ support range to 2024.3
- Updated `platformVersion` (IntelliJ version to build with) to latest fix release of 2024.3 stream
- Updated `ideTargetVersion` (IntelliJ version to run locally with and run UI tests on) to the latest IntelliJ release, `2025.2.1`