### PR TITLE
Resolved terminal exception for liberty:start action for lower intellij versions

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -169,8 +170,9 @@ public class LibertyProjectUtil {
                     Method setEngineMethod = optionsProviderClass
                             .getMethod("setTerminalEngine", terminalEngineClass);
                     setEngineMethod.invoke(optionsProviderInstance, classicEngine);
-                } catch (Exception e) {
-                    LOGGER.info("Falling back to default terminal engine.", e);
+                } catch (ClassNotFoundException | NoSuchMethodException |
+                         IllegalAccessException | InvocationTargetException e) {
+                    LOGGER.debug("Falling back to default terminal engine.", e);
                 }
             }
 

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -34,7 +34,6 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.Callable;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -183,7 +183,7 @@ public class LibertyProjectUtil {
                     LOGGER.info("TerminalEngine class is not an enum, using default.");
                 }
             } catch (Exception e) {
-                LOGGER.info("Falling back to default terminal engine.", t);
+                LOGGER.info("Falling back to default terminal engine.", e);
             }
 
             // create a new terminal tab

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -11,6 +11,7 @@ package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -156,33 +157,21 @@ public class LibertyProjectUtil {
                                                         TerminalToolWindowManager terminalToolWindowManager, ShellTerminalWidget widget) {
         // Set Terminal engine to CLASSIC
         if (widget == null && createWidget) {
-            try {
-                Class<?> terminalEngineClass = Class.forName("org.jetbrains.plugins.terminal.TerminalEngine");
+            if (shouldForceClassicTerminal()) {
+                try {
+                    Class<?> optionsProviderClass = Class.forName("org.jetbrains.plugins.terminal.TerminalOptionsProvider");
+                    Object optionsProviderInstance = optionsProviderClass
+                            .getMethod("getInstance")
+                            .invoke(null);
 
-                if (terminalEngineClass.isEnum()) {
-                    Object[] constants = terminalEngineClass.getEnumConstants();
-
-                    boolean hasClassic = Arrays.stream(constants)
-                            .map(c -> ((Enum<?>) c).name())
-                            .anyMatch("CLASSIC"::equals);
-
-                    if (hasClassic) {
-                        Object classicEngine = Enum.valueOf((Class<Enum>) terminalEngineClass.asSubclass(Enum.class), "CLASSIC");
-
-                        Class<?> optionsProviderClass = Class.forName("org.jetbrains.plugins.terminal.TerminalOptionsProvider");
-                        Object optionsProviderInstance = optionsProviderClass.getMethod("getInstance").invoke(null);
-                        Method setEngineMethod = optionsProviderClass.getMethod("setTerminalEngine", terminalEngineClass);
-                        setEngineMethod.invoke(optionsProviderInstance, classicEngine);
-
-                        LOGGER.info("Terminal engine set to CLASSIC.");
-                    } else {
-                        LOGGER.info("CLASSIC engine not available, using default.");
-                    }
-                } else {
-                    LOGGER.info("TerminalEngine class is not an enum, using default.");
+                    Class<?> terminalEngineClass = Class.forName("org.jetbrains.plugins.terminal.TerminalEngine");
+                    Object classicEngine = Enum.valueOf((Class<Enum>) terminalEngineClass, "CLASSIC");
+                    Method setEngineMethod = optionsProviderClass
+                            .getMethod("setTerminalEngine", terminalEngineClass);
+                    setEngineMethod.invoke(optionsProviderInstance, classicEngine);
+                } catch (Exception e) {
+                    LOGGER.info("Falling back to default terminal engine.", e);
                 }
-            } catch (Exception e) {
-                LOGGER.info("Falling back to default terminal engine.", e);
             }
 
             // create a new terminal tab
@@ -193,6 +182,28 @@ public class LibertyProjectUtil {
             return newTerminal;
         }
         return widget;
+    }
+
+    /**
+     * Determines whether the IntelliJ terminal engine should be forced to "CLASSIC"
+     * Return {@code true} for all IntelliJ versions starting with 2025.1.x,
+     *          except for the explicitly excluded versions: 2025.1, 2025.1.1, 2025.1.1.1
+     * Return {@code false} for all other versions (e.g., 2024.x and 2025.2+)
+     *
+     * @return {@code true} if the IDE version requires forcing the "CLASSIC"
+     *          terminal engine; {@code false} otherwise.
+     */
+    private static boolean shouldForceClassicTerminal() {
+        ApplicationInfo appInfo = ApplicationInfo.getInstance();
+        String fullVersion = appInfo.getFullVersion();
+
+        if (!fullVersion.startsWith("2025.1")) {
+            return false;
+        }
+
+        // Explicitly exclude safe builds
+        Set<String> excluded = Set.of("2025.1", "2025.1.1", "2025.1.1.1");
+        return !excluded.contains(fullVersion);
     }
 
     public static void setFocusToWidget(Project project, ShellTerminalWidget widget) {


### PR DESCRIPTION
Fixes #1392 

Checked the TerminalEngine enum contains CLASSIC, as it is not available for old intellij versions