### PR TITLE
Add intellij-2025.3-support branch to CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, intellij-2025.3-support ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/liberty-tools-intellij/issues/1424