### PR TITLE
Increase Gradle JVM memory to prevent out of memory error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ lemminxVersion=0.26.1
 lclsLemminxVersion=2.4
 lclsVersion=2.4
 
-# Set maximum heap size to 2 GB and minimum to 1 GB
+# Increase Gradle memory by setting maximum heap size to 2 GB and minimum to 1 GB to prevent OutOfMemoryError
 org.gradle.jvmargs=-Xmx2g -Xms1g -Dfile.encoding=UTF-8


### PR DESCRIPTION
Fixes #1383 

