### PR TITLE
Revert "JavaCursorContextKind IllegalArgumentException workaround del…

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/PropertiesManagerForJakarta.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Red Hat, Inc.
+ * Copyright (c) 2020, 2024 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -122,9 +122,19 @@ public final class PropertiesManagerForJakarta {
 
     private JavaCursorContextResult adapt(org.eclipse.lsp4mp.commons.JavaCursorContextResult contextResult) {
         if (contextResult != null) {
-            var kind = contextResult.getKind();
-            if(kind != null)
-                return new JavaCursorContextResult(JavaCursorContextKind.forValue(kind.getValue()), contextResult.getPrefix());
+            return new JavaCursorContextResult(adapt(contextResult.getKind()), contextResult.getPrefix());
+        }
+        return null;
+    }
+
+    private JavaCursorContextKind adapt(org.eclipse.lsp4mp.commons.JavaCursorContextKind kind) {
+        if (kind != null) {
+            // Workaround for an issue with JavaCursorContextKind.forValue().
+            // See https://github.com/OpenLiberty/liberty-tools-intellij/issues/681 for details.
+            if (kind == org.eclipse.lsp4mp.commons.JavaCursorContextKind.NONE) {
+                return JavaCursorContextKind.NONE;
+            }
+            return JavaCursorContextKind.forValue(kind.getValue());
         }
         return null;
     }


### PR DESCRIPTION
Fixes #1438 

Revert "JavaCursorContextKind IllegalArgumentException workaround deletion Liberty tools (#1365)"

This reverts commit f53dc01954d2585c914a2a2f3621163c62a4ad9f.