### PR TITLE
Replace deprecated DataContext#getData(String) usage with SimpleDataContext

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
+++ b/src/main/java/io/openliberty/tools/intellij/runConfiguration/LibertyRunConfiguration.java
@@ -15,6 +15,7 @@ import com.intellij.execution.configurations.*;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
@@ -152,15 +153,10 @@ public class LibertyRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         }
 
         // Required configuration event data.
-        DataContext dataCtx = dataId -> {
-            if (CommonDataKeys.PROJECT.is(dataId)) {
-                return libertyModule.getProject();
-            }
-            if (Constants.LIBERTY_BUILD_FILE_DATAKEY.getName().equals(dataId)) {
-                return libertyModule.getBuildFile();
-            }
-            return null;
-        };
+        DataContext dataCtx = SimpleDataContext.builder()
+                .add(CommonDataKeys.PROJECT, libertyModule.getProject())
+                .add(Constants.LIBERTY_BUILD_FILE_DATAKEY, libertyModule.getBuildFile())
+                .build();
 
         AnActionEvent event = new AnActionEvent(null, dataCtx, ActionPlaces.UNKNOWN, new Presentation(), ActionManager.getInstance(), 0);
         action.actionPerformed(event);


### PR DESCRIPTION
Fixes #1120 
This PR replaces the direct implementation of DataContext using the deprecated `getData(String)` method with `SimpleDataContext.builder()`.

The new approach aligns with IntelliJ’s recommended DataKey-based API, removes deprecation warnings, and ensures forward compatibility with future IntelliJ platform versions.