### PR TITLE
Temporarily run the builds on MacOS 14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
             os: ubuntu-latest
             reportName: linux-test-report
           - runtime: mac
-            os: macOS-latest
+            os: macOS-14
             reportName: mac-test-report
           - runtime: windows
             os: windows-latest


### PR DESCRIPTION
Temporary solution for #1451 