### PR TITLE
Fix quickfix typo error from plugin.xml

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -465,7 +465,7 @@
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#RemoveExtraDisposes"
-                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.InvalidDisposesAnnotationOnMultipleMethodParams"/>
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveInvalidDisposerParamAnnotationQuickFix"/>
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#RemoveExtraDisposes"


### PR DESCRIPTION
This is to fix the invalid quick-fix name from plugin.xml.
And will fix the issue https://github.com/OpenLiberty/liberty-tools-intellij/issues/1462