### PR TITLE
Resolved override-only method usage violation in 'LibertyGeneralAction.actionPerformed'

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -11,6 +11,7 @@ package io.openliberty.tools.intellij;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ex.ActionUtil;
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -284,9 +285,10 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             }
             LibertyGeneralAction action = (LibertyGeneralAction) am.getAction(actionId);
             if (action != null) {
-                action.actionPerformed(new AnActionEvent(DataManager.getInstance().getDataContext(tree),
+                AnActionEvent event = new AnActionEvent(DataManager.getInstance().getDataContext(tree),
                         new Presentation(), ActionPlaces.UNKNOWN, ActionUiKind.NONE, null,
-                        0, am));
+                        0, am);
+                ActionUtil.performActionDumbAwareWithCallbacks(action, event);
             }
         }
     }


### PR DESCRIPTION
Fixes #1189 

Replaced the usage of `action.actionPerformed()` with `ActionUtil.performActionDumbAwareWithCallbacks()` which resolves the override-only method usage violation in `LibertyGeneralAction.actionPerformed`