### PR TITLE
Fix test failure in testCreateRunConfigAction()

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModMPProjectCfgTestCommon.java
@@ -102,6 +102,8 @@ public abstract class SingleModMPProjectCfgTestCommon {
     @BeforeEach
     public void beforeEach(TestInfo info) {
         TestUtils.printTrace(TestUtils.TraceSevLevel.INFO, this.getClass().getSimpleName() + "." + info.getDisplayName() + ". Entry");
+        // IntelliJ does not start building and indexing until the Project View is open
+        UIBotTestUtils.waitForIndexing(remoteRobot);
     }
 
     /**


### PR DESCRIPTION
Fixes #1479 

- Added waitForIndexing before each test, so that test starts after indexing is complete and it doesn't fail to find 'Combobox' 

I ran the testCreateRunConfigAction test multiple times with this fix, and it passed consistently. Sharing the build reference link that includes this change: https://github.com/anusreelakshmi934/liberty-tools-intellij/actions/runs/19673130379.