### PR TITLE
Modification to make open ended untilBuild

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = provider { null }
         }
         changeNotes = """
         <h2> 25.0.9 </h2>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 useLocal=false
 pluginSinceBuild=251
-pluginUntilBuild=253.*
 
 javaVersion=21
 


### PR DESCRIPTION
- Changed untilBuild to null to resolve initialization test failure associated with gradle.properties change.
- Done modifications to make open ended untilBuild