### PR TITLE
Enabled testJakartaQuickFixInJavaPart test as its failure rate below 5%

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/SingleModJakartaLSTestCommon.java
@@ -149,8 +149,8 @@ public abstract class SingleModJakartaLSTestCommon {
     /**
      * Tests Jakarta Language Server quick fix support in a Java source file
      */
-//    @Test
-//    @Video
+    @Test
+    @Video
     public void testJakartaQuickFixInJavaPart() {
         String publicString = "public Response getProperties() {";
         String privateString = "private Response getProperties() {";


### PR DESCRIPTION
Fixes #1489 

This PR re-enables the `testJakartaQuickFixInJavaPart` test, which was previously disabled in 24.0.6 due to intermittent failures caused by missing Jakarta quick fixes in diagnostics.

- Multiple runs (across Windows, Linux, and macOS) indicate a failure rate below 5%.
- Continue observing the failure rate across environments.
- If failure rate increases or becomes disruptive, further investigation into the root cause of missing quick fixes may be required.