### PR TITLE
Upgraded the ideTargetVersion to 2025.3.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,9 @@ pluginSinceBuild=251
 
 javaVersion=21
 
-# IntelliJ Platform baseline version
+# Intellij platform specifications
 platformType=IU
 platformVersion=2024.3.6
-
-# IntelliJ Platform target version used for runtime and test validation
 ideTargetVersion=2025.3.1.1
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ javaVersion=21
 # Target IntelliJ Community by default
 platformType=IU
 platformVersion=2024.3.6
-ideTargetVersion=2025.3
+ideTargetVersion=2025.3.1.1
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,11 @@ pluginSinceBuild=251
 
 javaVersion=21
 
+# IntelliJ Platform baseline version
 platformType=IU
 platformVersion=2024.3.6
+
+# IntelliJ Platform target version used for runtime and test validation
 ideTargetVersion=2025.3.1.1
 
 # Example: platformBundledPlugins = com.intellij.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ pluginSinceBuild=251
 
 javaVersion=21
 
-# Target IntelliJ Community by default
 platformType=IU
 platformVersion=2024.3.6
 ideTargetVersion=2025.3.1.1


### PR DESCRIPTION
Fixes #1510 

This PR upgrades the IntelliJ Platform `ideTargetVersion` to 2025.3.1.1.

Changes:
- Updated `ideTargetVersion` in the build configuration
- Verified plugin builds successfully against IntelliJ 2025.3.1.1
