### PR TITLE
Lsp4jakarta issue 633: Diagnostic for missing public no-arg constructor for @ServerEndpoint and @ClientEndpoint classes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, lsp4jakarta-0.2.6-integration-branch ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketConstants.java
@@ -1,4 +1,4 @@
-/** Copyright (c) 2022, 2025 IBM Corporation and others.
+/** Copyright (c) 2022, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketConstants.java
@@ -47,6 +47,7 @@ public class WebSocketConstants {
 
     public static final String DIAGNOSTIC_SERVER_ENDPOINT = "ChangeInvalidServerEndpoint";
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_WITHOUT_SLASH = "InvalidEndpointWithoutStartingSlash";
+    public static final String DIAGNOSTICS_MISSING_NOARG_CONSTRUCTOR = "missingPublicNoArgConstructor";
 
     /*
      * https://jakarta.ee/specifications/websocket/2.0/websocket-spec-2.0.html#

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * 
  * This program and the accompanying materials are made available under the 
  * terms of the Eclipse Public License v. 2.0 which is available at 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
@@ -68,6 +68,8 @@ public class WebSocketDiagnosticsCollector extends AbstractDiagnosticsCollector 
 
                 // ServerEndpoint annotation diagnostics
                 serverEndpointErrorCheck(type, diagnostics, unit);
+
+                publicNoArgsConstructorCheck(type, diagnostics, unit);
             }
         }
     }
@@ -312,6 +314,28 @@ public class WebSocketDiagnosticsCollector extends AbstractDiagnosticsCollector 
         }
         return endpointPathVars;
     }
+
+    private void publicNoArgsConstructorCheck(PsiClass type, List<Diagnostic> diagnostics, PsiJavaFile unit){
+        boolean hasConstructor = false, hasPublicNoArgConstructor = false;
+        for (PsiMethod method : type.getMethods()) {
+            if (isConstructorMethod(method)){
+                hasConstructor = true;
+                PsiParameterList params = method.getParameterList();
+                boolean isPublic = method.hasModifierProperty(PsiModifier.PUBLIC);
+                if(params.getParametersCount()==0 && isPublic){
+                    hasPublicNoArgConstructor = true;
+                }
+
+            }
+        }
+
+        if (hasConstructor && !hasPublicNoArgConstructor) {
+            diagnostics.add(createDiagnostic(type, unit,
+                    Messages.getMessage("publicNoArgConstructorMissing", type.getName()),
+                    WebSocketConstants.DIAGNOSTICS_MISSING_NOARG_CONSTRUCTOR, null, DiagnosticSeverity.Error));
+        }
+    }
+
     /**
      * Check if valueClass is a wrapper object for a primitive value Based on
      * https://github.com/eclipse/lsp4mp/blob/9789a1a996811fade43029605c014c7825e8f1da/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java#L294-L298

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
@@ -325,7 +325,6 @@ public class WebSocketDiagnosticsCollector extends AbstractDiagnosticsCollector 
                 if(params.getParametersCount()==0 && isPublic){
                     hasPublicNoArgConstructor = true;
                 }
-
             }
         }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketDiagnosticsCollector.java
@@ -316,10 +316,10 @@ public class WebSocketDiagnosticsCollector extends AbstractDiagnosticsCollector 
     }
 
     private void publicNoArgsConstructorCheck(PsiClass type, List<Diagnostic> diagnostics, PsiJavaFile unit){
-        boolean hasConstructor = false, hasPublicNoArgConstructor = false;
+        boolean hasUserDefinedConstructor = false, hasPublicNoArgConstructor = false;
         for (PsiMethod method : type.getMethods()) {
             if (isConstructorMethod(method)){
-                hasConstructor = true;
+                hasUserDefinedConstructor = true;
                 PsiParameterList params = method.getParameterList();
                 boolean isPublic = method.hasModifierProperty(PsiModifier.PUBLIC);
                 if(params.getParametersCount()==0 && isPublic){
@@ -328,7 +328,7 @@ public class WebSocketDiagnosticsCollector extends AbstractDiagnosticsCollector 
             }
         }
 
-        if (hasConstructor && !hasPublicNoArgConstructor) {
+        if (hasUserDefinedConstructor && !hasPublicNoArgConstructor) {
             diagnostics.add(createDiagnostic(type, unit,
                     Messages.getMessage("publicNoArgConstructorMissing", type.getName()),
                     WebSocketConstants.DIAGNOSTICS_MISSING_NOARG_CONSTRUCTOR, null, DiagnosticSeverity.Error));

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketNoArgConstructorQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/websocket/WebSocketNoArgConstructorQuickFix.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Joseph Bineesh
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.AddConstructorProposal;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCodeActionParticipant;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.java.corrections.proposal.ChangeCorrectionProposal;
+import io.openliberty.tools.intellij.util.ExceptionUtil;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ *
+ * Quick fix for adding a `public` no argument constructor
+ * for a websocket endpoint that do not have:
+ * - a no argument constructor
+ */
+
+public class WebSocketNoArgConstructorQuickFix implements IJavaCodeActionParticipant {
+    private static final Logger LOGGER = Logger.getLogger(WebSocketNoArgConstructorQuickFix.class.getName());
+
+    @Override
+    public String getParticipantId() {
+        return WebSocketNoArgConstructorQuickFix.class.getName();
+    }
+
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        PsiElement node = context.getCoveredNode();
+        PsiClass parentType = getBinding(node);
+
+        if (parentType != null) {
+            return addConstructor(diagnostic, context);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public CodeAction resolveCodeAction(JavaCodeActionResolveContext context) {
+        final CodeAction toResolve = context.getUnresolved();
+        PsiElement node = context.getCoveredNode();
+        PsiClass parentType = getBinding(node);
+
+        String constructorName = toResolve.getTitle();
+        ChangeCorrectionProposal proposal = new AddConstructorProposal(constructorName, context.getSource().getCompilationUnit(), context.getASTRoot(), parentType, 0, "public");
+
+        ExceptionUtil.executeWithWorkspaceEditHandling(context, proposal, toResolve, LOGGER, "Unable to create workspace edit for code actions to add constructors");
+
+        return toResolve;
+    }
+
+    protected PsiClass getBinding(PsiElement node) {
+        return PsiTreeUtil.getParentOfType(node, PsiClass.class);
+    }
+
+    private List<CodeAction> addConstructor(Diagnostic diagnostic, JavaCodeActionContext context) {
+        List<CodeAction> codeActions = new ArrayList<>();
+        CodeAction codeAction = JDTUtils.createCodeAction(context, diagnostic, Messages.getMessage("AddPublicConstructor"), getParticipantId());
+        codeActions.add(codeAction);
+        return codeActions;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -371,6 +371,10 @@
                                    group="jakarta"
                                    targetDiagnostic="jakarta-websocket#InvalidEndpointWithoutStartingSlash"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.PrefixSlashAnnotationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-websocket#missingPublicNoArgConstructor"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketNoArgConstructorQuickFix"/>
         <!-- Servlet -->
         <javaCodeActionParticipant kind="quickfix"
                                    group="jakarta"

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -1,5 +1,5 @@
 # /*******************************************************************************
-# * Copyright (c) 2022, 2025 IBM Corporation and others.
+# * Copyright (c) 2022, 2026 IBM Corporation and others.
 # *
 # * This program and the accompanying materials are made available under the
 # * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -185,6 +185,7 @@ ServerEndpointNoSlash = Server endpoint paths must start with a leading '/'.
 ServerEndpointRelative = Server endpoint paths must not contain the sequences '/../', '/./' or '//'.
 ServerEndpointNotLevel1 = Server endpoint paths must be a URI-template (level-1) or a partial URI.
 ServerEndpointDuplicateVar = Server endpoint paths must not use the same variable more than once in a path.
+publicNoArgConstructorMissing = WebSocket endpoint class {0} must declare a public no-argument constructor.
 
 # WebSocketDiagnosticsQuickFix
 PrefixSlashToValueAttribute = Prefix value with '/'

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2022, 2025 IBM Corporation and others.
+* Copyright (c) 2022, 2026 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/websocket/JakartaWebSocketTest.java
@@ -266,4 +266,35 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         CodeAction ca = ca(uri, "Add a no-arg public constructor to this class", d, te);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionsParams, utils, ca);
     }
+
+
+    @Test
+    public void testDefaultConstructor() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/DefaultConstructorTest.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testUserDefinedNoArgConstructor() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/websocket/UserDefinedNoArgConstrctor.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DefaultConstructorTest.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DefaultConstructorTest.java
@@ -1,0 +1,9 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/path")
+public class DefaultConstructorTest {
+
+	
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/MissingPublicNoArgConstructor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/MissingPublicNoArgConstructor.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/path")
+public class MissingPublicNoArgConstructor {
+
+	String status;
+
+	public MissingPublicNoArgConstructor(String status) {
+		super();
+		this.status = status;
+	}
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/UserDefinedNoArgConstrctor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/UserDefinedNoArgConstrctor.java
@@ -1,0 +1,12 @@
+package io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/path")
+public class UserDefinedNoArgConstrctor {
+
+	public UserDefinedNoArgConstrctor() {
+		super();
+	}
+	
+}


### PR DESCRIPTION
Issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/633
Lsp4jakarta PR: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/795