### PR TITLE
Fixes issue #1522: Sync up from lsp4jakarta to show all valid diagnostics for constraint annotations at once

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -86,24 +86,25 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                 diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                         source, DIAGNOSTIC_CODE_STATIC,
                         annotationName, DiagnosticSeverity.Error));
-            } else {
-                PsiType type = (isMethod) ? ((PsiMethod) element).getReturnType() : (isField) ?
-                        ((PsiField) element).getType() : ((PsiParameter) element).getType();
-                if (type instanceof PsiClassType) {
-                    PsiType t = PsiPrimitiveType.getUnboxedType(type);
-                    if (t != null) {
-                        type = t;
-                    }
+            }
+            PsiType type = (isMethod) ? ((PsiMethod) element).getReturnType() : (isField) ?
+                    ((PsiField) element).getType() : ((PsiParameter) element).getType();
+            if (type instanceof PsiClassType) {
+                PsiType t = PsiPrimitiveType.getUnboxedType(type);
+                if (t != null) {
+                    type = t;
                 }
-
-                if (matchedAnnotation.equals(ASSERT_FALSE) || matchedAnnotation.equals(ASSERT_TRUE)) {
+            }
+            //The below block throws diagnostics if invalid element type is used with constraint annotations
+            switch (matchedAnnotation) {
+                case ASSERT_FALSE, ASSERT_TRUE -> {
                     String source = getSource(isMethod, isField, annotationName, "AnnotationBoolean");
                     if (!type.equals(PsiTypes.booleanType())) {
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
-                } else if (matchedAnnotation.equals(DECIMAL_MAX) || matchedAnnotation.equals(DECIMAL_MIN)
-                        || matchedAnnotation.equals(DIGITS)) {
+                }
+                case DECIMAL_MAX, DECIMAL_MIN, DIGITS -> {
                     if (!type.getCanonicalText().equals(BIG_DECIMAL)
                             && !type.getCanonicalText().equals(BIG_INTEGER)
                             && !type.getCanonicalText().equals(CHAR_SEQUENCE)
@@ -115,14 +116,9 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(), source,
                                 DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
-                } else if (matchedAnnotation.equals(EMAIL)) {
-                    checkStringOnly(element, diagnostics, annotationName, isMethod, type, isField);
-                } else if (matchedAnnotation.equals(NOT_BLANK)) {
-                    checkStringOnly(element, diagnostics, annotationName, isMethod, type, isField);
-                } else if (matchedAnnotation.equals(PATTERN)) {
-                    checkStringOnly(element, diagnostics, annotationName, isMethod, type, isField);
-                } else if (matchedAnnotation.equals(FUTURE) || matchedAnnotation.equals(FUTURE_OR_PRESENT)
-                        || matchedAnnotation.equals(PAST) || matchedAnnotation.equals(PAST_OR_PRESENT)) {
+                }
+                case EMAIL, PATTERN, NOT_BLANK -> checkStringOnly(element, diagnostics, annotationName, isMethod, type, isField);
+                case FUTURE, FUTURE_OR_PRESENT, PAST, PAST_OR_PRESENT -> {
                     String dataType = type.getCanonicalText();
                     String dataTypeFQName = getMatchedJavaElementName(classType, dataType,
                             SET_OF_DATE_TYPES.toArray(new String[0]));
@@ -131,7 +127,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
-                } else if (matchedAnnotation.equals(MIN) || matchedAnnotation.equals(MAX)) {
+                }
+                case MIN, MAX -> {
                     if (!type.getCanonicalText().equals(BIG_DECIMAL)
                             && !type.getCanonicalText().equals(BIG_INTEGER)
                             && !type.equals(PsiTypes.byteType())
@@ -142,8 +139,8 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
-                } else if (matchedAnnotation.equals(NEGATIVE) || matchedAnnotation.equals(NEGATIVE_OR_ZERO)
-                        || matchedAnnotation.equals(POSITIVE) || matchedAnnotation.equals(POSITIVE_OR_ZERO)) {
+                }
+                case NEGATIVE, NEGATIVE_OR_ZERO, POSITIVE, POSITIVE_OR_ZERO -> {
                     if (!type.getCanonicalText().equals(BIG_DECIMAL)
                             && !type.getCanonicalText().equals(BIG_INTEGER)
                             && !type.equals(PsiTypes.byteType())
@@ -156,13 +153,15 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
-                } else if (matchedAnnotation.equals(NOT_EMPTY) || matchedAnnotation.equals(SIZE)) {
+                }
+                case NOT_EMPTY, SIZE -> {
                     if (!(isSizeOrNonEmptyAllowed(type))) {
                         String source = getSource(isMethod, isField, annotationName, "SizeOrNonEmptyAnnotations");
                         diagnostics.add(createDiagnostic(element, (PsiJavaFile) element.getContainingFile(),
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
                 }
+                default -> System.out.println("Unexpected value for annotation");
             }
         }
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/beanvalidation/BeanValidationDiagnosticsCollector.java
@@ -25,9 +25,12 @@ import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils.getSimpl
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.beanvalidation.BeanValidationConstants.*;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsCollector {
 
+    private static final Logger LOGGER = Logger.getLogger(BeanValidationDiagnosticsCollector.class.getName());
     public BeanValidationDiagnosticsCollector() {
         super();
     }
@@ -161,7 +164,7 @@ public class BeanValidationDiagnosticsCollector extends AbstractDiagnosticsColle
                                 source, DIAGNOSTIC_CODE_INVALID_TYPE, annotationName, DiagnosticSeverity.Error));
                     }
                 }
-                default -> System.out.println("Unexpected value for annotation");
+                default -> LOGGER.log(Level.SEVERE, "Unexpected value for annotation");
             }
         }
     }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/beanvalidation/BeanValidationTest.java
@@ -162,14 +162,17 @@ public class BeanValidationTest extends BaseJakartaTest {
         Diagnostic d20 = d(63, 27, 36,
                 "Constraint annotations are not allowed on static fields.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.Past");
-        Diagnostic d21 = d(66, 20, 26,
+        Diagnostic d21 = d(63, 27, 36,
+                "The @Past annotation can only be used on: Date, Calendar, Instant, LocalDate, LocalDateTime, LocalTime, MonthDay, OffsetDateTime, OffsetTime, Year, YearMonth, ZonedDateTime, HijrahDate, JapaneseDate, JapaneseDate, MinguoDate and ThaiBuddhistDate type fields.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Past");
+        Diagnostic d22 = d(66, 20, 26,
                 "This annotation can only be used on fields of type CharSequence, Collection, Array, or Map.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Size");
-        Diagnostic d22 = d(69, 29, 45,
+        Diagnostic d23 = d(69, 29, 45,
                 "This annotation can only be used on fields of type CharSequence, Collection, Array, or Map.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.NotEmpty");
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7, d8,
-                d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20, d21, d22);
+                d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20, d21, d22, d23);
 
         // Test quickfix codeActions - type (1-17), static, static+type (should only display static)
         String newText = "package io.openliberty.sample.jakarta.beanvalidation;\n\nimport java.util.Calendar;\nimport java.util.List;\n\n" +
@@ -301,9 +304,9 @@ public class BeanValidationTest extends BaseJakartaTest {
                 "    private static boolean doubleBad;      // static and invalid type\n\n    private Integer number;\n\n" +
                 "    @NotEmpty\n    private ValidConstraints validConstraints;\n}";
 
-        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d21);
+        JakartaJavaCodeActionParams codeActionParams5 = createCodeActionParams(uri, d22);
         TextEdit te6 = te(0, 0, 70, 1, newText6);
-        CodeAction ca6 = ca(uri, "Remove constraint annotation Size from element", d1, te6);
+        CodeAction ca6 = ca(uri, "Remove constraint annotation Size from element", d22, te6);
 
         assertJavaCodeAction(codeActionParams5, utils, ca6);
 
@@ -322,9 +325,9 @@ public class BeanValidationTest extends BaseJakartaTest {
                 "    private static boolean doubleBad;      // static and invalid type\n\n    @Size\n    private Integer number;\n\n" +
                 "    private ValidConstraints validConstraints;\n}";
 
-        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d22);
+        JakartaJavaCodeActionParams codeActionParams6 = createCodeActionParams(uri, d23);
         TextEdit te7 = te(0, 0, 70, 1, newText7);
-        CodeAction ca7 = ca(uri, "Remove constraint annotation NotEmpty from element", d22, te7);
+        CodeAction ca7 = ca(uri, "Remove constraint annotation NotEmpty from element", d23, te7);
 
         assertJavaCodeAction(codeActionParams6, utils, ca7);
 
@@ -687,10 +690,13 @@ public class BeanValidationTest extends BaseJakartaTest {
         Diagnostic d3 = d(31, 23, 33,
                 "Constraint annotations are not allowed on static methods.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "MakeNotStatic", "jakarta.validation.constraints.AssertFalse");
-        Diagnostic d4 = d(36, 19, 28,
+        Diagnostic d4 = d(31, 23, 33,
+                "The @AssertFalse annotation can only be used on boolean and Boolean type methods.",
+                DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.AssertFalse");
+        Diagnostic d5 = d(36, 19, 28,
                 "This annotation can only be used on methods that have CharSequence, Collection, Array or Map as a return type.",
                 DiagnosticSeverity.Error, "jakarta-bean-validation", "FixTypeOfElement", "jakarta.validation.constraints.Size");
-        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4);
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
 
         // Test quickfix codeAction
         String newText1 = "package io.openliberty.sample.jakarta.beanvalidation;\n\nimport jakarta.validation.constraints.AssertFalse;\n" +
@@ -772,9 +778,9 @@ public class BeanValidationTest extends BaseJakartaTest {
                 "public String notBoolean() {            // invalid type\n        return \"aha!\";\n    }\n\n    @AssertFalse\n    " +
                 "private static int notBoolTwo(int x) {  // invalid type, static\n        return x;\n    }\n\n    " +
                 "private double getSalary(double x) {\n        return x;\n    }\n}";
-        codeActionParams = createCodeActionParams(uri, d4);
+        codeActionParams = createCodeActionParams(uri, d5);
         te = te(0, 0, 39, 1, newText6);
-        ca = ca(uri, "Remove constraint annotation Size from element", d4, te);
+        ca = ca(uri, "Remove constraint annotation Size from element", d5, te);
 
         assertJavaCodeAction(codeActionParams, utils, ca);
     }


### PR DESCRIPTION
Fixes #1522 
lsp4jakarta PR: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/806
lsp4jakarta issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/523