### PR TITLE
Fixes #1532: Sync diagnostics add invalid abstract and public no args constructor diagnostics for interceptors

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -240,5 +240,5 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
     protected static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
     }
-    
+
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -237,7 +237,7 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
      * @param m method
      * @return true if the given method is a constructor and false otherwise
      */
-    protected static boolean isConstructorMethod(PsiMethod m) {
+    public static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -239,6 +240,29 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
      */
     protected static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
+    }
+
+    /**
+     * Checks if the given method is a constructor and has valid no-args constructor.
+     *
+     * @param method
+     * @param constructorInfo
+     * @return Map<String, Boolean>
+     */
+    public static Map<String, Boolean> hasValidNoArgsConstructor(PsiMethod method, Map<String,Boolean> constructorInfo) {
+        if (isConstructorMethod(method)) {
+            constructorInfo.put("hasConstructor", true); // Check explicit constructor declaration
+            PsiParameterList params = method.getParameterList();
+            if (params.getParametersCount() == 0) { // Checks manually declared no-args constructor
+                if (method.hasModifierProperty(PsiModifier.PUBLIC)) {
+                    constructorInfo.put("hasValidPublicNoArgsConstructor", true);
+                }
+                if (method.hasModifierProperty(PsiModifier.PROTECTED)) {
+                    constructorInfo.put("hasValidProtectedNoArgsConstructor", true);
+                }
+            }
+        }
+        return constructorInfo;
     }
 
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2026 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,6 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -241,28 +240,4 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
     protected static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
     }
-
-    /**
-     * Checks if the given method is a constructor and has valid no-args constructor.
-     *
-     * @param method
-     * @param constructorInfo
-     * @return Map<String, Boolean>
-     */
-    public static Map<String, Boolean> hasValidNoArgsConstructor(PsiMethod method, Map<String,Boolean> constructorInfo) {
-        if (isConstructorMethod(method)) {
-            constructorInfo.put("hasConstructor", true); // Check explicit constructor declaration
-            PsiParameterList params = method.getParameterList();
-            if (params.getParametersCount() == 0) { // Checks for user defined no-args constructor
-                if (method.hasModifierProperty(PsiModifier.PUBLIC)) {
-                    constructorInfo.put("hasValidPublicNoArgsConstructor", true);
-                }
-                if (method.hasModifierProperty(PsiModifier.PROTECTED)) {
-                    constructorInfo.put("hasValidProtectedNoArgsConstructor", true);
-                }
-            }
-        }
-        return constructorInfo;
-    }
-
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -253,7 +253,7 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
         if (isConstructorMethod(method)) {
             constructorInfo.put("hasConstructor", true); // Check explicit constructor declaration
             PsiParameterList params = method.getParameterList();
-            if (params.getParametersCount() == 0) { // Checks manually declared no-args constructor
+            if (params.getParametersCount() == 0) { // Checks for user defined no-args constructor
                 if (method.hasModifierProperty(PsiModifier.PUBLIC)) {
                     constructorInfo.put("hasValidPublicNoArgsConstructor", true);
                 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -240,4 +240,5 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
     protected static boolean isConstructorMethod(PsiMethod m) {
         return m.isConstructor();
     }
+    
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/ConstructorInfoDiagnosticHelper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/ConstructorInfoDiagnosticHelper.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and calculatedValues.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
+
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiParameterList;
+
+/**
+ * Constructor information diagnostics helper for a given method.
+ *
+ * @author Archana Iyer
+ *
+ */
+public final class ConstructorInfoDiagnosticHelper {
+
+    private boolean hasConstructor;
+    private boolean hasValidPublicNoArgsConstructor;
+    private boolean hasValidProtectedNoArgsConstructor;
+
+    private ConstructorInfoDiagnosticHelper(boolean hasConstructor,
+                                            boolean hasValidPublicNoArgsConstructor,
+                                            boolean hasValidProtectedNoArgsConstructor) {
+        this.hasConstructor = hasConstructor;
+        this.hasValidPublicNoArgsConstructor = hasValidPublicNoArgsConstructor;
+        this.hasValidProtectedNoArgsConstructor = hasValidProtectedNoArgsConstructor;
+    }
+
+    public boolean hasConstructor() {
+        return hasConstructor;
+    }
+
+    public boolean hasValidPublicNoArgsConstructor() {
+        return hasValidPublicNoArgsConstructor;
+    }
+
+    public boolean hasValidProtectedNoArgsConstructor() {
+        return hasValidProtectedNoArgsConstructor;
+    }
+
+    @Override
+    public String toString() {
+        return "ConstructorInfoDiagnosticHelper [hasConstructor=" + hasConstructor
+                + ", hasValidPublicNoArgsConstructor=" + hasValidPublicNoArgsConstructor
+                + ", hasValidProtectedNoArgsConstructor=" + hasValidProtectedNoArgsConstructor + "]";
+    }
+
+    /**
+     * Factory utility method checks the constructor existence and returns the constructor information
+     *
+     * @param method
+     * @return
+     */
+    public static ConstructorInfoDiagnosticHelper getConstructorInfo(PsiMethod method) {
+        boolean isUserDefinedConstructor = false;
+        boolean isPublicNoArgsConstructor = false;
+        boolean isProtectedNoArgsConstructor = false;
+
+        if (AbstractDiagnosticsCollector.isConstructorMethod((method))) {
+            isUserDefinedConstructor = true; // Check explicit constructor declaration
+            PsiParameterList params = method.getParameterList();
+            if (params.getParametersCount() == 0) { // Checks for user defined no-args constructor
+                if (method.hasModifierProperty(PsiModifier.PUBLIC)) {
+                    isPublicNoArgsConstructor = true;
+                }
+                if (method.hasModifierProperty(PsiModifier.PROTECTED)) {
+                    isProtectedNoArgsConstructor = true;
+                }
+            }
+        }
+        return new ConstructorInfoDiagnosticHelper(isUserDefinedConstructor, isPublicNoArgsConstructor, isProtectedNoArgsConstructor); // This ensures that the values don't get changed
+    }
+
+    /**
+     * This method merges the constructor check info and retains the constructor information
+     *
+     * @param calculatedValue
+     * @return
+     */
+    public ConstructorInfoDiagnosticHelper mergeConstructorInfo(ConstructorInfoDiagnosticHelper calculatedValue) {
+        this.hasConstructor = this.hasConstructor || calculatedValue.hasConstructor;
+        this.hasValidPublicNoArgsConstructor = this.hasValidPublicNoArgsConstructor || calculatedValue.hasValidPublicNoArgsConstructor;
+        this.hasValidProtectedNoArgsConstructor = this.hasValidProtectedNoArgsConstructor || calculatedValue.hasValidProtectedNoArgsConstructor;
+        return this;
+    }
+
+    /**
+     * This is to return default values for constructor information
+     *
+     * @return
+     */
+    public static ConstructorInfoDiagnosticHelper initialize() {
+        return new ConstructorInfoDiagnosticHelper(false, false, false);
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
@@ -3,10 +3,9 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ * http://www.eclipse.org/legal/epl-2.0
  *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -68,7 +67,7 @@ public final class ConstructorInfoDiagnosticHelper {
         boolean isPublicNoArgsConstructor = false;
         boolean isProtectedNoArgsConstructor = false;
 
-        if (AbstractDiagnosticsCollector.isConstructorMethod((method))) {
+        if (AbstractDiagnosticsCollector.isConstructorMethod(method)) {
             isUserDefinedConstructor = true; // Check explicit constructor declaration
             PsiParameterList params = method.getParameterList();
             if (params.getParametersCount() == 0) { // Checks for user defined no-args constructor

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 IBM Corporation and calculatedValues.
+ * Copyright (c) 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/helpers/ConstructorInfoDiagnosticHelper.java
@@ -11,11 +11,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.helpers;
 
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiParameterList;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
 
 /**
  * Constructor information diagnostics helper for a given method.

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *		IBM Corporation, Archana Iyer R - initial implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor;
+
+
+/**
+ * Interceptor constants.
+ */
+public class Constants {
+
+    /* INTERCEPTOR_FQ_NAME */
+    public static final String INTERCEPTOR_FQ_NAME = "jakarta.interceptor.Interceptor";
+    
+    /* Source */
+	public static final String DIAGNOSTIC_SOURCE = "jakarta-interceptor";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_ON_ABSTRACT_CLASS = "RemoveInterceptorAnnotationOnAbstractClass";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR = "RemoveInterceptorAnnotationOnNoArgsConstructor";
+
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -74,18 +74,18 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 						Messages.getMessage("InvalidInterceptorAbstractClass", type.getName()),
 						DIAGNOSTIC_CODE_INTERCEPTOR_ON_ABSTRACT_CLASS, null,
 						DiagnosticSeverity.Error));
-			}
-			for (PsiMethod method : type.getMethods()) {
-				//Checks if method is a constructor and has valid no-args constructor
-				constructorInfo.mergeConstructorInfo(ConstructorInfoDiagnosticHelper.getConstructorInfo(method));
-			}
-			// Conditions for checking missing public no-args constructor
-			if(constructorInfo != null && !constructorInfo.hasValidPublicNoArgsConstructor()
-					&& constructorInfo.hasConstructor()) {
-				diagnostics.add(createDiagnostic(type, unit,
-						Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
-						DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,
-						DiagnosticSeverity.Error));
+			} else {
+				for (PsiMethod method : type.getMethods()) {
+					//Checks if method is a constructor and has valid no-args constructor
+					constructorInfo.mergeConstructorInfo(ConstructorInfoDiagnosticHelper.getConstructorInfo(method));
+				}
+				// Conditions for checking missing public no-args constructor
+				if (constructorInfo.hasConstructor() && !constructorInfo.hasValidPublicNoArgsConstructor()) {
+					diagnostics.add(createDiagnostic(type, unit,
+							Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
+							DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,
+							DiagnosticSeverity.Error));
+				}
 			}
 		}
 	}
@@ -98,6 +98,6 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 	 * @return boolean
 	 */
 	private static boolean isInterceptorType(PsiClass type) {
-		return Arrays.stream(type.getAnnotations()).filter(Objects::nonNull).anyMatch(annotation -> isMatchedJavaElement(type, annotation.getQualifiedName(), INTERCEPTOR_FQ_NAME));
+		return Arrays.stream(type.getAnnotations()).anyMatch(annotation -> isMatchedJavaElement(type, annotation.getQualifiedName(), INTERCEPTOR_FQ_NAME));
 	}
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.ConstructorInfoDiagnosticHelper;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
@@ -48,14 +49,13 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 		PsiClass[] alltypes;
 		alltypes = unit.getClasses();
 		for (PsiClass type : alltypes) {
-			Map<String,Boolean> constructorInfo = new HashMap<>();
 			//Build the diagnostics if the parent class is Interceptor type and is abstract.
 			// Also, checks for missing public no-args constructor.
-        	buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type, constructorInfo);
+        	buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type);
 			for(PsiClass innerClass: type.getInnerClasses()){
 				//Build the diagnostics if the child class is Interceptor type and is abstract.
 				// Also, checks for missing public no-args constructor.
-				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass, constructorInfo);
+				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass);
 			}
         }
     }
@@ -67,11 +67,9 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 	 * @param unit
 	 * @param diagnostics
 	 * @param type
-	 * @param constructorInfo
 	 */
-	private void buildAbstractAndNoArgsConstructorDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type, Map<String, Boolean> constructorInfo) {
-		constructorInfo.put("hasConstructor", false);
-		constructorInfo.put("hasValidPublicNoArgsConstructor", false);
+	private void buildAbstractAndNoArgsConstructorDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type) {
+		ConstructorInfoDiagnosticHelper constructorInfo = ConstructorInfoDiagnosticHelper.initialize();
 		if (isInterceptorType(type)) {
 			if(type.hasModifierProperty(PsiModifier.ABSTRACT)) {
 				diagnostics.add(createDiagnostic(type, unit,
@@ -81,10 +79,11 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 			}
 			for (PsiMethod method : type.getMethods()) {
 				//Checks if method is a constructor and has valid no-args constructor
-				constructorInfo = hasValidNoArgsConstructor(method, constructorInfo);
+				constructorInfo.mergeConstructorInfo(ConstructorInfoDiagnosticHelper.getConstructorInfo(method));
 			}
 			// Conditions for checking missing public no-args constructor
-			if(!constructorInfo.get("hasValidPublicNoArgsConstructor") && constructorInfo.get("hasConstructor")) {
+			if(constructorInfo != null && !constructorInfo.hasValidPublicNoArgsConstructor()
+					&& constructorInfo.hasConstructor()) {
 				diagnostics.add(createDiagnostic(type, unit,
 						Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
 						DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -14,13 +14,11 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.ConstructorInfoDiagnosticHelper;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.helpers.ConstructorInfoDiagnosticHelper;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation, Archana Iyer R - initial API and implementation
+*******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import com.intellij.psi.*;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.Constants.*;
+
+
+/**
+ * Interceptor diagnostic participant that manages the use of @Interceptor annotation.
+ */
+public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollector {
+
+	public InterceptorDiagnosticsParticipant() {
+		super();
+	}
+
+	@Override
+	protected String getDiagnosticSource() {
+		return DIAGNOSTIC_SOURCE;
+	}
+
+    @Override
+	public void collectDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics) {
+		if (unit == null)
+			return;
+
+		PsiClass[] alltypes;
+		alltypes = unit.getClasses();
+		for (PsiClass type : alltypes) {
+			Map<String,Boolean> constructorInfo = new HashMap<>();
+			//Build the diagnostics if the parent class is Interceptor type and is abstract.
+			// Also, checks for missing public no-args constructor.
+        	buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type, constructorInfo);
+			for(PsiClass innerClass: type.getInnerClasses()){
+				//Build the diagnostics if the child class is Interceptor type and is abstract.
+				// Also, checks for missing public no-args constructor.
+				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass, constructorInfo);
+			}
+        }
+    }
+
+	/**
+	 * buildAbstractAndNoArgsConstructorDiagnostics
+	 * Method checks if the parent or inner classes are Interceptor type and throws appropriate diagnostics
+	 *
+	 * @param unit
+	 * @param diagnostics
+	 * @param type
+	 * @param constructorInfo
+	 */
+	private void buildAbstractAndNoArgsConstructorDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type, Map<String, Boolean> constructorInfo) {
+		constructorInfo.put("hasConstructor", false);
+		constructorInfo.put("hasValidPublicNoArgsConstructor", false);
+		if (isInterceptorType(type)) {
+			if(type.hasModifierProperty(PsiModifier.ABSTRACT)) {
+				diagnostics.add(createDiagnostic(type, unit,
+						Messages.getMessage("InvalidInterceptorAbstractClass", type.getName()),
+						DIAGNOSTIC_CODE_INTERCEPTOR_ON_ABSTRACT_CLASS, null,
+						DiagnosticSeverity.Error));
+			}
+			for (PsiMethod method : type.getMethods()) {
+				//Checks if method is a constructor and has valid no-args constructor
+				constructorInfo = hasValidNoArgsConstructor(method, constructorInfo);
+			}
+			// Conditions for checking missing public no-args constructor
+			if(!constructorInfo.get("hasValidPublicNoArgsConstructor") && constructorInfo.get("hasConstructor")) {
+				diagnostics.add(createDiagnostic(type, unit,
+						Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
+						DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,
+						DiagnosticSeverity.Error));
+			}
+		}
+	}
+
+	/**
+	 * isInterceptorType
+	 * Method checks if the class is an Interceptor type
+	 *
+	 * @param type
+	 * @return boolean
+	 */
+	private static boolean isInterceptorType(PsiClass type) {
+		return Arrays.stream(type.getAnnotations()).filter(Objects::nonNull).anyMatch(annotation -> isMatchedJavaElement(type, annotation.getQualifiedName(), INTERCEPTOR_FQ_NAME));
+	}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -155,6 +155,9 @@
         <javaDiagnosticsParticipant
                 group="jakarta"
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.websocket.WebSocketDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.InterceptorDiagnosticsParticipant"/>
 
         <projectLabelProvider
                 implementation="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JakartaProjectLabelProvider"/>

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -208,5 +208,5 @@ DuplicateLifeCycleAnnotation = Life cycle annotation {0} already registered with
 PrefixSlashToValueAttribute = Prefix value with '/'
 
 # InterceptorDiagnosticsParticipant
-InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor: Class {0} is off Interceptor type, but does not declare a public no-argument constructor.
+InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor: Class {0} is of Interceptor type, but does not declare a public no-argument constructor.
 InvalidInterceptorAbstractClass = The class {0} should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -208,5 +208,5 @@ DuplicateLifeCycleAnnotation = Life cycle annotation {0} already registered with
 PrefixSlashToValueAttribute = Prefix value with '/'
 
 # InterceptorDiagnosticsParticipant
-InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor: Class {0} is of Interceptor type, but does not declare a public no-argument constructor.
+InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor. Class {0} is of Interceptor type, but does not declare a public no-argument constructor.
 InvalidInterceptorAbstractClass = The class {0} should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -206,3 +206,7 @@ DuplicateLifeCycleAnnotation = Life cycle annotation {0} already registered with
 
 # WebSocketDiagnosticsQuickFix
 PrefixSlashToValueAttribute = Prefix value with '/'
+
+# InterceptorDiagnosticsParticipant
+InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor: Class {0} is off Interceptor type, but does not declare a public no-argument constructor.
+InvalidInterceptorAbstractClass = The class {0} should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.interceptor;
+
+import java.io.File;
+import java.util.Arrays;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JakartaInterceptorTest extends BaseJakartaTest {
+
+	@Test
+	public void invalidInterceptorTest() throws Exception {
+		Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+		IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+		VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+				+ "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java");
+		String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+		JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+		diagnosticsParams.setUris(Arrays.asList(uri));
+
+		// Test diagnostics
+		Diagnostic d1 = JakartaForJavaAssert.d(5, 22, 40,
+				"The class InvalidInterceptor should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+		Diagnostic d2 = JakartaForJavaAssert.d(5, 22, 40,
+				"Missing Public NoArgsConstructor: Class InvalidInterceptor is off Interceptor type, but does not declare a public no-argument constructor.",
+				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
+		Diagnostic d3 = JakartaForJavaAssert.d(22, 14, 37,
+				"Missing Public NoArgsConstructor: Class InnerInvalidInterceptor is off Interceptor type, but does not declare a public no-argument constructor.",
+				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
+
+		JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+	}
+
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -51,10 +51,10 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
 				"The class InvalidInterceptor should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
 		Diagnostic d2 = JakartaForJavaAssert.d(5, 22, 40,
-				"Missing Public NoArgsConstructor: Class InvalidInterceptor is off Interceptor type, but does not declare a public no-argument constructor.",
+				"Missing Public NoArgsConstructor. Class InvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
 		Diagnostic d3 = JakartaForJavaAssert.d(22, 14, 37,
-				"Missing Public NoArgsConstructor: Class InnerInvalidInterceptor is off Interceptor type, but does not declare a public no-argument constructor.",
+				"Missing Public NoArgsConstructor. Class InnerInvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
 
 		JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -47,17 +47,30 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
 		diagnosticsParams.setUris(Arrays.asList(uri));
 
 		// Test diagnostics
-		Diagnostic d1 = JakartaForJavaAssert.d(5, 22, 40,
-				"The class InvalidInterceptor should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
-				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
-		Diagnostic d2 = JakartaForJavaAssert.d(5, 22, 40,
+		Diagnostic d1 = JakartaForJavaAssert.d(5, 13, 31,
 				"Missing Public NoArgsConstructor. Class InvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
-		Diagnostic d3 = JakartaForJavaAssert.d(32, 14, 37,
+		Diagnostic d2 = JakartaForJavaAssert.d(32, 14, 37,
 				"Missing Public NoArgsConstructor. Class InnerInvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
 
-		JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+		JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 	}
+	@Test
+	public void invalidAbstractInterceptorTest() throws Exception {
+		Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+		IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
 
+		VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+				+ "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAbstractInterceptor.java");
+		String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+		JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+		diagnosticsParams.setUris(Arrays.asList(uri));
+
+		// Test diagnostics
+		Diagnostic d1 = JakartaForJavaAssert.d(5, 22, 40,
+				"The class InvalidInterceptor should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+	}
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -53,7 +53,7 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
 		Diagnostic d2 = JakartaForJavaAssert.d(5, 22, 40,
 				"Missing Public NoArgsConstructor. Class InvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
-		Diagnostic d3 = JakartaForJavaAssert.d(22, 14, 37,
+		Diagnostic d3 = JakartaForJavaAssert.d(32, 14, 37,
 				"Missing Public NoArgsConstructor. Class InnerInvalidInterceptor is of Interceptor type, but does not declare a public no-argument constructor.",
 				DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnNoArgsConstructor");
 

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAbstractInterceptor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAbstractInterceptor.java
@@ -1,0 +1,33 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.Interceptor;
+
+@Interceptor
+public abstract class InvalidAbstractInterceptor {
+
+	String config;
+
+	String config1;
+
+	private InvalidAbstractInterceptor() {
+
+	}
+
+	private InvalidAbstractInterceptor(String config, String config1) {
+
+	}
+
+	public InvalidAbstractInterceptor(String config) {
+
+	}
+
+	public String getConfig() {
+		return config;
+	}
+
+	public void setConfig(String config) {
+		this.config = config;
+	}
+
+}
+

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
@@ -1,0 +1,42 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.Interceptor;
+
+@Interceptor
+public abstract class InvalidInterceptor {
+	
+	String config;
+	
+	public String getConfig() {
+		return config;
+	}
+
+	public void setConfig(String config) {
+		this.config = config;
+	}
+
+	public InvalidInterceptor(String config) {
+
+	}
+	
+	@Interceptor
+	public class InnerInvalidInterceptor{
+		
+		String innerConfig;
+		
+		public String getInnerConfig() {
+			return innerConfig;
+		}
+
+		public void setInnerConfig(String innerConfig) {
+			this.innerConfig = innerConfig;
+		}
+
+		public InnerInvalidInterceptor(String innerConfig) {
+
+		}
+		
+	}
+
+}
+

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
@@ -3,7 +3,7 @@ package io.openliberty.sample.jakarta.interceptor;
 import jakarta.interceptor.Interceptor;
 
 @Interceptor
-public abstract class InvalidInterceptor {
+public class InvalidInterceptor {
 
 	String config;
 

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptor.java
@@ -4,9 +4,23 @@ import jakarta.interceptor.Interceptor;
 
 @Interceptor
 public abstract class InvalidInterceptor {
-	
+
 	String config;
-	
+
+	String config1;
+
+	private InvalidInterceptor() {
+
+	}
+
+	private InvalidInterceptor(String config, String config1) {
+
+	}
+
+	public InvalidInterceptor(String config) {
+
+	}
+
 	public String getConfig() {
 		return config;
 	}
@@ -15,27 +29,33 @@ public abstract class InvalidInterceptor {
 		this.config = config;
 	}
 
-	public InvalidInterceptor(String config) {
-
-	}
-	
 	@Interceptor
 	public class InnerInvalidInterceptor{
-		
+
 		String innerConfig;
-		
+
+		String innerConfig1;
+
 		public String getInnerConfig() {
 			return innerConfig;
+		}
+
+		protected InnerInvalidInterceptor() {
+
+		}
+
+		public InnerInvalidInterceptor(String innerConfig) {
+
+		}
+
+		protected InnerInvalidInterceptor(String innerConfig, String innerConfig2) {
+
 		}
 
 		public void setInnerConfig(String innerConfig) {
 			this.innerConfig = innerConfig;
 		}
 
-		public InnerInvalidInterceptor(String innerConfig) {
-
-		}
-		
 	}
 
 }


### PR DESCRIPTION
Fixes #1532 

lsp4jakarta issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/656
lsp4jakarta PR: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/815
