### PR TITLE
Update ideTargetVersion to EAP 261.22158.46 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, intellij-2026.1-support ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,9 @@ intellijPlatformTesting.runIde {
                         "-DjbScreenMenuBar.enabled=false",
                         "-Dapple.laf.useScreenMenuBar=false",
                         // This disables the EAP login prompt:
-                        "-Deap.require.license=release"
+                        "-Deap.require.license=release",
+                        // Disable the Islands theme popup
+                        "-Didea.is.integration.test=true"
                 ]
             } as CommandLineArgumentProvider)
             systemProperty("ide.native.launcher", "true")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ javaVersion=21
 # Intellij platform specifications
 platformType=IU
 platformVersion=2024.3.6
-ideTargetVersion=2025.3.1.1
+ideTargetVersion=261.22158.46
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, com.intellij.gradle, org.jetbrains.plugins.terminal, com.intellij.properties


### PR DESCRIPTION
Part of #1544 

Changes in this PR
- Updates version to latest EAP 261.22158.46 
- Disables the islands theme popup
- Adds intellij-2026.1-support  branch to CI workflow

Created a separate issue to address the test failures - https://github.com/OpenLiberty/liberty-tools-intellij/issues/1546