### PR TITLE
Update IntelliJ Platform Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 plugins {
     id 'java'
     id 'org.jetbrains.intellij.platform' version '2.13.1'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
+    id 'org.jetbrains.kotlin.jvm' version '2.2.0'
 }
 
 group 'io.openliberty.tools'

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij.platform' version '2.10.1'
-    id 'org.jetbrains.kotlin.jvm' version '2.0.20'
+    id 'org.jetbrains.intellij.platform' version '2.13.1'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
 }
 
 group 'io.openliberty.tools'
@@ -14,9 +14,12 @@ def remoteRobotVersion = "0.11.23"
 // To switch to nightly version, append "@nightly" to the version number (i.e. 0.4.1-20240828-013108@nightly)
 def lsp4ijVersion = '0.19.2'
 
-allprojects {
+java {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
+}
+
+allprojects {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
         options.fork = true
@@ -162,7 +165,6 @@ dependencies {
 
         pluginVerifier()
         zipSigner()
-        instrumentationTools()
 
         testFramework TestFrameworkType.Platform.INSTANCE
         testFramework TestFrameworkType.Plugin.Java.INSTANCE

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes #1549 #1547 

- Upgraded IntelliJ Platform Gradle Plugin to 2.13.1
- Upgraded gradle version to 9.4.0. IntelliJ Platform Gradle Plugin requires Gradle Gradle 9.0.0 and higher
- Moved sourceCompatibility and targetCompatibility into the java {} block since java plugin convention was removed in Gradle 9. [Ref](https://discuss.gradle.org/t/error-could-not-set-unknown-property-sourcecompatibility-for-root-project/51978/2?u=anusreelakshmi934)
- Removed instrumentationTools() as per Jetbrains [doc](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-tasks.html#instrumentCode)
- Upgraded [kotlin](https://docs.gradle.org/current/userguide/compatibility.html#kotlin) version for the tests to succeed using gradle 9.4.0
