### PR TITLE
Update copyright year in java files

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation.
+ * Copyright (c) 2023, 2026 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/fixtures/ProjectFrameFixture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation.
+ * Copyright (c) 2023, 2026 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at


### PR DESCRIPTION
This PR updates the copyright year in UIBotTestUtils and ProjectFrameFixture java files as per the comment [here](https://github.com/OpenLiberty/liberty-tools-intellij/pull/1560#discussion_r3045240823)