### PR TITLE
Beans with @dependent scope must not declare conditional observer methods

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
@@ -38,6 +38,7 @@ public class ManagedBeanConstants {
     public static final String DIAGNOSTIC_CODE_INVALID_DISPOSES_PARAM = "RemoveDisposesOrConflictedAnnotations";
     public static final String DIAGNOSTIC_INJECT_MULTIPLE_METHOD_PARAM = "InvalidInjectAnnotationOnMultipleMethodParams";
     public static final String DIAGNOSTIC_OBSERVES_OBSERVESASYNC_PARAM_CONFLICT = "InvalidObservesObservesAsyncMethodParams";
+    public static final String DIAGNOSTIC_CODE_DEPENDENT_CONDITIONAL_OBSERVER = "InvalidDependentScopeWithConditionalObserver";
 
     public static final String DIAGNOSTIC_CODE_REDUNDANT_DISPOSES = "RemoveExtraDisposes";
     //Added as part of fix that adds two quick fixes which are mutually exclusive issue #540

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
@@ -192,6 +193,18 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                 if (!conflictParams.isEmpty()) {
                     diagnostics.add(createDiagnostic(method, unit, Messages.getMessage("ManagedBeanObservesAndObservesAsyncParam", String.join(", ", conflictParams)),
                             DIAGNOSTIC_OBSERVES_OBSERVESASYNC_PARAM_CONFLICT, null, DiagnosticSeverity.Error));
+                }
+
+                // Check for conditional observer methods on @Dependent scoped beans
+                // Beans with scope @Dependent may not have conditional observer methods.
+                // If a bean with scope @Dependent has an observer method declared notifyObserver=IF_EXISTS,
+                // the container automatically detects the problem and treats it as a definition error.
+                if (isDependent) {
+                    if (hasConditionalObserverAnnotation(type, method)) {
+                        diagnostics.add(createDiagnostic(method, unit,
+                                Messages.getMessage("ManagedBeanDependentScopeConditionalObserver", method.getName()),
+                                DIAGNOSTIC_CODE_DEPENDENT_CONDITIONAL_OBSERVER, null, DiagnosticSeverity.Error));
+                    }
                 }
             }
 
@@ -398,5 +411,42 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                                                  PsiField field) {
         return isManagedBean && field.hasModifierProperty(PsiModifier.PUBLIC) && !field.hasModifierProperty(PsiModifier.STATIC)
                 && (!isDependent || hasMultipleScopes);
+    }
+
+    /**
+     * isConditionalObserver
+     * Checks if the annotation is a conditional observer (notifyObserver=IF_EXISTS).
+     *
+     * @param type the type
+     * @param annotation the annotation to check
+     * @return true if the annotation is @Observes or @ObservesAsync with notifyObserver=IF_EXISTS
+     */
+    private boolean isConditionalObserver(PsiClass type, PsiAnnotation annotation) {
+        String matched = getMatchedJavaElementName(type, annotation.getQualifiedName(),
+                new String[] { OBSERVES_FQ_NAME, OBSERVES_ASYNC_FQ_NAME });
+        if (matched != null) {
+            String notifyObserverValue = AnnotationUtils.getAnnotationMemberValue(annotation, "notifyObserver");
+            return notifyObserverValue != null && notifyObserverValue.contains("IF_EXISTS");
+        }
+        return false;
+    }
+
+    /**
+     * hasConditionalObserverAnnotation
+     * Checks if any parameter in the method has a conditional observer annotation.
+     *
+     * @param type the type
+     * @param method the method to check
+     * @return true if any parameter has a conditional observer annotation
+     */
+    private boolean hasConditionalObserverAnnotation(PsiClass type, PsiMethod method) {
+        for (PsiParameter param : method.getParameterList().getParameters()) {
+            for (PsiAnnotation annotation : param.getAnnotations()) {
+                if (isConditionalObserver(type, annotation)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -426,7 +426,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                 new String[] { OBSERVES_FQ_NAME, OBSERVES_ASYNC_FQ_NAME });
         if (matched != null) {
             String notifyObserverValue = AnnotationUtils.getAnnotationMemberValue(annotation, "notifyObserver");
-            return notifyObserverValue != null && notifyObserverValue.contains("IF_EXISTS");
+            return notifyObserverValue != null && notifyObserverValue.endsWith("IF_EXISTS");
         }
         return false;
     }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -497,13 +497,8 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
      * @return true if any parameter has a conditional observer annotation
      */
     private boolean hasConditionalObserverAnnotation(PsiClass type, PsiMethod method) {
-        for (PsiParameter param : method.getParameterList().getParameters()) {
-            for (PsiAnnotation annotation : param.getAnnotations()) {
-                if (isConditionalObserver(type, annotation)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return Stream.of(method.getParameterList().getParameters())
+                .flatMap(param -> Stream.of(param.getAnnotations()))
+                .anyMatch(annotation -> isConditionalObserver(type, annotation));
     }
 }

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -107,6 +107,7 @@ ManagedBeanInvalidInject = A bean constructor or a method annotated with @Inject
 ManagedBeanGenericType = The @Dependent annotation must be the only scope defined by a Managed bean class of generic type.
 ManagedBeanProducesAndInject = The @Produces and @Inject annotations must not be used on the same field or property.
 ManagedBeanObservesAndObservesAsyncParam = A CDI method must not have parameter(s): {0} annotated with @Observes and @ObservesAsync.
+ManagedBeanDependentScopeConditionalObserver = Beans with scope @Dependent may not have conditional observer methods. Observer method ''{0}'' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.
 
 # ManagedBeanNoArgConstructorQuickFix
 AddProtectedConstructor = Add a no-arg protected constructor to this class

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -107,7 +107,7 @@ ManagedBeanInvalidInject = A bean constructor or a method annotated with @Inject
 ManagedBeanGenericType = The @Dependent annotation must be the only scope defined by a Managed bean class of generic type.
 ManagedBeanProducesAndInject = The @Produces and @Inject annotations must not be used on the same field or property.
 ManagedBeanObservesAndObservesAsyncParam = A CDI method must not have parameter(s): {0} annotated with @Observes and @ObservesAsync.
-ManagedBeanDependentScopeConditionalObserver = Beans with scope @Dependent may not have conditional observer methods. Observer method ''{0}'' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.
+ManagedBeanDependentScopeConditionalObserver = Beans with scope @Dependent may not have conditional observer methods. Observer method ''{0}'' sets notifyObserver to Reception.IF_EXISTS, which is not permitted for @Dependent scoped bean.
 
 # ManagedBeanNoArgConstructorQuickFix
 AddProtectedConstructor = Add a no-arg protected constructor to this class

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/DependentScopedConditionalObserverTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/DependentScopedConditionalObserverTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.cdi;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+@RunWith(JUnit4.class)
+public class DependentScopedConditionalObserverTest extends BaseJakartaTest {
+
+    @Test
+    public void testDependentScopedConditionalObserver() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/DependentScopedConditionalObserver.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test case 1: @Dependent with conditional @Observes (should trigger diagnostic)
+        Diagnostic dependentWithConditionalObserves = d(12, 16, 30,
+                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidDependentScopeWithConditionalObserver");
+
+        // Test case 2: @Dependent with conditional @ObservesAsync (should trigger diagnostic)
+        Diagnostic dependentWithConditionalObservesAsync = d(21, 16, 30,
+                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidDependentScopeWithConditionalObserver");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, dependentWithConditionalObserves, dependentWithConditionalObservesAsync);
+    }
+}

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/DependentScopedConditionalObserverTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/DependentScopedConditionalObserverTest.java
@@ -50,12 +50,12 @@ public class DependentScopedConditionalObserverTest extends BaseJakartaTest {
 
         // Test case 1: @Dependent with conditional @Observes (should trigger diagnostic)
         Diagnostic dependentWithConditionalObserves = d(12, 16, 30,
-                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.",
+                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' sets notifyObserver to Reception.IF_EXISTS, which is not permitted for @Dependent scoped bean.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidDependentScopeWithConditionalObserver");
 
         // Test case 2: @Dependent with conditional @ObservesAsync (should trigger diagnostic)
         Diagnostic dependentWithConditionalObservesAsync = d(21, 16, 30,
-                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' has notifyObserver set to Reception.IF_EXISTS, which is not allowed on a @Dependent scoped bean.",
+                "Beans with scope @Dependent may not have conditional observer methods. Observer method 'observerMethod' sets notifyObserver to Reception.IF_EXISTS, which is not permitted for @Dependent scoped bean.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidDependentScopeWithConditionalObserver");
 
         assertJavaDiagnostics(diagnosticsParams, utils, dependentWithConditionalObserves, dependentWithConditionalObservesAsync);

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/DependentScopedConditionalObserver.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/DependentScopedConditionalObserver.java
@@ -1,0 +1,52 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.event.Reception;
+
+// Test case 1: @Dependent with conditional @Observes (should trigger diagnostic)
+@Dependent
+public class DependentScopedConditionalObserver {
+    
+    public void observerMethod(@Observes(notifyObserver = Reception.IF_EXISTS) String event) {
+        // This should trigger a diagnostic
+    }
+}
+
+// Test case 2: @Dependent with conditional @ObservesAsync (should trigger diagnostic)
+@Dependent
+class DependentScopedConditionalObserverAsync {
+    
+    public void observerMethod(@ObservesAsync(notifyObserver = Reception.IF_EXISTS) String event) {
+        // This should trigger a diagnostic
+    }
+}
+
+// Test case 3: @Dependent with ALWAYS (should NOT trigger diagnostic)
+@Dependent
+class DependentScopedAlwaysObserver {
+    
+    public void observerMethod(@Observes(notifyObserver = jakarta.enterprise.event.Reception.ALWAYS) String event) {
+        // This should NOT trigger a diagnostic
+    }
+}
+
+// Test case 4: @Dependent without notifyObserver attribute (should NOT trigger diagnostic - defaults to ALWAYS)
+@Dependent
+class DependentScopedDefaultObserver {
+    
+    public void observerMethod(@Observes String event) {
+        // This should NOT trigger a diagnostic (defaults to ALWAYS)
+    }
+}
+
+// Test case 5: @ApplicationScoped with conditional observer (should NOT trigger diagnostic)
+@ApplicationScoped
+class ApplicationScopedConditionalObserver {
+    
+    public void observerMethod(@Observes(notifyObserver = Reception.IF_EXISTS) String event) {
+        // This should NOT trigger a diagnostic (not @Dependent)
+    }
+}


### PR DESCRIPTION
This is a sync pr which will address the https://github.com/OpenLiberty/liberty-tools-intellij/pull/1540/changes
corresponding issue - https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/707