### PR TITLE
Remove intellij-2026.1-support branch from GitHub workflows (build.yaml) 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main, intellij-2026.1-support ]
+    branches: [ main ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:


### PR DESCRIPTION
Fixes #1561 