### PR TITLE
Producer fields must not declare a bean name. Added Diagnostics and Quickfix

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
@@ -30,6 +30,7 @@ public class ManagedBeanConstants {
     public static final String SINGLETON_FQ_NAME = "jakarta.ejb.Singleton";
     public static final String APPLICATION_SCOPED_FQ_NAME = "jakarta.enterprise.context.ApplicationScoped";
     public static final String STATELESS_FQ_NAME = "jakarta.ejb.Stateless";
+    public static final String NAMED_FQ_NAME = "jakarta.inject.Named";
 
     public static final String DIAGNOSTIC_SOURCE = "jakarta-cdi";
     public static final String DIAGNOSTIC_CODE = "InvalidManagedBeanAnnotation";
@@ -37,6 +38,7 @@ public class ManagedBeanConstants {
     public static final String DIAGNOSTIC_CODE_INVALID_SINGLETON_SCOPE = "InvalidSingletonSessionBeanScope";
     public static final String DIAGNOSTIC_CODE_PRODUCES_INJECT = "RemoveProducesOrInject";
     public static final String DIAGNOSTIC_CODE_STATELESS_ILLEGAL_SCOPE = "InvalidStatelessSessionBeanScope";
+    public static final String DIAGNOSTIC_CODE_PRODUCER_FIELD_NAMED = "InvalidProducerFieldWithNamedAnnotation";
 
     public static final String CONSTRUCTOR_DIAGNOSTIC_CODE = "InvalidManagedBeanConstructor";
 

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -140,7 +140,7 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                     for (PsiAnnotation annotation : field.getAnnotations()) {
                         if (isMatchedJavaElement(type, annotation.getQualifiedName(), NAMED_FQ_NAME)) {
                             diagnostics.add(createDiagnostic(annotation, unit,
-                                    Messages.getMessage("ProducerFieldWithNamedAnnotation"),
+                                    Messages.getMessage("ProducerFieldWithNamedAnnotation", field.getName()),
                                     DIAGNOSTIC_CODE_PRODUCER_FIELD_NAMED, null,
                                     DiagnosticSeverity.Error));
                             break;

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanDiagnosticsCollector.java
@@ -129,6 +129,25 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                             ManagedBeanConstants.DIAGNOSTIC_CODE_PRODUCES_INJECT, null, DiagnosticSeverity.Error));
                 }
 
+                /**
+                 * Producer fields must not declare a bean name using @Named annotation.
+                 *
+                 * https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#declaring_producer_field
+                 * Section 3.3.2: A producer field may have a bean name, specified using the @Named qualifier.
+                 * However, the specification states that producer fields must not declare a bean name using @Named.
+                 */
+                if (isProducerField) {
+                    for (PsiAnnotation annotation : field.getAnnotations()) {
+                        if (isMatchedJavaElement(type, annotation.getQualifiedName(), NAMED_FQ_NAME)) {
+                            diagnostics.add(createDiagnostic(annotation, unit,
+                                    Messages.getMessage("ProducerFieldWithNamedAnnotation"),
+                                    DIAGNOSTIC_CODE_PRODUCER_FIELD_NAMED, null,
+                                    DiagnosticSeverity.Error));
+                            break;
+                        }
+                    }
+                }
+
             }
 
             PsiMethod[] methods = type.getMethods();

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2026 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
+
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveAnnotationConflictQuickFix;
+
+/**
+ * Quick fix for removing @Named annotation from producer fields
+ * 
+ * Producer fields must not declare a bean name using @Named annotation.
+ *
+ */
+public class RemoveNamedAnnotationQuickFix extends RemoveAnnotationConflictQuickFix {
+
+    public RemoveNamedAnnotationQuickFix() {
+        super(false, "jakarta.inject.Named");
+    }
+
+    @Override
+    public String getParticipantId() {
+        return RemoveNamedAnnotationQuickFix.class.getName();
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/RemoveNamedAnnotationQuickFix.java
@@ -14,16 +14,18 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
 
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveAnnotationConflictQuickFix;
 
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants.NAMED_FQ_NAME;
+
 /**
  * Quick fix for removing @Named annotation from producer fields
- * 
+ *
  * Producer fields must not declare a bean name using @Named annotation.
  *
  */
 public class RemoveNamedAnnotationQuickFix extends RemoveAnnotationConflictQuickFix {
 
     public RemoveNamedAnnotationQuickFix() {
-        super(false, "jakarta.inject.Named");
+        super(false, NAMED_FQ_NAME);
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -574,6 +574,10 @@
                                    group="jakarta"
                                    targetDiagnostic="jakarta-cdi#InvalidSingletonSessionBeanScope"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-cdi#InvalidProducerFieldWithNamedAnnotation"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.RemoveNamedAnnotationQuickFix"/>
 
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -98,6 +98,7 @@ SizeOrNonEmptyAnnotationsParams = This annotation can only be used on parameters
 # The next two messages do not include CharSequence
 AnnotationMinMaxMethods = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type methods.
 AnnotationMinMaxFields = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type fields.
+ProducerFieldWithNamedAnnotation = Producer fields must not declare a bean name using @Named annotation.
 AnnotationMinMaxParams = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type parameters.
 # The next two messages include float and double
 AnnotationPositiveMethods = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long, float, double (and their respective wrappers) \n type methods.

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -98,7 +98,7 @@ SizeOrNonEmptyAnnotationsParams = This annotation can only be used on parameters
 # The next two messages do not include CharSequence
 AnnotationMinMaxMethods = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type methods.
 AnnotationMinMaxFields = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type fields.
-ProducerFieldWithNamedAnnotation = Producer fields must not declare a bean name using @Named annotation.
+ProducerFieldWithNamedAnnotation = Producer field ''{0}'' must not declare a bean name using @Named annotation.
 AnnotationMinMaxParams = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type parameters.
 # The next two messages include float and double
 AnnotationPositiveMethods = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long, float, double (and their respective wrappers) \n type methods.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -1555,20 +1555,20 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         // Test expected diagnostics for producer fields with @Named annotation
         // Diagnostic for producer field with @Named("config")
-        Diagnostic d1 = d(12, 4, 20,
+        Diagnostic namedConfigDiagnostic = d(12, 4, 20,
                 "Producer fields must not declare a bean name using @Named annotation.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
 
         // Diagnostic for producer field with @Named (no value)
-        Diagnostic d2 = d(17, 4, 10,
+        Diagnostic namedGreetingDiagnostic = d(17, 4, 10,
                 "Producer fields must not declare a bean name using @Named annotation.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
 
-        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+        assertJavaDiagnostics(diagnosticsParams, utils, namedConfigDiagnostic, namedGreetingDiagnostic);
 
         // Test quickfix for first diagnostic (remove @Named("config"))
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        String newText1 = "package io.openliberty.sample.jakarta.cdi;\n\n" +
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, namedConfigDiagnostic);
+        String newTextWithoutNamedConfig = "package io.openliberty.sample.jakarta.cdi;\n\n" +
                 "import jakarta.enterprise.context.ApplicationScoped;\n" +
                 "import jakarta.enterprise.inject.Produces;\n" +
                 "import jakarta.inject.Named;\n" +
@@ -1592,13 +1592,13 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 "@Produces\n    " +
                 "private Integer count = 0;\n" +
                 "}\n";
-        TextEdit te1 = te(0, 0, 31, 0, newText1);
-        CodeAction ca1 = ca(uri, "Remove @Named", d1, te1);
-        assertJavaCodeAction(codeActionParams1, utils, ca1);
+        TextEdit removeNamedConfigEdit = te(0, 0, 31, 0, newTextWithoutNamedConfig);
+        CodeAction removeNamedConfigAction = ca(uri, "Remove @Named", namedConfigDiagnostic, removeNamedConfigEdit);
+        assertJavaCodeAction(codeActionParams1, utils, removeNamedConfigAction);
 
         // Test quickfix for second diagnostic (remove @Named)
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-        String newText2 = "package io.openliberty.sample.jakarta.cdi;\n\n" +
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, namedGreetingDiagnostic);
+        String newTextWithoutNamedGreeting = "package io.openliberty.sample.jakarta.cdi;\n\n" +
                 "import jakarta.enterprise.context.ApplicationScoped;\n" +
                 "import jakarta.enterprise.inject.Produces;\n" +
                 "import jakarta.inject.Named;\n" +
@@ -1622,8 +1622,8 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 "@Produces\n    " +
                 "private Integer count = 0;\n" +
                 "}\n";
-        TextEdit te2 = te(0, 0, 31, 0, newText2);
-        CodeAction ca2 = ca(uri, "Remove @Named", d2, te2);
-        assertJavaCodeAction(codeActionParams2, utils, ca2);
+        TextEdit removeNamedGreetingEdit = te(0, 0, 31, 0, newTextWithoutNamedGreeting);
+        CodeAction removeNamedGreetingAction = ca(uri, "Remove @Named", namedGreetingDiagnostic, removeNamedGreetingEdit);
+        assertJavaCodeAction(codeActionParams2, utils, removeNamedGreetingAction);
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -1556,12 +1556,12 @@ public class ManagedBeanTest extends BaseJakartaTest {
         // Test expected diagnostics for producer fields with @Named annotation
         // Diagnostic for producer field with @Named("config")
         Diagnostic namedConfigDiagnostic = d(12, 4, 20,
-                "Producer fields must not declare a bean name using @Named annotation.",
+                "Producer field 'config' must not declare a bean name using @Named annotation.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
 
         // Diagnostic for producer field with @Named (no value)
         Diagnostic namedGreetingDiagnostic = d(17, 4, 10,
-                "Producer fields must not declare a bean name using @Named annotation.",
+                "Producer field 'greeting' must not declare a bean name using @Named annotation.",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
 
         assertJavaDiagnostics(diagnosticsParams, utils, namedConfigDiagnostic, namedGreetingDiagnostic);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/ManagedBeanTest.java
@@ -1540,4 +1540,90 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, utils, observesDiagnostic, observesAsyncDiagnostic);
     }
+
+    @Test
+    public void producerFieldWithNamed() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/cdi/ProducerFieldWithNamed.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test expected diagnostics for producer fields with @Named annotation
+        // Diagnostic for producer field with @Named("config")
+        Diagnostic d1 = d(12, 4, 20,
+                "Producer fields must not declare a bean name using @Named annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
+
+        // Diagnostic for producer field with @Named (no value)
+        Diagnostic d2 = d(17, 4, 10,
+                "Producer fields must not declare a bean name using @Named annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidProducerFieldWithNamedAnnotation");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        // Test quickfix for first diagnostic (remove @Named("config"))
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        String newText1 = "package io.openliberty.sample.jakarta.cdi;\n\n" +
+                "import jakarta.enterprise.context.ApplicationScoped;\n" +
+                "import jakarta.enterprise.inject.Produces;\n" +
+                "import jakarta.inject.Named;\n" +
+                "import java.util.Properties;\n\n" +
+                "@ApplicationScoped\n" +
+                "public class ProducerFieldWithNamed {\n    \n    " +
+                "// Invalid: Producer field with @Named annotation\n    " +
+                "@Produces\n    " +
+                "private Properties config = new Properties();\n    \n    " +
+                "// Invalid: Producer field with @Named annotation (no value)\n    " +
+                "@Produces\n    " +
+                "@Named\n    " +
+                "private String greeting = \"Hello\"; \n    \n    " +
+                "// Valid: Producer method with @Named annotation (methods are allowed)\n    " +
+                "@Produces\n    " +
+                "@Named(\"message\")\n    " +
+                "public String getMessage() {\n        " +
+                "return \"Valid producer method\";\n    " +
+                "}\n    \n    " +
+                "// Valid: Producer field without @Named annotation\n    " +
+                "@Produces\n    " +
+                "private Integer count = 0;\n" +
+                "}\n";
+        TextEdit te1 = te(0, 0, 31, 0, newText1);
+        CodeAction ca1 = ca(uri, "Remove @Named", d1, te1);
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+        // Test quickfix for second diagnostic (remove @Named)
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        String newText2 = "package io.openliberty.sample.jakarta.cdi;\n\n" +
+                "import jakarta.enterprise.context.ApplicationScoped;\n" +
+                "import jakarta.enterprise.inject.Produces;\n" +
+                "import jakarta.inject.Named;\n" +
+                "import java.util.Properties;\n\n" +
+                "@ApplicationScoped\n" +
+                "public class ProducerFieldWithNamed {\n    \n    " +
+                "// Invalid: Producer field with @Named annotation\n    " +
+                "@Produces\n    " +
+                "@Named(\"config\")\n    " +
+                "private Properties config = new Properties();\n    \n    " +
+                "// Invalid: Producer field with @Named annotation (no value)\n    " +
+                "@Produces\n    " +
+                "private String greeting = \"Hello\"; \n    \n    " +
+                "// Valid: Producer method with @Named annotation (methods are allowed)\n    " +
+                "@Produces\n    " +
+                "@Named(\"message\")\n    " +
+                "public String getMessage() {\n        " +
+                "return \"Valid producer method\";\n    " +
+                "}\n    \n    " +
+                "// Valid: Producer field without @Named annotation\n    " +
+                "@Produces\n    " +
+                "private Integer count = 0;\n" +
+                "}\n";
+        TextEdit te2 = te(0, 0, 31, 0, newText2);
+        CodeAction ca2 = ca(uri, "Remove @Named", d2, te2);
+        assertJavaCodeAction(codeActionParams2, utils, ca2);
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducerFieldWithNamed.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ProducerFieldWithNamed.java
@@ -1,0 +1,31 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import java.util.Properties;
+
+@ApplicationScoped
+public class ProducerFieldWithNamed {
+    
+    // Invalid: Producer field with @Named annotation
+    @Produces
+    @Named("config")
+    private Properties config = new Properties();
+    
+    // Invalid: Producer field with @Named annotation (no value)
+    @Produces
+    @Named
+    private String greeting = "Hello"; 
+    
+    // Valid: Producer method with @Named annotation (methods are allowed)
+    @Produces
+    @Named("message")
+    public String getMessage() {
+        return "Valid producer method";
+    }
+    
+    // Valid: Producer field without @Named annotation
+    @Produces
+    private Integer count = 0;
+}


### PR DESCRIPTION
Fixes [ #713 ](https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/713)
Sync PR for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/867

Recording 

https://github.com/user-attachments/assets/8c7431a8-1ce0-4240-bc68-b3ecb8bacdb9

