### PR TITLE
Fixes #1551: Sync up diagnostics and quick for invalid method modifiers on Interceptor methods

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/AbstractDiagnosticsCollector.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -277,10 +277,9 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
      * Note: This excludes PostConstruct and PreDestroy as they belong to the annotations module.
      *
      * @param type     the type to check
-     * @param javaFile the Java file containing the type
      * @return true if the type is an interceptor type or uses interceptor-related features
      */
-    public static boolean isInterceptorTypeReferenced(PsiClass type, PsiJavaFile javaFile) {
+    public static boolean isInterceptorTypeReferenced(PsiClass type) {
         if (type == null) {
             return false;
         }
@@ -375,5 +374,27 @@ public abstract class AbstractDiagnosticsCollector implements DiagnosticsCollect
         
         String fqn = containingClass.getQualifiedName();
         return methodTargetClass.equals(fqn);
+    }
+
+    /**
+     * Checks if a method contains any annotations that match the provided fully qualified annotation names.
+     * Returns a list of matched annotation FQNs found on the method.
+     *
+     * @param type              the class containing the method
+     * @param method            the method to check for annotations
+     * @param annotationFQNames the set of fully qualified annotation names to match against
+     * @return a list of matched fully qualified annotation names, or an empty list if no matches found
+     */
+    public List<String> containsAnyMatchingAnnotations(PsiClass type, PsiMethod method, Set<String> annotationFQNames) {
+        List<String> matchedAnnotations = Arrays.stream(method.getAnnotations())
+                .map(annotation -> getMatchedJavaElementName(
+                        type,
+                        annotation.getQualifiedName(),
+                        annotationFQNames.toArray(String[]::new)
+                ))
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+        return matchedAnnotations;
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/annotations/AnnotationDiagnosticsCollector.java
@@ -167,7 +167,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                 if (isMatchedAnnotation(annotation, AnnotationConstants.POST_CONSTRUCT_FQ_NAME)) {
                     if (element instanceof PsiMethod method) {
                         List<String> checkedExceptions = getCheckedExceptionPresent(method);
-                        if(!isInterceptorTypeReferenced(method.getContainingClass(), unit)) {
+                        if(!isInterceptorTypeReferenced(method.getContainingClass())) {
                             if (!checkedExceptions.isEmpty()) {
                                 String diagnosticMessage = Messages.getMessage("MethodMustNotThrow",
                                         "@PostConstruct");
@@ -196,7 +196,7 @@ public class AnnotationDiagnosticsCollector extends AbstractDiagnosticsCollector
                 } else if (isMatchedAnnotation(annotation, AnnotationConstants.PRE_DESTROY_FQ_NAME)) {
                     if (element instanceof PsiMethod method) {
                         List<String> checkedExceptions = getCheckedExceptionPresent(method);
-                        if(!isInterceptorTypeReferenced(method.getContainingClass(), unit)) {
+                        if(!isInterceptorTypeReferenced(method.getContainingClass())) {
                             if (!checkedExceptions.isEmpty()) {
                                 String diagnosticMessage = Messages.getMessage("MethodMustNotThrow",
                                         "@PreDestroy");

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
@@ -26,7 +26,10 @@ public class Constants {
     public static final String DIAGNOSTIC_SOURCE = "jakarta-interceptor";
     public static final String DIAGNOSTIC_CODE_INTERCEPTOR_ON_ABSTRACT_CLASS = "RemoveInterceptorAnnotationOnAbstractClass";
     public static final String DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR = "RemoveInterceptorAnnotationOnNoArgsConstructor";
-    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_METHOD_MISSING_PROCEED = "RemoveInterceptorMethodAnnotationOnMethod";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_METHOD_MISSING_PROCEED = "InvalidInterceptorMethodsProceedMissing";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_FINAL = "InvalidInterceptorMethodAnnotationOnFinalMethod";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_ABSTRACT = "InvalidInterceptorMethodAnnotationOnAbstractMethod";
+    public static final String DIAGNOSTIC_CODE_INTERCEPTOR_STATIC = "InvalidInterceptorMethodAnnotationOnStaticMethod";
 
     private static final String AROUND_CONSTRUCT_FQ_NAME = "jakarta.interceptor.AroundConstruct";
 
@@ -49,8 +52,6 @@ public class Constants {
 
     public static final String PROCEED = "proceed";
 
-    public static final String INTERCEPTOR_IMPORT = "jakarta.interceptor";
-
-    public static final String INTERCEPTORS_FQ_NAME = "jakarta.interceptor.Interceptors";
+    public static final Set<String> LIFECYCLE_CALLBACK_INTERCEPTOR_METHODS = Set.of(AROUND_CONSTRUCT_FQ_NAME, PRE_DESTROY_FQ_NAME, POST_CONSTRUCT_FQ_NAME);
 
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -56,11 +56,11 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 			if (isInterceptorTypeReferenced(type)) {
 				//Build the diagnostics if the parent class is Interceptor type and is abstract.
 				// Also, checks for missing public no-args constructor.
-				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type);
+				validateAbstractClassAndNoArgsConstructor(unit, diagnostics, type);
 				for (PsiClass innerClass : type.getInnerClasses()) {
 					//Build the diagnostics if the child class is Interceptor type and is abstract.
 					// Also, checks for missing public no-args constructor.
-					buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass);
+					validateAbstractClassAndNoArgsConstructor(unit, diagnostics, innerClass);
 				}
 				PsiMethod[] allMethods = type.getMethods();
 				for (PsiMethod method : allMethods) {
@@ -128,14 +128,14 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 	}
 
 	/**
-	 * buildAbstractAndNoArgsConstructorDiagnostics
+	 * validateAbstractClassAndNoArgsConstructor
 	 * Method checks if the parent or inner classes are Interceptor type and throws appropriate diagnostics
 	 *
 	 * @param unit
 	 * @param diagnostics
 	 * @param type
 	 */
-	private void buildAbstractAndNoArgsConstructorDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type) {
+	private void validateAbstractClassAndNoArgsConstructor(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type) {
 		ConstructorInfoDiagnosticHelper constructorInfo = ConstructorInfoDiagnosticHelper.initialize();
 		if(type.hasModifierProperty(PsiModifier.ABSTRACT)) {
 				diagnostics.add(createDiagnostic(type, unit,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -16,15 +16,18 @@ package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.Collection;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.intellij.psi.*;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PositionUtils;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.ASTUtils;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import org.eclipse.lsp4j.Range;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.helpers.ConstructorInfoDiagnosticHelper;
-import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.ASTUtils;
 import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.Constants.*;
 
 
@@ -50,15 +53,45 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 		PsiClass[] alltypes;
 		alltypes = unit.getClasses();
 		for (PsiClass type : alltypes) {
-			//Build the diagnostics if the parent class is Interceptor type and is abstract.
-			// Also, checks for missing public no-args constructor.
-      		buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type);
-			for(PsiClass innerClass: type.getInnerClasses()){
-				//Build the diagnostics if the child class is Interceptor type and is abstract.
+			if (isInterceptorTypeReferenced(type)) {
+				//Build the diagnostics if the parent class is Interceptor type and is abstract.
 				// Also, checks for missing public no-args constructor.
-				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass);
+				buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, type);
+				for (PsiClass innerClass : type.getInnerClasses()) {
+					//Build the diagnostics if the child class is Interceptor type and is abstract.
+					// Also, checks for missing public no-args constructor.
+					buildAbstractAndNoArgsConstructorDiagnostics(unit, diagnostics, innerClass);
+				}
+				PsiMethod[] allMethods = type.getMethods();
+				for (PsiMethod method : allMethods) {
+					List<String> interceptorTypeMethodAnnotations = containsAnyMatchingAnnotations(type, method, Constants.INTERCEPTOR_METHODS);
+					boolean isFinal = method.hasModifierProperty(PsiModifier.FINAL);
+					boolean isAbstract = method.hasModifierProperty(PsiModifier.ABSTRACT);
+					boolean isStatic = method.hasModifierProperty(PsiModifier.STATIC);
+					String msg;
+					DiagnosticSeverity severity = null;
+					if (isFinal) {
+						addInvalidModifierDiagnostic(method, unit, diagnostics, interceptorTypeMethodAnnotations,
+								"InvalidInterceptorMethodAnnotationFinalMethod", DIAGNOSTIC_CODE_INTERCEPTOR_FINAL,
+								DiagnosticSeverity.Error);
+					}
+					if (isAbstract) {
+						addInvalidModifierDiagnostic(method, unit, diagnostics, interceptorTypeMethodAnnotations,
+								"InvalidInterceptorMethodAnnotationAbstractMethod", DIAGNOSTIC_CODE_INTERCEPTOR_ABSTRACT,
+								DiagnosticSeverity.Error);
+					}
+					if (isStatic) {
+						boolean isLifecycleCallback = !containsAnyMatchingAnnotations(type, method, LIFECYCLE_CALLBACK_INTERCEPTOR_METHODS).isEmpty();
+						String messageKey = isLifecycleCallback
+								? "InvalidLifecycleCallbackMethodAnnotationStaticMethod"
+								: "InvalidInterceptorMethodAnnotationStaticMethod";
+						severity = isLifecycleCallback ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error;
+						addInvalidModifierDiagnostic(method, unit, diagnostics, interceptorTypeMethodAnnotations,
+								messageKey, DIAGNOSTIC_CODE_INTERCEPTOR_STATIC, severity);
+					}
+				}
 			}
-     }
+     	}
 		Collection<PsiMethod> allMethodDeclarations = ASTUtils.getAllMethodDeclarations(unit);
 		List<PsiMethod> methodsMissingProceedInvocation = allMethodDeclarations.stream().filter(m -> missingInterceptorMethodProceedInvocation(m, unit)).collect(Collectors.toList());
 		for(PsiMethod invokeMethod: methodsMissingProceedInvocation){
@@ -81,7 +114,7 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 	 * @return true if the method is an interceptor method missing proceed() invocation, false otherwise
 	 */
 	private boolean missingInterceptorMethodProceedInvocation(PsiMethod method, PsiJavaFile unit) {
-		if(isInterceptorTypeReferenced(method.getContainingClass(), unit)) {
+		if(isInterceptorTypeReferenced(method.getContainingClass())) {
 			PsiAnnotation[] annotations = method.getModifierList().getAnnotations();
 			for (PsiAnnotation ann : annotations) {
 				boolean isInterceptorMethod = Constants.INTERCEPTOR_METHODS.stream().anyMatch(annotation -> isMatchedJavaElement(method.getContainingClass(), ann.getQualifiedName(), annotation));
@@ -104,25 +137,54 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 	 */
 	private void buildAbstractAndNoArgsConstructorDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics, PsiClass type) {
 		ConstructorInfoDiagnosticHelper constructorInfo = ConstructorInfoDiagnosticHelper.initialize();
-		if (isInterceptorType(type)) {
-			if(type.hasModifierProperty(PsiModifier.ABSTRACT)) {
+		if(type.hasModifierProperty(PsiModifier.ABSTRACT)) {
 				diagnostics.add(createDiagnostic(type, unit,
 						Messages.getMessage("InvalidInterceptorAbstractClass", type.getName()),
 						DIAGNOSTIC_CODE_INTERCEPTOR_ON_ABSTRACT_CLASS, null,
 						DiagnosticSeverity.Error));
 			} else {
-				for (PsiMethod method : type.getMethods()) {
-					//Checks if method is a constructor and has valid no-args constructor
-					constructorInfo.mergeConstructorInfo(ConstructorInfoDiagnosticHelper.getConstructorInfo(method));
-				}
-				// Conditions for checking missing public no-args constructor
-				if (constructorInfo.hasConstructor() && !constructorInfo.hasValidPublicNoArgsConstructor()) {
-					diagnostics.add(createDiagnostic(type, unit,
-							Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
-							DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,
-							DiagnosticSeverity.Error));
-				}
+			for (PsiMethod method : type.getMethods()) {
+				//Checks if method is a constructor and has valid no-args constructor
+				constructorInfo.mergeConstructorInfo(ConstructorInfoDiagnosticHelper.getConstructorInfo(method));
+			}
+			// Conditions for checking missing public no-args constructor
+			if (constructorInfo.hasConstructor() && !constructorInfo.hasValidPublicNoArgsConstructor()) {
+				diagnostics.add(createDiagnostic(type, unit,
+						Messages.getMessage("InterceptorNoArgConstructorMissing", type.getName()),
+						DIAGNOSTIC_CODE_INTERCEPTOR_ON_NO_ARGS_CONSTRUCTOR, null,
+						DiagnosticSeverity.Error));
 			}
 		}
+	}
+
+	/**
+	 * Adds a diagnostic for an invalid method modifier on an interceptor method.
+	 *
+	 * @param method                          the method with the invalid modifier
+	 * @param unit                            the compilation unit
+	 * @param diagnostics                     the list to add the diagnostic to
+	 * @param interceptorTypeMethodAnnotations the list of interceptor annotation FQNs
+	 * @param messageKey                      the message key for the diagnostic message
+	 * @param diagnosticCode                  the diagnostic code
+	 * @param severity                        the diagnostic severity
+	 */
+	private void addInvalidModifierDiagnostic(PsiMethod method, PsiJavaFile unit, List<Diagnostic> diagnostics,
+											   List<String> interceptorTypeMethodAnnotations, String messageKey,
+											   String diagnosticCode, DiagnosticSeverity severity) {
+		String msg = Messages.getMessage(messageKey, getSimpleAnnotationNames(interceptorTypeMethodAnnotations));
+		JsonArray annotationData = (JsonArray) new Gson().toJsonTree(interceptorTypeMethodAnnotations);
+		diagnostics.add(createDiagnostic(method, unit, msg, diagnosticCode, annotationData, severity));
+	}
+
+	/**
+	 * Converts a list of fully qualified annotation names to a comma-separated string of simple names.
+	 * Duplicate simple names are removed.
+	 *
+	 * @param annotations the list of fully qualified annotation names
+	 * @return a comma-separated string of simple annotation names
+	 */
+	private String getSimpleAnnotationNames(List<String> annotations) {
+		List<String> simpleAnnotationNames = annotations.stream().map(name -> JDTUtils.getSimpleName(name)).distinct().collect(Collectors.toList());
+		return String.join(", ", simpleAnnotationNames);
 	}
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/RemoveInterceptorMethodAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/RemoveInterceptorMethodAnnotationQuickFix.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Archana Iyer - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor;
+
+import com.intellij.openapi.project.Project;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveMultipleAnnotations;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quick fix for removing Interceptror method annotations when more than
+ * one occur in a class.
+ * The getCodeActions method is overridden in order to make sure that
+ * we return our custom quick fixes. There will be two quick fixes given
+ * to the user: (1) remove @AroundInvoke (2) remove @AroundTimeout (3) remove @AroundConstruct (4) remove @PreDestroy (5) remove @PostConstruct
+ *
+ * @author Archana Iyer
+ *
+ */
+public class RemoveInterceptorMethodAnnotationQuickFix extends RemoveMultipleAnnotations {
+    @Override
+    protected List<List<String>> getMultipleRemoveAnnotations(Project project, List<String> annotations) {
+        List<List<String>> annotationsListsToRemove = new ArrayList<List<String>>();
+        if (annotations.size() > 0 && annotations.stream().anyMatch(Constants.INTERCEPTOR_METHODS::contains)) {
+            annotationsListsToRemove.add(annotations);
+        }
+        return annotationsListsToRemove;
+    }
+
+    @Override
+    public String getParticipantId() {
+        return RemoveInterceptorMethodAnnotationQuickFix.class.getName();
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/RemoveInterceptorMethodAnnotationQuickFix.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/RemoveInterceptorMethodAnnotationQuickFix.java
@@ -31,7 +31,7 @@ public class RemoveInterceptorMethodAnnotationQuickFix extends RemoveMultipleAnn
     @Override
     protected List<List<String>> getMultipleRemoveAnnotations(Project project, List<String> annotations) {
         List<List<String>> annotationsListsToRemove = new ArrayList<List<String>>();
-        if (annotations.size() > 0 && annotations.stream().anyMatch(Constants.INTERCEPTOR_METHODS::contains)) {
+        if (!annotations.isEmpty() && annotations.stream().anyMatch(Constants.INTERCEPTOR_METHODS::contains)) {
             annotationsListsToRemove.add(annotations);
         }
         return annotationsListsToRemove;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -575,6 +575,32 @@
                                    targetDiagnostic="jakarta-cdi#InvalidSingletonSessionBeanScope"
                                    implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanQuickFix"/>
 
+        <!-- Interceptor -->
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnFinalMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveFinalModifierQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnFinalMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.RemoveInterceptorMethodAnnotationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnStaticMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveStaticModifierQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnStaticMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.RemoveInterceptorMethodAnnotationQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnAbstractMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.codeAction.proposal.quickfix.RemoveAbstractModifierQuickFix"/>
+        <javaCodeActionParticipant kind="quickfix"
+                                   group="jakarta"
+                                   targetDiagnostic="jakarta-interceptor#InvalidInterceptorMethodAnnotationOnAbstractMethod"
+                                   implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.interceptor.RemoveInterceptorMethodAnnotationQuickFix"/>
+
         <configSourceProvider
                 implementation="io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.providers.MicroProfileConfigSourceProvider"/>
 

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -250,3 +250,7 @@ PrefixSlashToValueAttribute = Prefix value with '/'
 InterceptorNoArgConstructorMissing = Missing Public NoArgsConstructor. Class {0} is of Interceptor type, but does not declare a public no-argument constructor.
 InvalidInterceptorAbstractClass = The class {0} should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.
 InvalidInterceptorMethodsProceedMissing = Interceptor methods must always call the InvocationContext.proceed method.
+InvalidInterceptorMethodAnnotationFinalMethod = {0} interceptor method must not be declared as a final method.
+InvalidInterceptorMethodAnnotationAbstractMethod = {0} interceptor method must not be declared as an abstract method.
+InvalidLifecycleCallbackMethodAnnotationStaticMethod = {0} lifecycle callback interceptor method must not be declared as static except in an application client.
+InvalidInterceptorMethodAnnotationStaticMethod = {0} interceptor method must not be declared as a static method.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -347,12 +347,22 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
                 new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
 
+        Diagnostic multipleFinalModifierDiagnostic = JakartaForJavaAssert.d(21, 31, 50,
+                "AroundConstruct interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
+
+        Diagnostic multipleStaticModifierDiagnostic = JakartaForJavaAssert.d(21, 31, 50,
+                "AroundConstruct lifecycle callback interceptor method must not be declared as static except in an application client.",
+                DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
+
         Diagnostic invalidAbstractClassDiagnostics = JakartaForJavaAssert.d(5, 22, 51,
                 "The class InvalidAroundConstructMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
                 DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, finalModifierDiagnostic, abstractModifierDiagnostic, proceedDiagnostics, staticModifierDiagnostic,
-                invalidAbstractClassDiagnostics);
+                 multipleFinalModifierDiagnostic, multipleStaticModifierDiagnostic, invalidAbstractClassDiagnostics);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
@@ -372,6 +382,11 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "\n" +
                 "    @AroundConstruct\n" +
                 "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "\n" +
@@ -402,13 +417,18 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "    }\n" +
                 "\n" +
                 "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
                 "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "}";
 
-        TextEdit removeAroundConstructOnFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText6);
-        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText7);
+        TextEdit removeAroundConstructOnFinalEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText6);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText7);
         CodeAction removeAroundConstructOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", finalModifierDiagnostic, removeAroundConstructOnFinalEdit);
         CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removeAroundConstructOnFinalAction, removeFinalAction);
@@ -431,6 +451,11 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "\n" +
                 "    @AroundConstruct\n" +
                 "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "\n" +
@@ -461,13 +486,18 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "    }\n" +
                 "\n" +
                 "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
                 "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "}";
 
-        TextEdit removeAroundConstructOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText8);
-        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText9);
+        TextEdit removeAroundConstructOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText8);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText9);
         CodeAction removeAroundConstructOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", abstractModifierDiagnostic, removeAroundConstructOnAbstractEdit);
         CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removeAroundConstructOnAbstractAction, removeAbstractAction);
@@ -490,6 +520,11 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
                 "\n" +
                 "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "\n" +
@@ -520,16 +555,154 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
                 "    }\n" +
                 "\n" +
                 "    @AroundConstruct\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
                 "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
                 "        return ctx.proceed();\n" +
                 "    }\n" +
                 "}";
 
-        TextEdit removeAroundConstructOnStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText10);
-        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText11);
+        TextEdit removeAroundConstructOnStaticEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText10);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText11);
         CodeAction removeAroundConstructOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", staticModifierDiagnostic, removeAroundConstructOnStaticEdit);
         CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
         JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removeAroundConstructOnStaticAction, removeStaticAction);
+
+        // Test code actions for multiple modifiers
+        JakartaJavaCodeActionParams codeActionParams4 = JakartaForJavaAssert.createCodeActionParams(uri, multipleStaticModifierDiagnostic);
+        String newText12 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+        String newText13 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public  final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+        TextEdit removeAroundConstructOnMultipleModifiersEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText12);
+        TextEdit removeStaticOnMultipleModifiersEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText13);
+        CodeAction removeAroundConstructOnMultipleModifiersAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", multipleStaticModifierDiagnostic, removeAroundConstructOnMultipleModifiersEdit);
+        CodeAction removeStaticOnMultipleModifiersAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", multipleStaticModifierDiagnostic, removeStaticOnMultipleModifiersEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams4, utils, removeAroundConstructOnMultipleModifiersAction, removeStaticOnMultipleModifiersAction);
+
+        JakartaJavaCodeActionParams codeActionParams5 = JakartaForJavaAssert.createCodeActionParams(uri, multipleFinalModifierDiagnostic);
+        String newText14 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+        String newText15 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logMulipleModifiers(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+        TextEdit removeAroundConstructOnMultipleFinalEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText14);
+        TextEdit removeFinalOnMultipleModifiersEdit = JakartaForJavaAssert.te(0, 0, 29, 1, newText15);
+        CodeAction removeAroundConstructOnMultipleFinalAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", multipleFinalModifierDiagnostic, removeAroundConstructOnMultipleFinalEdit);
+        CodeAction removeFinalOnMultipleModifiersAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", multipleFinalModifierDiagnostic, removeFinalOnMultipleModifiersEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams5, utils, removeAroundConstructOnMultipleFinalAction, removeFinalOnMultipleModifiersAction);
     }
 
     @Test

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -15,6 +15,7 @@ package io.openliberty.tools.intellij.lsp4jakarta.it.interceptor;
 import java.io.File;
 import java.util.Arrays;
 
+import com.google.gson.Gson;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -24,8 +25,11 @@ import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
 import io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,31 +93,1047 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
         // Test diagnostics
         Diagnostic aroundInvokeInvalidProceed = JakartaForJavaAssert.d(17, 18, 38,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic aroundConstructInvalidProceed = JakartaForJavaAssert.d(23, 18, 41,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic aroundTimeoutInvalidProceed = JakartaForJavaAssert.d(29, 18, 39,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic postConstructInvalidProceed = JakartaForJavaAssert.d(35, 16, 36,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic preDestroyInvalidProceed = JakartaForJavaAssert.d(40, 16, 33,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic aroundInvokeInvalidProceedChild = JakartaForJavaAssert.d(51, 22, 47,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic postConstructInvalidProceedChild = JakartaForJavaAssert.d(67, 20, 45,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
         Diagnostic preDestroyInvalidProceedChild = JakartaForJavaAssert.d(72, 20, 42,
                 "Interceptor methods must always call the InvocationContext.proceed method.",
-                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorMethodAnnotationOnMethod");
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, aroundInvokeInvalidProceed, aroundConstructInvalidProceed,
                 aroundTimeoutInvalidProceed, postConstructInvalidProceed, preDestroyInvalidProceed, aroundInvokeInvalidProceedChild,
                 postConstructInvalidProceedChild, preDestroyInvalidProceedChild);
+    }
+
+    @Test
+    public void invalidAroundInvokeMethodModifiersTest() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundInvokeMethods.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics for invalid method modifiers
+        Diagnostic finalModifierDiagnostic = JakartaForJavaAssert.d(8, 24, 32,
+                "AroundInvoke interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundInvoke")));
+
+        Diagnostic abstractModifierDiagnostic = JakartaForJavaAssert.d(13, 27, 38,
+                "AroundInvoke interceptor method must not be declared as an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnAbstractMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundInvoke")));
+
+        Diagnostic proceedDiagnostic = JakartaForJavaAssert.d(13, 27, 38,
+                "Interceptor methods must always call the InvocationContext.proceed method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        Diagnostic staticModifierDiagnostic = JakartaForJavaAssert.d(16, 25, 34,
+                "AroundInvoke interceptor method must not be declared as a static method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundInvoke")));
+
+        Diagnostic invalidAbstractClassDiagnostic = JakartaForJavaAssert.d(5, 22, 48,
+                "The class InvalidAroundInvokeMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, finalModifierDiagnostic, abstractModifierDiagnostic, proceedDiagnostic, staticModifierDiagnostic,
+                invalidAbstractClassDiagnostic);
+
+        // Test code actions for final modifier
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
+        String newText = "package io.openliberty.sample.jakarta.interceptor;\n\nimport jakarta.interceptor.AroundInvoke;\nimport jakarta.interceptor.InvocationContext;\n\npublic abstract class InvalidAroundInvokeMethods {\n\n\tpublic final Object logFinal(InvocationContext ctx) throws Exception {\n        return ctx.proceed();\n    }\n\n    @AroundInvoke\n    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n    @AroundInvoke\n    public static Object logStatic(InvocationContext ctx) throws Exception {\n        return ctx.proceed();\n    }\n\n    @AroundInvoke\n    public Object logValid(InvocationContext ctx) throws Exception {\n        return ctx.proceed();\n    }\n}";
+
+        String newText1 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundInvoke;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundInvokeMethods {\n" +
+                "\n" +
+                "\t@AroundInvoke\n" +
+                "    public Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundInvokeOnFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText1);
+        CodeAction removeAroundInvokeOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @AroundInvoke", finalModifierDiagnostic, removeAroundInvokeOnFinalEdit);
+        CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removeAroundInvokeOnFinalAction, removeFinalAction);
+
+        // Test code actions for abstract modifier
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, abstractModifierDiagnostic);
+        String newText2 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundInvoke;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundInvokeMethods {\n" +
+                "\n" +
+                "\t@AroundInvoke\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText3 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundInvoke;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundInvokeMethods {\n" +
+                "\n" +
+                "\t@AroundInvoke\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundInvokeOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText2);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText3);
+        CodeAction removeAroundInvokeOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @AroundInvoke", abstractModifierDiagnostic, removeAroundInvokeOnAbstractEdit);
+        CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removeAroundInvokeOnAbstractAction, removeAbstractAction);
+
+        // Test code actions for static modifier
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, staticModifierDiagnostic);
+        String newText4 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundInvoke;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundInvokeMethods {\n" +
+                "\n" +
+                "\t@AroundInvoke\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText5 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundInvoke;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundInvokeMethods {\n" +
+                "\n" +
+                "\t@AroundInvoke\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundInvoke\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundInvokeOnStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText4);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText5);
+        CodeAction removeAroundInvokeOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @AroundInvoke", staticModifierDiagnostic, removeAroundInvokeOnStaticEdit);
+        CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removeAroundInvokeOnStaticAction, removeStaticAction);
+    }
+
+    @Test
+    public void invalidAroundConstructMethodModifiersTest() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundConstructMethods.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics for invalid method modifiers
+        Diagnostic finalModifierDiagnostic = JakartaForJavaAssert.d(8, 24, 32,
+                "AroundConstruct interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
+
+        Diagnostic abstractModifierDiagnostic = JakartaForJavaAssert.d(13, 27, 38,
+                "AroundConstruct interceptor method must not be declared as an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnAbstractMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
+
+        Diagnostic proceedDiagnostics = JakartaForJavaAssert.d(13, 27, 38,
+                "Interceptor methods must always call the InvocationContext.proceed method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        Diagnostic staticModifierDiagnostic = JakartaForJavaAssert.d(16, 25, 34,
+                "AroundConstruct lifecycle callback interceptor method must not be declared as static except in an application client.",
+                DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct")));
+
+        Diagnostic invalidAbstractClassDiagnostics = JakartaForJavaAssert.d(5, 22, 51,
+                "The class InvalidAroundConstructMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, finalModifierDiagnostic, abstractModifierDiagnostic, proceedDiagnostics, staticModifierDiagnostic,
+                invalidAbstractClassDiagnostics);
+
+        // Test code actions for final modifier
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
+        String newText6 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\tpublic final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText7 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundConstructOnFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText6);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText7);
+        CodeAction removeAroundConstructOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", finalModifierDiagnostic, removeAroundConstructOnFinalEdit);
+        CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removeAroundConstructOnFinalAction, removeFinalAction);
+
+        // Test code actions for abstract modifier
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, abstractModifierDiagnostic);
+        String newText8 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText9 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundConstructOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText8);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText9);
+        CodeAction removeAroundConstructOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", abstractModifierDiagnostic, removeAroundConstructOnAbstractEdit);
+        CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removeAroundConstructOnAbstractAction, removeAbstractAction);
+
+        // Test code actions for static modifier
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, staticModifierDiagnostic);
+        String newText10 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText11 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundConstruct;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundConstructMethods {\n" +
+                "\n" +
+                "\t@AroundConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundConstructOnStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText10);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText11);
+        CodeAction removeAroundConstructOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @AroundConstruct", staticModifierDiagnostic, removeAroundConstructOnStaticEdit);
+        CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removeAroundConstructOnStaticAction, removeStaticAction);
+    }
+
+    @Test
+    public void invalidAroundTimeoutMethodModifiersTest() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundTimeoutMethods.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics for invalid method modifiers
+        Diagnostic finalModifierDiagnostic = JakartaForJavaAssert.d(8, 24, 32,
+                "AroundTimeout interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundTimeout")));
+
+        Diagnostic abstractModifierDiagnostic = JakartaForJavaAssert.d(13, 27, 38,
+                "AroundTimeout interceptor method must not be declared as an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnAbstractMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundTimeout")));
+
+        Diagnostic proceedDiagnostic = JakartaForJavaAssert.d(13, 27, 38,
+                "Interceptor methods must always call the InvocationContext.proceed method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        Diagnostic staticModifierDiagnostic = JakartaForJavaAssert.d(16, 25, 34,
+                "AroundTimeout interceptor method must not be declared as a static method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundTimeout")));
+
+        Diagnostic invalidAbstractClassDiagnostic = JakartaForJavaAssert.d(5, 22, 49,
+                "The class InvalidAroundTimeoutMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, finalModifierDiagnostic, abstractModifierDiagnostic, proceedDiagnostic, staticModifierDiagnostic,
+                invalidAbstractClassDiagnostic);
+
+        // Test code actions for final modifier
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
+        String newText12 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\tpublic final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText13 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\t@AroundTimeout\n" +
+                "    public Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundTimeoutOnFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText12);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText13);
+        CodeAction removeAroundTimeoutOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @AroundTimeout", finalModifierDiagnostic, removeAroundTimeoutOnFinalEdit);
+        CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removeAroundTimeoutOnFinalAction, removeFinalAction);
+
+        // Test code actions for abstract modifier
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, abstractModifierDiagnostic);
+        String newText14 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\t@AroundTimeout\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText15 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\t@AroundTimeout\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundTimeoutOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText14);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText15);
+        CodeAction removeAroundTimeoutOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @AroundTimeout", abstractModifierDiagnostic, removeAroundTimeoutOnAbstractEdit);
+        CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removeAroundTimeoutOnAbstractAction, removeAbstractAction);
+
+        // Test code actions for static modifier
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, staticModifierDiagnostic);
+        String newText16 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\t@AroundTimeout\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText17 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.interceptor.AroundTimeout;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "public abstract class InvalidAroundTimeoutMethods {\n" +
+                "\n" +
+                "\t@AroundTimeout\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "\n" +
+                "    @AroundTimeout\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removeAroundTimeoutOnStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText16);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 24, 1, newText17);
+        CodeAction removeAroundTimeoutOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @AroundTimeout", staticModifierDiagnostic, removeAroundTimeoutOnStaticEdit);
+        CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removeAroundTimeoutOnStaticAction, removeStaticAction);
+    }
+
+    @Test
+    public void invalidPostConstructMethodModifiersTest() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPostConstructMethods.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics for abstract class
+        Diagnostic abstractClassDiagnostic = JakartaForJavaAssert.d(7, 22, 49,
+                "The class InvalidPostConstructMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+
+        // Test diagnostics for invalid method modifiers
+        Diagnostic finalModifierDiagnostic = JakartaForJavaAssert.d(10, 24, 32,
+                "PostConstruct interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct")));
+
+        Diagnostic abstractModifierDiagnostic = JakartaForJavaAssert.d(15, 27, 38,
+                "PostConstruct interceptor method must not be declared as an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnAbstractMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct")));
+
+        Diagnostic proceedDiagnostic = JakartaForJavaAssert.d(15, 27, 38,
+                "Interceptor methods must always call the InvocationContext.proceed method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        Diagnostic staticModifierDiagnostic = JakartaForJavaAssert.d(18, 25, 34,
+                "PostConstruct lifecycle callback interceptor method must not be declared as static except in an application client.",
+                DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct")));
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, abstractClassDiagnostic, finalModifierDiagnostic,
+                abstractModifierDiagnostic, proceedDiagnostic, staticModifierDiagnostic);
+
+        // Test code actions for final modifier
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
+        String newText18 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPostConstructMethods {\n\n" +
+                "	public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n	@PostConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PostConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText19 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\npublic abstract class InvalidPostConstructMethods {\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PostConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePostConstructOnFinalEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText18);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText19);
+        CodeAction removePostConstructOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @PostConstruct", finalModifierDiagnostic, removePostConstructOnFinalEdit);
+        CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removePostConstructOnFinalAction, removeFinalAction);
+
+        // Test code actions for abstract modifier
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, abstractModifierDiagnostic);
+        String newText20 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPostConstructMethods {\n\n" +
+                "	@PostConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "\tpublic abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PostConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n}";
+
+        String newText21 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPostConstructMethods {\n\n" +
+                "	@PostConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PostConstruct\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePostConstructOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText20);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText21);
+        CodeAction removePostConstructOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @PostConstruct", abstractModifierDiagnostic, removePostConstructOnAbstractEdit);
+        CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removePostConstructOnAbstractAction, removeAbstractAction);
+
+        // Test code actions for static modifier
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, staticModifierDiagnostic);
+        String newText22 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPostConstructMethods {\n\n" +
+                "	@PostConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText23 = "package io.openliberty.sample.jakarta.interceptor;\n" +
+                "\n" +
+                "import jakarta.annotation.PostConstruct;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n" +
+                "\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPostConstructMethods {\n" +
+                "\n" +
+                "\t@PostConstruct\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "\t@PostConstruct\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "\t@PostConstruct\n" +
+                "    public Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "\t@PostConstruct\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePostConstructOnStaticEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText22);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText23);
+        CodeAction removePostConstructOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @PostConstruct", staticModifierDiagnostic, removePostConstructOnStaticEdit);
+        CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removePostConstructOnStaticAction, removeStaticAction);
+    }
+
+    @Test
+    public void invalidPreDestroyMethodModifiersTest() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPreDestroyMethods.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Test diagnostics for abstract class
+        Diagnostic abstractClassDiagnostic = JakartaForJavaAssert.d(7, 22, 46,
+                "The class InvalidPreDestroyMethods should not contain the abstract modifier. If it contains the abstract modifier, the class should not be annotated with @Interceptor.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "RemoveInterceptorAnnotationOnAbstractClass");
+
+        // Test diagnostics for invalid method modifiers
+        Diagnostic finalModifierDiagnostic = JakartaForJavaAssert.d(10, 24, 32,
+                "PreDestroy interceptor method must not be declared as a final method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnFinalMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy")));
+
+        Diagnostic abstractModifierDiagnostic = JakartaForJavaAssert.d(15, 27, 38,
+                "PreDestroy interceptor method must not be declared as an abstract method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnAbstractMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy")));
+
+        Diagnostic proceedDiagnostic = JakartaForJavaAssert.d(15, 27, 38,
+                "Interceptor methods must always call the InvocationContext.proceed method.",
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        Diagnostic staticModifierDiagnostic = JakartaForJavaAssert.d(18, 25, 34,
+                "PreDestroy lifecycle callback interceptor method must not be declared as static except in an application client.",
+                DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMethodAnnotationOnStaticMethod",
+                new Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy")));
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, abstractClassDiagnostic, finalModifierDiagnostic,
+                abstractModifierDiagnostic, proceedDiagnostic, staticModifierDiagnostic);
+
+        // Test code actions for final modifier
+        JakartaJavaCodeActionParams codeActionParams1 = JakartaForJavaAssert.createCodeActionParams(uri, finalModifierDiagnostic);
+        String newText24 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PreDestroy\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText25 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PreDestroy\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePreDestroyOnFinalEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText24);
+        TextEdit removeFinalEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText25);
+        CodeAction removePreDestroyOnFinalAction = JakartaForJavaAssert.ca(uri, "Remove @PreDestroy", finalModifierDiagnostic, removePreDestroyOnFinalEdit);
+        CodeAction removeFinalAction = JakartaForJavaAssert.ca(uri, "Remove the 'final' modifier from this method", finalModifierDiagnostic, removeFinalEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams1, utils, removePreDestroyOnFinalAction, removeFinalAction);
+
+        // Test code actions for abstract modifier
+        JakartaJavaCodeActionParams codeActionParams2 = JakartaForJavaAssert.createCodeActionParams(uri, abstractModifierDiagnostic);
+        String newText26 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	@PreDestroy\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "\tpublic abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PreDestroy\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText27 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	@PreDestroy\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PreDestroy\n" +
+                "    public static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePreDestroyOnAbstractEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText26);
+        TextEdit removeAbstractEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText27);
+        CodeAction removePreDestroyOnAbstractAction = JakartaForJavaAssert.ca(uri, "Remove @PreDestroy", abstractModifierDiagnostic, removePreDestroyOnAbstractEdit);
+        CodeAction removeAbstractAction = JakartaForJavaAssert.ca(uri, "Remove the 'abstract' modifier from this method", abstractModifierDiagnostic, removeAbstractEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams2, utils, removePreDestroyOnAbstractAction, removeAbstractAction);
+
+        // Test code actions for static modifier
+        JakartaJavaCodeActionParams codeActionParams3 = JakartaForJavaAssert.createCodeActionParams(uri, staticModifierDiagnostic);
+        String newText28 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	@PreDestroy\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "\tpublic static Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        String newText29 = "package io.openliberty.sample.jakarta.interceptor;\n\n" +
+                "import jakarta.annotation.PreDestroy;\n" +
+                "import jakarta.interceptor.Interceptor;\n" +
+                "import jakarta.interceptor.InvocationContext;\n\n" +
+                "@Interceptor\n" +
+                "public abstract class InvalidPreDestroyMethods {\n\n" +
+                "	@PreDestroy\n" +
+                "    public final Object logFinal(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public abstract Object logAbstract(InvocationContext ctx) throws Exception;\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logStatic(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n\n" +
+                "	@PreDestroy\n" +
+                "    public Object logValid(InvocationContext ctx) throws Exception {\n" +
+                "        return ctx.proceed();\n" +
+                "    }\n" +
+                "}";
+
+        TextEdit removePreDestroyOnStaticEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText28);
+        TextEdit removeStaticEdit = JakartaForJavaAssert.te(0, 0, 26, 1, newText29);
+        CodeAction removePreDestroyOnStaticAction = JakartaForJavaAssert.ca(uri, "Remove @PreDestroy", staticModifierDiagnostic, removePreDestroyOnStaticEdit);
+        CodeAction removeStaticAction = JakartaForJavaAssert.ca(uri, "Remove the 'static' modifier from this method", staticModifierDiagnostic, removeStaticEdit);
+        JakartaForJavaAssert.assertJavaCodeAction(codeActionParams3, utils, removePreDestroyOnStaticAction, removeStaticAction);
     }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundConstructMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundConstructMethods.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.InvocationContext;
+
+public abstract class InvalidAroundConstructMethods {
+
+	@AroundConstruct
+    public final Object logFinal(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundConstruct
+    public abstract Object logAbstract(InvocationContext ctx) throws Exception;
+
+    @AroundConstruct
+    public static Object logStatic(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundConstruct
+    public Object logValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundConstructMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundConstructMethods.java
@@ -19,6 +19,11 @@ public abstract class InvalidAroundConstructMethods {
     }
 
     @AroundConstruct
+    public static final Object logMulipleModifiers(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundConstruct
     public Object logValid(InvocationContext ctx) throws Exception {
         return ctx.proceed();
     }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundInvokeMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundInvokeMethods.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+public abstract class InvalidAroundInvokeMethods {
+
+	@AroundInvoke
+    public final Object logFinal(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundInvoke
+    public abstract Object logAbstract(InvocationContext ctx) throws Exception;
+
+    @AroundInvoke
+    public static Object logStatic(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundInvoke
+    public Object logValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundTimeoutMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidAroundTimeoutMethods.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundTimeout;
+import jakarta.interceptor.InvocationContext;
+
+public abstract class InvalidAroundTimeoutMethods {
+
+	@AroundTimeout
+    public final Object logFinal(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundTimeout
+    public abstract Object logAbstract(InvocationContext ctx) throws Exception;
+
+    @AroundTimeout
+    public static Object logStatic(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    @AroundTimeout
+    public Object logValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPostConstructMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPostConstructMethods.java
@@ -1,0 +1,27 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+public abstract class InvalidPostConstructMethods {
+
+	@PostConstruct
+    public final Object logFinal(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+	@PostConstruct
+    public abstract Object logAbstract(InvocationContext ctx) throws Exception;
+
+	@PostConstruct
+    public static Object logStatic(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+	@PostConstruct
+    public Object logValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPreDestroyMethods.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidPreDestroyMethods.java
@@ -1,0 +1,27 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+public abstract class InvalidPreDestroyMethods {
+
+	@PreDestroy
+    public final Object logFinal(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+	@PreDestroy
+    public abstract Object logAbstract(InvocationContext ctx) throws Exception;
+
+	@PreDestroy
+    public static Object logStatic(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+	@PreDestroy
+    public Object logValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION
Fixes #1551 
lsp4jakarta PR: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/869
lsp4jakarta issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/659