### PR TITLE
Added diagnostic to detect manual JSON-P parsing and recommend Jakarta JSON Binding

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonp/JsonpConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonp/JsonpConstants.java
@@ -28,4 +28,17 @@ public class JsonpConstants {
     public static final String JAKARTA_JSON_BUILDER_ADD_METHOD = "add";
     public static final String JAKARTA_JSON_ARRAY_BUILDER_FQ_NAME = "jakarta.json.JsonArrayBuilder";
     public static final int EXPRESSION_COUNT_CREATE_POINTER = 1;
+
+    /* JSON-B recommendation constants */
+    public static final String CREATE_READER = "createReader";
+    public static final String READ_OBJECT = "readObject";
+    public static final String JSON_READER_FQ_NAME = "jakarta.json.JsonReader";
+    public static final String JSON_OBJECT_FQ_NAME = "jakarta.json.JsonObject";
+    public static final String GET_STRING = "getString";
+    public static final String GET_INT = "getInt";
+    public static final String GET_BOOLEAN = "getBoolean";
+    public static final String GET_JSON_NUMBER = "getJsonNumber";
+    public static final String GET_JSON_OBJECT = "getJsonObject";
+    public static final String GET_JSON_ARRAY = "getJsonArray";
+    public static final String DIAGNOSTIC_CODE_USE_JSONB = "UseJsonbInsteadOfManualParsing";
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonp/JsonpDiagnosticCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/jsonp/JsonpDiagnosticCollector.java
@@ -23,6 +23,7 @@ import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsColle
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
 import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.PositionUtils;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
 
 public class JsonpDiagnosticCollector extends AbstractDiagnosticsCollector {
@@ -77,6 +78,9 @@ public class JsonpDiagnosticCollector extends AbstractDiagnosticsCollector {
         createDiagnosticsForMethodInvocations(diagnostics, createArrayBuilderMethodInvocations,
                 Messages.getMessage("ErrorMessageJsonPArrayValueNonNull"),
                 JsonpConstants.DIAGNOSTIC_CODE_INVALID_ARRAY_BUILDER_VALUE);
+
+        // Detect manual JSON parsing patterns that should use JSON-B
+        detectManualJsonParsingPatterns(diagnostics, allMethodInvocations);
     }
 
     /**
@@ -180,5 +184,116 @@ public class JsonpDiagnosticCollector extends AbstractDiagnosticsCollector {
             }
         }
         return false;
+    }
+
+    /**
+     * Detects manual JSON parsing patterns where Json.createReader() is used
+     * followed by manual field mapping with getter methods like getString(), getInt(), etc.
+     * This pattern should use JSON-B instead for better performance and maintainability.
+     *
+     * @param diagnostics the list to add diagnostics to
+     * @param allMethodInvocations all method call expressions in the file
+     */
+    private void detectManualJsonParsingPatterns(List<Diagnostic> diagnostics,
+                                                 Collection<PsiMethodCallExpression> allMethodInvocations) {
+        for (PsiMethodCallExpression mce : allMethodInvocations) {
+            if (isJsonCreateReaderInvocation(mce) && isManualParsingPattern(mce, allMethodInvocations)) {
+                Range range = PositionUtils.toNameRange(mce);
+                Diagnostic diagnostic = new Diagnostic(range, Messages.getMessage("UseJsonbInsteadOfManualParsing"));
+                completeDiagnostic(diagnostic, JsonpConstants.DIAGNOSTIC_CODE_USE_JSONB,
+                                   DiagnosticSeverity.Warning);
+                diagnostics.add(diagnostic);
+            }
+        }
+    }
+
+    /**
+     * Checks if a method call expression is Json.createReader().
+     *
+     * @param mce the method call expression
+     * @return true if it's Json.createReader()
+     */
+    private boolean isJsonCreateReaderInvocation(PsiMethodCallExpression mce) {
+        PsiMethod method = mce.resolveMethod();
+        if (method == null || !JsonpConstants.CREATE_READER.equals(method.getName())) {
+            return false;
+        }
+        PsiClass containingClass = method.getContainingClass();
+        return containingClass != null && JsonpConstants.JSON_FQ_NAME.equals(containingClass.getQualifiedName());
+    }
+
+    /**
+     * Checks if a createReader invocation is part of a manual parsing pattern.
+     * A manual parsing pattern is detected when readObject() and JsonObject getter
+     * methods (getString, getInt, etc.) are also called in the same method scope.
+     *
+     * @param createReaderMce the createReader method call expression
+     * @param allMethodInvocations all method call expressions in the file
+     * @return true if manual parsing pattern is detected
+     */
+    private boolean isManualParsingPattern(PsiMethodCallExpression createReaderMce,
+                                           Collection<PsiMethodCallExpression> allMethodInvocations) {
+        boolean hasReadObject = allMethodInvocations.stream()
+            .anyMatch(mi -> isReadObjectInvocation(mi) && isInSameMethodScope(createReaderMce, mi));
+
+        if (!hasReadObject) {
+            return false;
+        }
+
+        return allMethodInvocations.stream()
+            .anyMatch(mi -> isJsonObjectGetterMethod(mi) && isInSameMethodScope(createReaderMce, mi));
+    }
+
+    /**
+     * Checks if a method call expression is JsonReader.readObject().
+     *
+     * @param mce the method call expression
+     * @return true if it's readObject() on a JsonReader
+     */
+    private boolean isReadObjectInvocation(PsiMethodCallExpression mce) {
+        PsiMethod method = mce.resolveMethod();
+        if (method == null || !JsonpConstants.READ_OBJECT.equals(method.getName())) {
+            return false;
+        }
+        PsiClass containingClass = method.getContainingClass();
+        return containingClass != null && JsonpConstants.JSON_READER_FQ_NAME.equals(containingClass.getQualifiedName());
+    }
+
+    /**
+     * Checks if a method call expression is a JsonObject getter method
+     * (getString, getInt, getBoolean, etc.).
+     *
+     * @param mce the method call expression
+     * @return true if it's a JsonObject getter method
+     */
+    private boolean isJsonObjectGetterMethod(PsiMethodCallExpression mce) {
+        PsiMethod method = mce.resolveMethod();
+        if (method == null) {
+            return false;
+        }
+        String name = method.getName();
+        if (!name.equals(JsonpConstants.GET_STRING) &&
+            !name.equals(JsonpConstants.GET_INT) &&
+            !name.equals(JsonpConstants.GET_BOOLEAN) &&
+            !name.equals(JsonpConstants.GET_JSON_NUMBER) &&
+            !name.equals(JsonpConstants.GET_JSON_OBJECT) &&
+            !name.equals(JsonpConstants.GET_JSON_ARRAY)) {
+            return false;
+        }
+        PsiClass containingClass = method.getContainingClass();
+        return containingClass != null && JsonpConstants.JSON_OBJECT_FQ_NAME.equals(containingClass.getQualifiedName());
+    }
+
+    /**
+     * Checks if two method call expressions are enclosed by the same PsiMethod.
+     *
+     * @param mce1 first method call expression
+     * @param mce2 second method call expression
+     * @return true if both are enclosed by the same PsiMethod
+     */
+    private boolean isInSameMethodScope(PsiMethodCallExpression mce1, PsiMethodCallExpression mce2) {
+        PsiMethod enclosing1 = PsiTreeUtil.getParentOfType(mce1, PsiMethod.class);
+        PsiMethod enclosing2 = PsiTreeUtil.getParentOfType(mce2, PsiMethod.class);
+        return enclosing1 != null && enclosing1 == enclosing2;
     }
 }

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -180,6 +180,7 @@ ErrorMessageJsonbNonPublicProtectedStaticNestedClass = Static nested class {0} m
 CreatePointerErrorMessage = Json.createPointer target must be a sequence of '/' prefixed tokens or an empty String.
 ErrorMessageJsonPObjectKeyNonNull = The JsonObjectBuilder class does not allow null to be used as a name while building the JSON object.
 ErrorMessageJsonPArrayValueNonNull = JsonArrayBuilder class does not allow null to be used as a value while building the JSON array.
+UseJsonbInsteadOfManualParsing = Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.
 
 # PersistenceAnnotationQuickFix
 AddTheMissingAttributes = Add the missing attributes to the @MapKeyJoinColumn annotation

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -111,4 +111,31 @@ public class JakartaJsonpTest extends BaseJakartaTest {
 
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, invalidArrayBuilderStringNull, invalidArrayBuilderNull, invalidArrayBuilderTwoParamString);
     }
+
+    @Test
+    public void manualJsonParsingToPojoPattern() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = JakartaForJavaAssert.d(42, 25, 71,
+                "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+
+        Diagnostic d2 = JakartaForJavaAssert.d(52, 24, 80,
+                "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+
+        Diagnostic d3 = JakartaForJavaAssert.d(62, 29, 85,
+                "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+    }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -124,15 +124,15 @@ public class JakartaJsonpTest extends BaseJakartaTest {
         JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d1 = JakartaForJavaAssert.d(41, 28, 75,
+        Diagnostic d1 = JakartaForJavaAssert.d(43, 28, 75,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 
-        Diagnostic d2 = JakartaForJavaAssert.d(53, 26, 73,
+        Diagnostic d2 = JakartaForJavaAssert.d(55, 26, 73,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 
-        Diagnostic d3 = JakartaForJavaAssert.d(64, 32, 79,
+        Diagnostic d3 = JakartaForJavaAssert.d(66, 32, 79,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/jsonp/JakartaJsonpTest.java
@@ -124,15 +124,15 @@ public class JakartaJsonpTest extends BaseJakartaTest {
         JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d1 = JakartaForJavaAssert.d(42, 25, 71,
+        Diagnostic d1 = JakartaForJavaAssert.d(41, 28, 75,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 
-        Diagnostic d2 = JakartaForJavaAssert.d(52, 24, 80,
+        Diagnostic d2 = JakartaForJavaAssert.d(53, 26, 73,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 
-        Diagnostic d3 = JakartaForJavaAssert.d(62, 29, 85,
+        Diagnostic d3 = JakartaForJavaAssert.d(64, 32, 79,
                 "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                 DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
@@ -15,6 +15,8 @@ package io.openliberty.sample.jakarta.jsonp;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 import java.io.StringReader;
 
 public class ManualJsonParsingToPojoExample {
@@ -70,5 +72,11 @@ public class ManualJsonParsingToPojoExample {
         user.setAge(jsonObject.getInt("age"));
         
         return user;
+    }
+
+    // Valid: Using JSON-B for direct POJO deserialization - no diagnostic expected
+    public User parseUserWithJsonb(String jsonString) {
+        Jsonb jsonb = JsonbBuilder.create();
+        return jsonb.fromJson(jsonString, User.class);
     }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.sample.jakarta.jsonp;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+
+public class ManualJsonParsingToPojoExample {
+
+    public static class User {
+        private String name;
+        private int age;
+
+        public User() {}
+
+        public User(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public int getAge() { return age; }
+        public void setAge(int age) { this.age = age; }
+    }
+
+    // Example 1: Manual parsing with Json.createReader followed by manual mapping
+    public User parseUserManually(String jsonString) {
+        JsonReader reader = Json.createReader(new StringReader(jsonString));
+        JsonObject json = reader.readObject();
+        
+        User user = new User();
+        user.setName(json.getString("name"));
+        user.setAge(json.getInt("age"));
+        
+        return user;
+    }
+
+    // Example 2: Another manual parsing pattern
+    public User anotherManualParsing(String jsonString) {
+        JsonObject json = Json.createReader(new StringReader(jsonString)).readObject();
+        
+        User user = new User();
+        user.setName(json.getString("name"));
+        user.setAge(json.getInt("age"));
+        
+        return user;
+    }
+
+    // Example 3: Multiple field mappings
+    public User complexManualParsing(String jsonString) {
+        JsonReader jsonReader = Json.createReader(new StringReader(jsonString));
+        JsonObject jsonObject = jsonReader.readObject();
+        
+        User user = new User();
+        user.setName(jsonObject.getString("name"));
+        user.setAge(jsonObject.getInt("age"));
+        
+        return user;
+    }
+}


### PR DESCRIPTION
Fixes [#782 ](https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/782)

Adding a new diagnostic to detect manual JSON parsing anti-patterns where developers use Jakarta JSON Processing (JSON-P) APIs like Json.createReader(), readObject(), and field-by-field getter methods (getString(), getInt(), etc.) to manually map JSON to POJOs. The diagnostic issues a warning recommending the use of Jakarta JSON Binding (JSON-B) with Jsonb.fromJson() instead, which provides automatic object-to-JSON mapping for better performance and maintainability. The implementation includes detection logic in JsonpDiagnosticParticipant, new error codes and constants, comprehensive test cases, and follows the existing diagnostic patterns in the codebase.



https://github.com/user-attachments/assets/29eba45d-256b-4c62-bea5-041061a7b43a



