### PR TITLE
Replaced all internal API PluginManagerCore.getPlugin(PluginId) with the public API PluginPathManager.getPluginResource(getClass(),<path>)

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Red Hat, Inc.
+ * Copyright (c) 2020, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,9 +11,7 @@
 package io.openliberty.tools.intellij.liberty.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.application.PluginPathManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import io.openliberty.tools.intellij.util.JavaVersionUtil;
@@ -34,8 +32,8 @@ public class LibertyConfigLanguageServer extends OSProcessStreamConnectionProvid
 
     public LibertyConfigLanguageServer() {
         String javaHome = System.getProperty("java.home");
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("open-liberty.intellij"));
-        File libertyServerPath = new File(descriptor.getPluginPath().toFile(), "lib/server/liberty-langserver-jar-with-dependencies.jar");
+        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
+        File libertyServerPath = new File(pluginPath, "lib/server/liberty-langserver-jar-with-dependencies.jar");
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.LIBERTY_CONFIG_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyConfigLanguageServer.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Start Liberty Language Server
@@ -32,8 +33,7 @@ public class LibertyConfigLanguageServer extends OSProcessStreamConnectionProvid
 
     public LibertyConfigLanguageServer() {
         String javaHome = System.getProperty("java.home");
-        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
-        File libertyServerPath = new File(pluginPath, "lib/server/liberty-langserver-jar-with-dependencies.jar");
+        File libertyServerPath = Objects.requireNonNull(PluginPathManager.getPluginResource(getClass(), "lib/server/liberty-langserver-jar-with-dependencies.jar"));
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.LIBERTY_CONFIG_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Red Hat, Inc.
+ * Copyright (c) 2020, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,9 +11,7 @@
 package io.openliberty.tools.intellij.liberty.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.application.PluginPathManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import io.openliberty.tools.intellij.util.JavaVersionUtil;
@@ -35,9 +33,9 @@ public class LibertyXmlServer extends OSProcessStreamConnectionProvider {
 
     public LibertyXmlServer() {
         String javaHome = System.getProperty("java.home");
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("open-liberty.intellij"));
-        File lemminxServerPath = new File(descriptor.getPluginPath().toFile(), "lib/server/org.eclipse.lemminx-uber.jar");
-        File libertyServerPath = new File(descriptor.getPluginPath().toFile(), "lib/server/liberty-langserver-lemminx-jar-with-dependencies.jar");
+        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
+        File lemminxServerPath = new File(pluginPath, "lib/server/org.eclipse.lemminx-uber.jar");
+        File libertyServerPath = new File(pluginPath, "lib/server/liberty-langserver-lemminx-jar-with-dependencies.jar");
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.LIBERTY_XML_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/liberty/lsp/LibertyXmlServer.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Start LemMinX language server with Liberty LemMinX ext
@@ -33,9 +34,8 @@ public class LibertyXmlServer extends OSProcessStreamConnectionProvider {
 
     public LibertyXmlServer() {
         String javaHome = System.getProperty("java.home");
-        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
-        File lemminxServerPath = new File(pluginPath, "lib/server/org.eclipse.lemminx-uber.jar");
-        File libertyServerPath = new File(pluginPath, "lib/server/liberty-langserver-lemminx-jar-with-dependencies.jar");
+        File lemminxServerPath = Objects.requireNonNull(PluginPathManager.getPluginResource(getClass(), "lib/server/org.eclipse.lemminx-uber.jar"));
+        File libertyServerPath = Objects.requireNonNull(PluginPathManager.getPluginResource(getClass(), "lib/server/liberty-langserver-lemminx-jar-with-dependencies.jar"));
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.LIBERTY_XML_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Red Hat, Inc. and others.
+ * Copyright (c) 2020, 2026 Red Hat, Inc. and others.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -12,9 +12,7 @@
 package io.openliberty.tools.intellij.lsp4jakarta.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.application.PluginPathManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import io.openliberty.tools.intellij.util.Constants;
@@ -34,8 +32,8 @@ public class JakartaLanguageServer extends OSProcessStreamConnectionProvider {
 
     public JakartaLanguageServer() {
         String javaHome = System.getProperty("java.home");
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("open-liberty.intellij"));
-        File lsp4JakartaServerPath = new File(descriptor.getPluginPath().toFile(), JAR_DIR + LANGUAGESERVER_JAR);
+        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
+        File lsp4JakartaServerPath = new File(pluginPath, JAR_DIR + LANGUAGESERVER_JAR);
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.JAKARTA_LANG_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp/JakartaLanguageServer.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class JakartaLanguageServer extends OSProcessStreamConnectionProvider {
     private static final String JAR_DIR = "lib/server/";
@@ -32,8 +33,7 @@ public class JakartaLanguageServer extends OSProcessStreamConnectionProvider {
 
     public JakartaLanguageServer() {
         String javaHome = System.getProperty("java.home");
-        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
-        File lsp4JakartaServerPath = new File(pluginPath, JAR_DIR + LANGUAGESERVER_JAR);
+        File lsp4JakartaServerPath = Objects.requireNonNull(PluginPathManager.getPluginResource(getClass(), JAR_DIR + LANGUAGESERVER_JAR));
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.JAKARTA_LANG_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 Red Hat, Inc.
+ * Copyright (c) 2020, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,9 +11,7 @@
 package io.openliberty.tools.intellij.lsp4mp.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.application.PluginPathManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import io.openliberty.tools.intellij.util.Constants;
@@ -36,8 +34,8 @@ public class MicroProfileServer extends OSProcessStreamConnectionProvider {
 
     public MicroProfileServer() {
         String javaHome = System.getProperty("java.home");
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("open-liberty.intellij"));
-        File lsp4mpServerPath = new File(descriptor.getPluginPath().toFile(), "lib/server/org.eclipse.lsp4mp.ls-uber.jar");
+        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
+        File lsp4mpServerPath = new File(pluginPath, "lib/server/org.eclipse.lsp4mp.ls-uber.jar");
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.MICROPROFILE_SERVER)){
             return;
         }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4mp/lsp/MicroProfileServer.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Adapted from https://github.com/redhat-developer/intellij-quarkus/blob/2585eb422beeb69631076d2c39196d6eca2f5f2e/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
@@ -34,8 +35,7 @@ public class MicroProfileServer extends OSProcessStreamConnectionProvider {
 
     public MicroProfileServer() {
         String javaHome = System.getProperty("java.home");
-        File pluginPath = PluginPathManager.getPluginHome("open-liberty.intellij");
-        File lsp4mpServerPath = new File(pluginPath, "lib/server/org.eclipse.lsp4mp.ls-uber.jar");
+        File lsp4mpServerPath = Objects.requireNonNull(PluginPathManager.getPluginResource(getClass(), "lib/server/org.eclipse.lsp4mp.ls-uber.jar"));
         if(!JavaVersionUtil.isJavaHomeValid(javaHome, Constants.MICROPROFILE_SERVER)){
             return;
         }


### PR DESCRIPTION
Fixes #1642 

Replaced all 4 usages of the internal API `PluginManagerCore.getPlugin(PluginId)` with the public API `PluginPathManager.getPluginResource(getClass(),<path>)`.

- `LibertyConfigLanguageServer.java` - Replaced `PluginManagerCore.getPlugin()` with `PluginPathManager.getPluginResource(getClass(),<path>)`
- `MicroProfileServer.java` - Replaced `PluginManagerCore.getPlugin()` with `PluginPathManager.getPluginResource(getClass(),<path>)`
- `LibertyXmlServer.java` - Replaced `PluginManagerCore.getPlugin()` with `PluginPathManager.getPluginResource(getClass(),<path>)`
- `JakartaLanguageServer.java` - Replaced `PluginManagerCore.getPlugin()` with `PluginPathManager.getPluginResource(getClass(),<path>)`

<img width="2554" height="1636" alt="image" src="https://github.com/user-attachments/assets/0b7ccaf3-437f-4b13-892a-7de86e2b7b3b" />

