### PR TITLE
Resolve the initialization error occurring in test automation with IntelliJ 2026.2 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, intellij-2026.2-test-automation ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:

--- a/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
+++ b/src/test/java/io/openliberty/tools/intellij/it/UIBotTestUtils.java
@@ -1678,9 +1678,19 @@ public class UIBotTestUtils {
                     searchFixture.click();
                 }
 
-                // Click on the Actions tab
-                ComponentFixture actionsTabFixture = projectFrame.getSETabLabel("Actions");
-                actionsTabFixture.click();
+                // Click on the Actions tab. Poll until the click succeeds.
+                RepeatUtilsKt.waitFor(Duration.ofSeconds(30),
+                        Duration.ofSeconds(1),
+                        "Waiting for the Actions tab to become visible in the Search Everywhere dialog",
+                        "The Actions tab did not become visible in the Search Everywhere dialog",
+                        () -> {
+                            try {
+                                projectFrame.getSETabLabel("Actions").click();
+                                return true;
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        });
 
                 // Type the search string in the search dialog box.
                 JTextFieldFixture searchField = projectFrame.textField(JTextFieldFixture.Companion.byType(), Duration.ofSeconds(10));


### PR DESCRIPTION
Fixes #1652 
Add retry logic for Actions tab click in Search Everywhere

Attaching build link where the error was resolved - https://github.com/anusreelakshmi934/liberty-tools-intellij/actions/runs/29321523943