### PR TITLE
Fix EDT threading assertions thrown by LibertyDevStopAction and LibertyDevRunTestsAction from IntelliJ 2026.1

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -15,6 +15,7 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -30,7 +31,10 @@ import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public abstract class LibertyGeneralAction extends AnAction {
     protected static final Logger LOGGER = Logger.getInstance(LibertyGeneralAction.class);
@@ -177,7 +181,8 @@ public abstract class LibertyGeneralAction extends AnAction {
         LibertyProjectUtil.setFocusToWidget(project, existingWidget);
 
         // Shows error for actions where terminal widget does not exist or action requires a terminal to already exist and expects "Start" to be running
-        if (widget == null || (!createWidget && !widget.hasRunningCommands())) {
+        // hasRunningCommands() must not be called from the EDT (asserted since IntelliJ 2026.1)
+        if (widget == null || (!createWidget && !computeOffEdt(widget::hasRunningCommands))) {
             String msg;
             if (createWidget) {
                 msg = LocalizedResourceUtil.getMessage("liberty.terminal.cannot.resolve", actionCmd, project.getName());
@@ -204,4 +209,20 @@ public abstract class LibertyGeneralAction extends AnAction {
      * @return The string representation of the action command being processed.
      */
     protected abstract String getActionCommandName();
+
+    /**
+     * Runs the given supplier on a pooled thread and blocks for the result.
+     * Use this to call APIs that assert they must not be called from the EDT.
+     */
+    private static <T> T computeOffEdt(Supplier<T> supplier) {
+        Future<T> future = ApplicationManager.getApplication().executeOnPooledThread(supplier::get);
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation.
+ * Copyright (c) 2020, 2026 IBM Corporation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -220,9 +220,11 @@ public abstract class LibertyGeneralAction extends AnAction {
             return future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
+            throw new ProcessCanceledException(e);
         } catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+            throw new RuntimeException(cause != null ? cause : e);
         }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -214,6 +214,8 @@ public abstract class LibertyGeneralAction extends AnAction {
     /**
      * Runs the given supplier on a pooled thread and blocks for the result.
      * Use this to call APIs that assert they must not be called from the EDT.
+     *
+     * Method assisted by IBM Bob
      */
     private static <T> T computeOffEdt(Supplier<T> supplier) {
         Future<T> future = ApplicationManager.getApplication().executeOnPooledThread(supplier::get);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.LibertyModule;


### PR DESCRIPTION
Temporary workaround for #1666 

`LibertyGeneralAction.getTerminalWidgetWithFocus()` called `widget.hasRunningCommands()` directly on the EDT, which is the thread all IntelliJ actions run on.

Only `hasRunningCommands()` is moved off the EDT - everything else (terminal widget creation via `createShellWidget`, error notifications) stays on the EDT where those APIs require it.

A private `computeOffEdt(Supplier<T>)` helper is added to `LibertyGeneralAction` that submits the call to a pooled thread and blocks for the result.

**Files changed**
`src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java`
- Added `computeOffEdt(Supplier<T>)` helper
- Replaced direct `widget.hasRunningCommands()` call with `computeOffEdt(widget::hasRunningCommands)`

Tested with different intelliJ versions and no EDT exception observed.