### PR TITLE
Suppress deprecated `setupDependencies` task and warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,11 @@ dependencies {
         testFramework TestFrameworkType.Plugin.Maven.INSTANCE
     }
 }
+
+// The setupDependencies task is a deprecated stub from the IntelliJ Platform Gradle Plugin v1 that
+// IntelliJ IDEA may still invoke via its "After Sync" trigger. Disabling it suppresses the warning.
+tasks.named('setupDependencies').configure { enabled = false }
+
 task copyDeps(type: Copy) {
     from configurations.lsp
     into new File(buildDir, 'server/server')


### PR DESCRIPTION
Fixes #1198

Disables the deprecated `setupDependencies` task that was carried over from IntelliJ Platform Gradle Plugin v1. IntelliJ IDEA may still invoke this task automatically via its "After Sync" trigger, which produces a warning. By explicitly disabling the task stub, the spurious warning is suppressed without affecting any actual build behavior.

See comment here - https://github.com/OpenLiberty/liberty-tools-intellij/issues/1198#issuecomment-5201818217