### PR TITLE
Disable all jobs from running on forks.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,8 @@ on:
   push:
     # Restricted to main to avoid triggering workflows on forks.
     branches: [ main ]
+  # Runs only when the 'run-ci' label is applied to the PR, preventing CI from triggering on every push.
+  # To re-trigger after new commits, remove and re-add the label.
   pull_request:
     types: [ labeled ]
     branches: [ main ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,10 +48,13 @@ on:
     # Restricted to main to avoid triggering workflows on forks.
     branches: [ main ]
   pull_request:
+    types: [ labeled ]
     branches: [ main ]
 
 jobs:
   fetch_merge_commit_sha_from_lsp4ij_PR:
+    # Only run when the 'run-ci' label is applied to the PR; ignored for push and workflow_call/workflow_dispatch triggers.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'run-ci'
     runs-on: ubuntu-latest
     outputs:
       pr_details: ${{ steps.extract.outputs.pr_details }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,8 @@ on:
         required: false
         default: main
   push:
-    branches: '**'
+    # Restricted to main to avoid triggering workflows on forks.
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/pr-slack-notification.yaml
+++ b/.github/workflows/pr-slack-notification.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   fetch_all_pull_requests_and_notify_using_condition_and_cron:
+    # Skip this job when running on forked repositories
+    if: github.repository == 'OpenLiberty/liberty-tools-intellij'
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
Fixes #1697 

- This PR disable all jobs from running on forks. Now it only runs on PRs
- Skip this pr-slack-notification.yaml job running on forked repositories
- The trigger is restricted to 'types: [labeled]' so the workflow only starts when a label is explicitly applied , not on every push. When the PR is ready, apply the 'run-ci' label from the PR sidebar. This fires the 'pull_request: labeled' event and starts the build.

How it works:
1. Open a PR and push all your commits without CI running automatically.
2. When the PR is ready, apply the 'run-ci' label from the PR sidebar. This fires the 'pull_request: labeled' event and starts the build.
3. To re-trigger after further commits, remove and re-add the 'run-ci' label. GitHub only fires the event on the label transition (unlabeled → labeled), so the label must be toggled — not just left in place.
