### PR TITLE
Sync Fixes #691 Diagnostics for Lifecycle callback interceptor methods declared in an interceptor class or superclass of an interceptor class must have one of the signatures void (InvocationContext) or Object (InvocationContext).

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/Constants.java
@@ -60,4 +60,13 @@ public class Constants {
 
     public static final String PRIORITY_FQ_NAME = "jakarta.annotation.Priority";
 
+    /* Diagnostic code for invalid lifecycle callback interceptor method signature */
+    public static final String DIAGNOSTIC_CODE_INVALID_LIFECYCLE_CALLBACK_SIGNATURE = "InvalidLifecycleCallbackInterceptorMethodSignature";
+
+    /* Fully qualified name of java.lang.Object */
+    public static final String JAVA_LANG_OBJECT = "java.lang.Object";
+
+    /* Fully qualified name of void (as used by PsiType) */
+    public static final String VOID_TYPE = "void";
+
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/interceptor/InterceptorDiagnosticsParticipant.java
@@ -100,6 +100,8 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 						addInvalidModifierDiagnostic(method, unit, diagnostics, interceptorTypeMethodAnnotations,
 								messageKey, DIAGNOSTIC_CODE_INTERCEPTOR_STATIC, severity);
 					}
+					// Validate lifecycle callback method signatures
+					validateLifecycleCallbackMethodSignature(type, method, unit, diagnostics);
 				}
 				// Check for duplicate interceptor method annotations
 				validateDuplicateInterceptorMethods(methodsByAnnotationType, unit, diagnostics);
@@ -342,6 +344,49 @@ public class InterceptorDiagnosticsParticipant extends AbstractDiagnosticsCollec
 			String msg = Messages.getMessage("InvalidInterceptorMissingInterceptorBinding");
 			Diagnostic diagnostic = new Diagnostic(range, msg);
 			completeDiagnostic(diagnostic, DIAGNOSTIC_CODE_MISSING_INTERCEPTOR_BINDING, DiagnosticSeverity.Warning);
+			diagnostics.add(diagnostic);
+		}
+	}
+
+	/**
+	 * Validates that a lifecycle callback interceptor method has the required signature.
+	 * According to Jakarta Interceptors specification, lifecycle callback interceptor methods
+	 * declared in an interceptor class or superclass must have one of the signatures:
+	 * <ul>
+	 * <li>{@code void <METHOD>(InvocationContext)}</li>
+	 * <li>{@code Object <METHOD>(InvocationContext)}</li>
+	 * </ul>
+	 *
+	 * @param type        the declaring class
+	 * @param method      the method to validate
+	 * @param unit        the compilation unit
+	 * @param diagnostics the list to add diagnostics to
+	 */
+	private void validateLifecycleCallbackMethodSignature(PsiClass type, PsiMethod method,
+														   PsiJavaFile unit, List<Diagnostic> diagnostics) {
+		// Only validate lifecycle callback annotations (@PreDestroy, @PostConstruct, @AroundConstruct)
+		List<String> lifecycleAnnotations = containsAnyMatchingAnnotations(type, method, LIFECYCLE_CALLBACK_INTERCEPTOR_METHODS);
+		if (lifecycleAnnotations.isEmpty()) {
+			return;
+		}
+
+		boolean validSignature = false;
+		PsiParameter[] params = method.getParameterList().getParameters();
+		if (params.length == 1) {
+			String paramType = params[0].getType().getCanonicalText();
+			if (JAKARTA_INTERCEPTOR_INVOCATION_CONTEXT.equals(paramType)) {
+				PsiType returnType = method.getReturnType();
+				if (returnType != null) {
+					String returnTypeName = returnType.getCanonicalText();
+					validSignature = VOID_TYPE.equals(returnTypeName) || JAVA_LANG_OBJECT.equals(returnTypeName);
+				}
+			}
+		}
+
+		if (!validSignature) {
+			Range range = PositionUtils.toNameRange(method);
+			Diagnostic diagnostic = new Diagnostic(range, Messages.getMessage("InvalidLifecycleCallbackInterceptorMethodSignature"));
+			completeDiagnostic(diagnostic, DIAGNOSTIC_CODE_INVALID_LIFECYCLE_CALLBACK_SIGNATURE, DiagnosticSeverity.Error);
 			diagnostics.add(diagnostic);
 		}
 	}

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -298,6 +298,7 @@ InvalidInterceptorMethodAnnotationStaticMethod = {0} interceptor method must not
 InterceptorNegativePriority = Interceptor priority values must not be negative. Negative values are reserved for future use by the specification.
 InvalidMultipleInterceptorMethodsOfSameType = Only one method with {0} annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.
 InvalidInterceptorMissingInterceptorBinding = An interceptor declared using @Interceptor must specify at least one interceptor binding annotation.
+InvalidLifecycleCallbackInterceptorMethodSignature = Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).
 
 # EjbDiagnosticsCollector
 SessionBeanNoArgConstructor = Session beans must have a public no-arg constructor.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/interceptor/JakartaInterceptorTest.java
@@ -1538,4 +1538,158 @@ public class JakartaInterceptorTest extends BaseJakartaTest {
         // Assert NO diagnostics for valid interceptor with binding
         JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
     }
+    @Test
+    public void testInvalidLifecycleCallbackMethodSignatures() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        String sig = "Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).";
+        String dup_ac = "Only one method with @AroundConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+        String dup_pc = "Only one method with @PostConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+        String dup_pd = "Only one method with @PreDestroy annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+        String proceed = "Interceptor methods must always call the InvocationContext.proceed method.";
+        String SIG = "InvalidLifecycleCallbackInterceptorMethodSignature";
+        String DUP = "InvalidMultipleInterceptorMethodsOfSameType";
+        String PRO = "InvalidInterceptorMethodsProceedMissing";
+
+        // Engine emits diagnostics in reverse source order (highest line first),
+        // with sig+dup+proceed interleaved per method, then proceed diagnostics appended.
+        // Exact actual order from engine output:
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils,
+                // line 86 — aroundConstructMultipleParams (4th @AroundConstruct — dup)
+                JakartaForJavaAssert.d(86, 16, 45, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(86, 16, 45, dup_ac,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct"))),
+                // line 80 — postConstructMultipleParams (4th @PostConstruct — dup)
+                JakartaForJavaAssert.d(80, 16, 43, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(80, 16, 43, dup_pc,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct"))),
+                // line 74 — preDestroyMultipleParams (4th @PreDestroy — dup)
+                JakartaForJavaAssert.d(74, 16, 40, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(74, 16, 40, dup_pd,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy"))),
+                // line 66 — aroundConstructInvalidReturnType (3rd @AroundConstruct — dup)
+                JakartaForJavaAssert.d(66, 18, 50, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(66, 18, 50, dup_ac,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct"))),
+                // line 60 — aroundConstructObjectWrongParam (2nd @AroundConstruct — dup + proceed)
+                JakartaForJavaAssert.d(60, 18, 49, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(60, 18, 49, dup_ac,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.interceptor.AroundConstruct"))),
+                JakartaForJavaAssert.d(60, 18, 49, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO),
+                // line 56 — aroundConstructVoidWrongParam (1st @AroundConstruct — proceed)
+                JakartaForJavaAssert.d(56, 16, 45, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(56, 16, 45, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO),
+                // line 48 — postConstructInvalidReturnType (3rd @PostConstruct — dup)
+                JakartaForJavaAssert.d(48, 18, 48, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(48, 18, 48, dup_pc,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct"))),
+                // line 42 — postConstructObjectWrongParam (2nd @PostConstruct — dup + proceed)
+                JakartaForJavaAssert.d(42, 18, 47, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(42, 18, 47, dup_pc,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PostConstruct"))),
+                JakartaForJavaAssert.d(42, 18, 47, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO),
+                // line 38 — postConstructVoidWrongParam (1st @PostConstruct — proceed)
+                JakartaForJavaAssert.d(38, 16, 43, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(38, 16, 43, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO),
+                // line 30 — preDestroyInvalidReturnType (3rd @PreDestroy — dup)
+                JakartaForJavaAssert.d(30, 18, 45, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(30, 18, 45, dup_pd,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy"))),
+                // line 24 — preDestroyObjectWrongParam (2nd @PreDestroy — dup + proceed)
+                JakartaForJavaAssert.d(24, 18, 44, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(24, 18, 44, dup_pd,DiagnosticSeverity.Error, "jakarta-interceptor", DUP,
+                        new com.google.gson.Gson().toJsonTree(Arrays.asList("jakarta.annotation.PreDestroy"))),
+                JakartaForJavaAssert.d(24, 18, 44, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO),
+                // line 20 — preDestroyVoidWrongParam (1st @PreDestroy — proceed)
+                JakartaForJavaAssert.d(20, 16, 40, sig,   DiagnosticSeverity.Error, "jakarta-interceptor", SIG),
+                JakartaForJavaAssert.d(20, 16, 40, proceed,DiagnosticSeverity.Error, "jakarta-interceptor", PRO));
+    }
+
+    @Test
+    public void testValidLifecycleCallbackMethodSignatures() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // void/Object + InvocationContext on all three lifecycle annotations — no diagnostic expected
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testNonLifecycleAnnotationsDoNotTriggerSignatureDiagnostic() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @AroundInvoke and @AroundTimeout must NOT trigger InvalidLifecycleCallbackInterceptorMethodSignature
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testSuperClassWithInvalidLifecycleCallbackMethodSignatures() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        String signatureMsg = "Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).";
+        String proceedMsg = "Interceptor methods must always call the InvocationContext.proceed method.";
+
+        // InterceptorSuperClassBase has @AroundConstruct so it is interceptor-referenced;
+        // the lifecycle signature check fires directly on its own methods.
+        // Engine order: line 28 (AroundConstruct), line 22 (PostConstruct), line 18 sig + proceed (PreDestroy)
+        Diagnostic aroundConstructInvalidReturn = JakartaForJavaAssert.d(28, 18, 46, signatureMsg,
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic postConstructInvalidReturn = JakartaForJavaAssert.d(22, 18, 44, signatureMsg,
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyWrongParamSig = JakartaForJavaAssert.d(18, 16, 36, signatureMsg,
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyWrongParamProceed = JakartaForJavaAssert.d(18, 16, 36, proceedMsg,
+                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils,
+                aroundConstructInvalidReturn, postConstructInvalidReturn,
+                preDestroyWrongParamSig, preDestroyWrongParamProceed);
+    }
+
+    @Test
+    public void testSuperClassWithValidLifecycleCallbackMethodSignatures() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // All lifecycle callback methods in InterceptorSuperClassValidBase have valid signatures
+        JakartaForJavaAssert.assertJavaDiagnostics(diagnosticsParams, utils);
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java
@@ -1,0 +1,45 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Superclass of an interceptor class with invalid lifecycle callback method
+ * signatures. Because it declares @AroundConstruct it is interceptor-referenced,
+ * so the lifecycle callback signature check fires directly on its methods.
+ */
+class InterceptorSuperClassBase {
+
+    // Invalid: wrong param type — @PreDestroy
+    @PreDestroy
+    public void preDestroyWrongParam(String name) throws Exception { }
+
+    // Invalid: wrong return type — @PostConstruct
+    @PostConstruct
+    public String postConstructInvalidReturn(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // Invalid: wrong return type — @AroundConstruct
+    @AroundConstruct
+    public String aroundConstructInvalidReturn(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+}
+
+/**
+ * Interceptor subclass — extends InterceptorSuperClassBase.
+ */
+@Monitored
+@Interceptor
+public class InterceptorSubClassWithInvalidSuperClass extends InterceptorSuperClassBase {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java
@@ -1,0 +1,46 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Superclass of an interceptor class with valid lifecycle callback method
+ * signatures — no InvalidLifecycleCallbackInterceptorMethodSignature diagnostic
+ * must fire when this file is opened.
+ */
+class InterceptorSuperClassValidBase {
+
+    // Makes this superclass interceptor-referenced
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    // Valid: void + InvocationContext — @PreDestroy
+    @PreDestroy
+    public void preDestroyValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+
+    // Valid: Object + InvocationContext — @PostConstruct
+    @PostConstruct
+    public Object postConstructValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+
+/**
+ * Interceptor subclass — extends InterceptorSuperClassValidBase.
+ */
+@Monitored
+@Interceptor
+public class InterceptorSubClassWithValidSuperClass extends InterceptorSuperClassValidBase {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java
@@ -1,0 +1,91 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource for lifecycle callback interceptor method signature validation.
+ * Valid signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).
+ */
+@Monitored
+@Interceptor
+public class InvalidLifecycleCallbackMethodSignature {
+
+    // ── @PreDestroy ──────────────────────────────────────────────────────────
+
+    // Invalid 1: void return + wrong parameter type (String)
+    @PreDestroy
+    public void preDestroyVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 2: Object return + wrong parameter type (String)
+    @PreDestroy
+    public Object preDestroyObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 3: String return + InvocationContext parameter
+    @PreDestroy
+    public String preDestroyInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── @PostConstruct ───────────────────────────────────────────────────────
+
+    // Invalid 4: void return + wrong parameter type (String)
+    @PostConstruct
+    public void postConstructVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 5: Object return + wrong parameter type (String)
+    @PostConstruct
+    public Object postConstructObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 6: String return + InvocationContext parameter
+    @PostConstruct
+    public String postConstructInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── @AroundConstruct ─────────────────────────────────────────────────────
+
+    // Invalid 7: void return + wrong parameter type (String)
+    @AroundConstruct
+    public void aroundConstructVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 8: Object return + wrong parameter type (String)
+    @AroundConstruct
+    public Object aroundConstructObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 9: String return + InvocationContext parameter
+    @AroundConstruct
+    public String aroundConstructInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── Multiple parameters (invalid: spec requires exactly one InvocationContext) ──
+
+    // Invalid 10: two parameters — @PreDestroy
+    @PreDestroy
+    public void preDestroyMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+    // Invalid 11: two parameters — @PostConstruct
+    @PostConstruct
+    public void postConstructMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+    // Invalid 12: two parameters — @AroundConstruct
+    @AroundConstruct
+    public void aroundConstructMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java
@@ -1,0 +1,28 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.AroundTimeout;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource: @AroundInvoke and @AroundTimeout with non-void/non-Object return types
+ * must NOT trigger InvalidLifecycleCallbackInterceptorMethodSignature — they are not
+ * lifecycle callbacks.
+ */
+@Monitored
+@Interceptor
+public class NonLifecycleInterceptorAnnotations {
+
+    // @AroundInvoke with String return — NOT a lifecycle callback, no signature diagnostic
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    // @AroundTimeout with Object return — NOT a lifecycle callback, no signature diagnostic
+    @AroundTimeout
+    public Object aroundTimeout(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java
@@ -1,0 +1,35 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource: lifecycle callback interceptor methods with valid signatures.
+ * All three lifecycle annotations use void <METHOD>(InvocationContext) or
+ * Object <METHOD>(InvocationContext) — no diagnostic must fire.
+ */
+@Monitored
+@Interceptor
+public class ValidLifecycleCallbackMethodSignature {
+
+    // Valid: void return + InvocationContext — @PreDestroy
+    @PreDestroy
+    public void preDestroyVoidValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+
+    // Valid: Object return + InvocationContext — @PostConstruct
+    @PostConstruct
+    public Object postConstructObjectValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    // Valid: void return + InvocationContext — @AroundConstruct
+    @AroundConstruct
+    public void aroundConstructVoidValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+}


### PR DESCRIPTION
lsp4jakarta issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/691
lsp4jakarta PR: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/957