### PR TITLE
Implements Jakarta Persistence 3.0 §2.9 bidirectional relationship rules

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
@@ -13,21 +13,14 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.tree.IElementType;
 
 import java.beans.Introspector;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -268,61 +261,4 @@ public class DiagnosticsUtils {
         return null;
     }
 
-    /**
-     * Visits every source {@link PsiClass} in the module that owns {@code context}
-     * and passes each one to {@code visitor}.
-     *
-     * <p>Performs a direct filesystem traversal of the module's non-test source roots
-     * (via {@link ModuleRootManager}) rather than relying on IntelliJ's annotation
-     * index, so it is safe to call during tests before the index is fully built.
-     *
-     * <p>Example — count {@code @NamedEntityGraph} names module-wide:
-     * <pre>{@code
-     * Map<String, Integer> counts = new HashMap<>();
-     * DiagnosticsUtils.scanSourceClasses(anyClassInModule, psiClass -> {
-     *     PsiAnnotation ann = psiClass.getAnnotation(NAMED_ENTITY_GRAPH);
-     *     if (ann != null) {
-     *         String name = AnnotationUtils.getAnnotationMemberValue(ann, "name");
-     *         if (name != null) counts.merge(name, 1, Integer::sum);
-     *     }
-     * });
-     * }</pre>
-     *
-     * @param context any {@link PsiClass} from the module (provides module and project)
-     * @param visitor called once for every source class found
-     */
-    public static void scanSourceClasses(PsiClass context, Consumer<PsiClass> visitor) {
-        Module module = ModuleUtilCore.findModuleForPsiElement(context);
-        if (module == null) {
-            return;
-        }
-        PsiManager psiManager = PsiManager.getInstance(context.getProject());
-        for (VirtualFile sourceRoot : ModuleRootManager.getInstance(module).getSourceRoots(false)) {
-            visitClasses(sourceRoot, psiManager, visitor);
-        }
-    }
-
-    /**
-     * Recursively visits all {@code .java} files under {@code directory} and
-     * passes every {@link PsiClass} found to {@code visitor}.
-     *
-     * @param directory  the virtual file directory to traverse
-     * @param psiManager the PSI manager used to parse virtual files
-     * @param visitor    called for each class found
-     */
-    private static void visitClasses(VirtualFile directory, PsiManager psiManager,
-                                     Consumer<PsiClass> visitor) {
-        for (VirtualFile child : directory.getChildren()) {
-            if (child.isDirectory()) {
-                visitClasses(child, psiManager, visitor);
-            } else if ("java".equals(child.getExtension())) {
-                PsiFile psiFile = psiManager.findFile(child);
-                if (psiFile instanceof PsiJavaFile javaFile) {
-                    for (PsiClass psiClass : javaFile.getClasses()) {
-                        visitor.accept(psiClass);
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
@@ -13,14 +13,20 @@
 
 package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
 
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.tree.IElementType;
 
 import java.beans.Introspector;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -234,5 +240,90 @@ public class DiagnosticsUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Extracts the simple class name from a {@link PsiType}.
+     *
+     * <p>For a plain class type ({@code Department}) returns the class's simple name.
+     * For a parameterized collection type ({@code List<Employee>}) returns the simple
+     * name of the first type argument.
+     *
+     * @param psiType the PSI type to inspect
+     * @return the simple class name, or {@code null} if it cannot be extracted
+     */
+    public static String getElementTypeSimpleName(PsiType psiType) {
+        if (psiType instanceof PsiClassType classType) {
+            PsiType[] typeArguments = classType.getParameters();
+            if (typeArguments.length > 0 && typeArguments[0] instanceof PsiClassType argType) {
+                // Collection type: return the simple name of the first type argument.
+                PsiClass argClass = argType.resolve();
+                return argClass != null ? argClass.getName() : null;
+            }
+            // Plain class type.
+            PsiClass resolved = classType.resolve();
+            return resolved != null ? resolved.getName() : null;
+        }
+        return null;
+    }
+
+    /**
+     * Builds a map from simple class name to {@link PsiClass} for every class
+     * carrying the given annotation in the module's non-test source roots.
+     *
+     * <p>Performs a direct filesystem traversal of the module's source roots
+     * (via {@link ModuleRootManager}) rather than relying on IntelliJ's
+     * annotation index, which may not yet be fully populated during tests.
+     *
+     * @param context      any {@link PsiClass} from the module (provides module and project)
+     * @param annotationFQ the fully-qualified annotation name to filter by
+     * @return a map from simple class name to {@link PsiClass}; never {@code null}
+     */
+    public static Map<String, PsiClass> findAnnotatedClassesInModule(PsiClass context,
+                                                                     String annotationFQ) {
+        Map<String, PsiClass> result = new HashMap<>();
+        Module module = ModuleUtilCore.findModuleForPsiElement(context);
+        if (module == null) {
+            return result;
+        }
+
+        PsiManager psiManager = PsiManager.getInstance(context.getProject());
+        VirtualFile[] sourceRoots = ModuleRootManager.getInstance(module).getSourceRoots(false);
+
+        for (VirtualFile sourceRoot : sourceRoots) {
+            collectAnnotatedClasses(sourceRoot, psiManager, annotationFQ, result);
+        }
+
+        return result;
+    }
+
+    /**
+     * Recursively visits all {@code .java} files under {@code directory} and
+     * records every class annotated with {@code annotationFQ} into {@code classMap}.
+     *
+     * @param directory    the virtual file directory to traverse
+     * @param psiManager   the PSI manager used to parse virtual files
+     * @param annotationFQ the fully-qualified annotation name to match
+     * @param classMap     the map to populate with simple-name → {@link PsiClass} entries
+     */
+    private static void collectAnnotatedClasses(VirtualFile directory, PsiManager psiManager,
+                                                String annotationFQ,
+                                                Map<String, PsiClass> classMap) {
+        for (VirtualFile child : directory.getChildren()) {
+            if (child.isDirectory()) {
+                collectAnnotatedClasses(child, psiManager, annotationFQ, classMap);
+            } else if ("java".equals(child.getExtension())) {
+                PsiFile psiFile = psiManager.findFile(child);
+                if (psiFile instanceof PsiJavaFile javaFile) {
+                    for (PsiClass psiClass : javaFile.getClasses()) {
+                        if (AbstractDiagnosticsCollector.isMatchedAnnotation(
+                                psiClass.getAnnotations(), annotationFQ)
+                                && psiClass.getName() != null) {
+                            classMap.put(psiClass.getName(), psiClass);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/DiagnosticsUtils.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -268,59 +269,57 @@ public class DiagnosticsUtils {
     }
 
     /**
-     * Builds a map from simple class name to {@link PsiClass} for every class
-     * carrying the given annotation in the module's non-test source roots.
+     * Visits every source {@link PsiClass} in the module that owns {@code context}
+     * and passes each one to {@code visitor}.
      *
-     * <p>Performs a direct filesystem traversal of the module's source roots
-     * (via {@link ModuleRootManager}) rather than relying on IntelliJ's
-     * annotation index, which may not yet be fully populated during tests.
+     * <p>Performs a direct filesystem traversal of the module's non-test source roots
+     * (via {@link ModuleRootManager}) rather than relying on IntelliJ's annotation
+     * index, so it is safe to call during tests before the index is fully built.
      *
-     * @param context      any {@link PsiClass} from the module (provides module and project)
-     * @param annotationFQ the fully-qualified annotation name to filter by
-     * @return a map from simple class name to {@link PsiClass}; never {@code null}
+     * <p>Example — count {@code @NamedEntityGraph} names module-wide:
+     * <pre>{@code
+     * Map<String, Integer> counts = new HashMap<>();
+     * DiagnosticsUtils.scanSourceClasses(anyClassInModule, psiClass -> {
+     *     PsiAnnotation ann = psiClass.getAnnotation(NAMED_ENTITY_GRAPH);
+     *     if (ann != null) {
+     *         String name = AnnotationUtils.getAnnotationMemberValue(ann, "name");
+     *         if (name != null) counts.merge(name, 1, Integer::sum);
+     *     }
+     * });
+     * }</pre>
+     *
+     * @param context any {@link PsiClass} from the module (provides module and project)
+     * @param visitor called once for every source class found
      */
-    public static Map<String, PsiClass> findAnnotatedClassesInModule(PsiClass context,
-                                                                     String annotationFQ) {
-        Map<String, PsiClass> result = new HashMap<>();
+    public static void scanSourceClasses(PsiClass context, Consumer<PsiClass> visitor) {
         Module module = ModuleUtilCore.findModuleForPsiElement(context);
         if (module == null) {
-            return result;
+            return;
         }
-
         PsiManager psiManager = PsiManager.getInstance(context.getProject());
-        VirtualFile[] sourceRoots = ModuleRootManager.getInstance(module).getSourceRoots(false);
-
-        for (VirtualFile sourceRoot : sourceRoots) {
-            collectAnnotatedClasses(sourceRoot, psiManager, annotationFQ, result);
+        for (VirtualFile sourceRoot : ModuleRootManager.getInstance(module).getSourceRoots(false)) {
+            visitClasses(sourceRoot, psiManager, visitor);
         }
-
-        return result;
     }
 
     /**
      * Recursively visits all {@code .java} files under {@code directory} and
-     * records every class annotated with {@code annotationFQ} into {@code classMap}.
+     * passes every {@link PsiClass} found to {@code visitor}.
      *
-     * @param directory    the virtual file directory to traverse
-     * @param psiManager   the PSI manager used to parse virtual files
-     * @param annotationFQ the fully-qualified annotation name to match
-     * @param classMap     the map to populate with simple-name → {@link PsiClass} entries
+     * @param directory  the virtual file directory to traverse
+     * @param psiManager the PSI manager used to parse virtual files
+     * @param visitor    called for each class found
      */
-    private static void collectAnnotatedClasses(VirtualFile directory, PsiManager psiManager,
-                                                String annotationFQ,
-                                                Map<String, PsiClass> classMap) {
+    private static void visitClasses(VirtualFile directory, PsiManager psiManager,
+                                     Consumer<PsiClass> visitor) {
         for (VirtualFile child : directory.getChildren()) {
             if (child.isDirectory()) {
-                collectAnnotatedClasses(child, psiManager, annotationFQ, classMap);
+                visitClasses(child, psiManager, visitor);
             } else if ("java".equals(child.getExtension())) {
                 PsiFile psiFile = psiManager.findFile(child);
                 if (psiFile instanceof PsiJavaFile javaFile) {
                     for (PsiClass psiClass : javaFile.getClasses()) {
-                        if (AbstractDiagnosticsCollector.isMatchedAnnotation(
-                                psiClass.getAnnotations(), annotationFQ)
-                                && psiClass.getName() != null) {
-                            classMap.put(psiClass.getName(), psiClass);
-                        }
+                        visitor.accept(psiClass);
                     }
                 }
             }

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/SourceClassScanner.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/SourceClassScanner.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiManager;
+
+import java.util.function.Consumer;
+
+/**
+ * Utility class for scanning source classes across an IntelliJ module.
+ *
+ * <p>Provides a module-wide class visitor facility used by diagnostic collectors
+ * that require cross-file analysis.
+ */
+public class SourceClassScanner {
+
+    private SourceClassScanner() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Visits every source {@link PsiClass} in the module that owns {@code context}
+     * and passes each one to {@code visitor}.
+     *
+     * <p>Performs a direct filesystem traversal of the module's non-test source roots
+     * (via {@link ModuleRootManager}) rather than relying on IntelliJ's annotation
+     * index, so it is safe to call during tests before the index is fully built.
+     *
+     * @param context any {@link PsiClass} from the module (provides module and project)
+     * @param visitor called once for every source class found
+     */
+    public static void scanSourceClasses(PsiClass context, Consumer<PsiClass> visitor) {
+        Module module = ModuleUtilCore.findModuleForPsiElement(context);
+        if (module == null) {
+            return;
+        }
+        PsiManager psiManager = PsiManager.getInstance(context.getProject());
+        for (VirtualFile sourceRoot : ModuleRootManager.getInstance(module).getSourceRoots(false)) {
+            visitClasses(sourceRoot, psiManager, visitor);
+        }
+    }
+
+    /**
+     * Recursively visits all {@code .java} files under {@code directory} and
+     * passes every {@link PsiClass} found to {@code visitor}.
+     *
+     * @param directory  the virtual file directory to traverse
+     * @param psiManager the PSI manager used to parse virtual files
+     * @param visitor    called for each class found
+     */
+    private static void visitClasses(VirtualFile directory, PsiManager psiManager,
+                                     Consumer<PsiClass> visitor) {
+        for (VirtualFile child : directory.getChildren()) {
+            if (child.isDirectory()) {
+                visitClasses(child, psiManager, visitor);
+            } else if ("java".equals(child.getExtension())) {
+                PsiFile psiFile = psiManager.findFile(child);
+                if (psiFile instanceof PsiJavaFile javaFile) {
+                    for (PsiClass psiClass : javaFile.getClasses()) {
+                        visitor.accept(psiClass);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence;
+
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiType;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.DiagnosticsUtils;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.JDTUtils;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Persistence diagnostic collector that validates bidirectional JPA
+ * relationships across entity classes.
+ *
+ * <p>Two rules are checked using cross-file (module-wide) analysis:
+ * <ol>
+ *   <li>The inverse side of a bidirectional relationship must declare the
+ *       {@code mappedBy} attribute on its {@code @OneToMany}, {@code @OneToOne},
+ *       or {@code @ManyToMany} annotation.</li>
+ *   <li>The inverse side of a relationship must not carry a {@code @JoinTable}
+ *       annotation.</li>
+ * </ol>
+ *
+ * <p>Cross-file analysis is performed via
+ * {@link DiagnosticsUtils#findAnnotatedClassesInModule}, which traverses
+ * the module's source roots directly and is always consistent with the
+ * current workspace state.
+ *
+ * <p>Specification reference:
+ * https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0
+ */
+public class PersistenceBidirectionalDiagnosticsCollector extends AbstractDiagnosticsCollector {
+
+    public PersistenceBidirectionalDiagnosticsCollector() {
+        super();
+    }
+
+    @Override
+    protected String getDiagnosticSource() {
+        return PersistenceConstants.DIAGNOSTIC_SOURCE;
+    }
+
+    @Override
+    public void collectDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics) {
+        if (unit == null) {
+            return;
+        }
+
+        for (PsiClass type : unit.getClasses()) {
+            // Only process @Entity-annotated classes.
+            if (!isMatchedAnnotation(type.getAnnotations(), PersistenceConstants.ENTITY)) {
+                continue;
+            }
+
+            // Build a module-wide map of all @Entity types keyed by simple name.
+            Map<String, PsiClass> entityTypeMap = DiagnosticsUtils.findAnnotatedClassesInModule(
+                    type, PersistenceConstants.ENTITY);
+
+            for (PsiField field : type.getFields()) {
+                validateRelationshipMember(field, field.getType(), type, unit,
+                        entityTypeMap, diagnostics);
+            }
+
+            for (PsiMethod method : type.getMethods()) {
+                validateRelationshipMember(method, method.getReturnType(), type, unit,
+                        entityTypeMap, diagnostics);
+            }
+        }
+    }
+
+    /**
+     * Validates relationship annotations on a single field or method.
+     *
+     * @param member        the PSI element (field or method) being validated
+     * @param memberType    the field type or method return type
+     * @param declaringType the entity class that owns the member
+     * @param unit          the compilation unit of the declaring class
+     * @param entityTypeMap module-wide map from simple class name to {@link PsiClass}
+     * @param diagnostics   the list to append new diagnostics to
+     */
+    private void validateRelationshipMember(PsiElement member, PsiType memberType,
+                                            PsiClass declaringType,
+                                            PsiJavaFile unit,
+                                            Map<String, PsiClass> entityTypeMap,
+                                            List<Diagnostic> diagnostics) {
+        for (String relAnnotationFQ : PersistenceConstants.INVERSE_CAPABLE_RELATIONSHIP_ANNOTATIONS) {
+            PsiAnnotation relAnnotation = AnnotationUtils.getAnnotation(member, relAnnotationFQ);
+            if (relAnnotation == null) {
+                continue;
+            }
+
+            String relSimpleName = JDTUtils.getSimpleName(relAnnotationFQ);
+            String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
+                    relAnnotation, PersistenceConstants.MAPPED_BY);
+            boolean hasMappedBy = mappedByValue != null && !mappedByValue.isEmpty();
+
+            if (hasMappedBy) {
+                // Explicitly the inverse side — @JoinTable is forbidden here.
+                if (AnnotationUtils.getAnnotation(member, PersistenceConstants.JOIN_TABLE) != null) {
+                    diagnostics.add(createDiagnostic(member, unit,
+                            Messages.getMessage("JoinTableOnInverseSide"),
+                            PersistenceConstants.DIAGNOSTIC_CODE_JOIN_TABLE_ON_INVERSE, null,
+                            DiagnosticSeverity.Error));
+                }
+            } else {
+                // No mappedBy — flag only when the target entity back-references this class,
+                // proving the relationship is bidirectional.
+                String targetSimpleName = DiagnosticsUtils.getElementTypeSimpleName(memberType);
+                PsiClass targetType = targetSimpleName != null
+                        ? entityTypeMap.get(targetSimpleName) : null;
+                if (targetType != null && isInverseSideOf(targetType, declaringType, relAnnotationFQ)) {
+                    diagnostics.add(createDiagnostic(member, unit,
+                            Messages.getMessage("InverseSideMissingMappedBy", relSimpleName),
+                            PersistenceConstants.DIAGNOSTIC_CODE_INVERSE_MISSING_MAPPED_BY, null,
+                            DiagnosticSeverity.Error));
+                }
+            }
+            // Only one relationship annotation per member expected — stop after first match.
+            break;
+        }
+    }
+
+    /**
+     * Checks whether {@code targetType} has a back-reference field or method
+     * pointing at {@code declaringType} via the mirrored relationship annotation,
+     * confirming a bidirectional relationship.
+     *
+     * @param targetType      the other side of the potential relationship
+     * @param declaringType   the entity class whose member is being validated
+     * @param relAnnotationFQ the fully-qualified relationship annotation on the declaring side
+     * @return {@code true} if a back-reference exists
+     */
+    private boolean isInverseSideOf(PsiClass targetType, PsiClass declaringType,
+                                    String relAnnotationFQ) {
+        // Mirrored annotations:
+        //   @OneToMany  ↔  @ManyToOne
+        //   @ManyToMany ↔  @ManyToMany  (self-mirroring)
+        //   @OneToOne   ↔  @OneToOne    (self-mirroring)
+        //
+        // For self-mirroring annotations (@ManyToMany, @OneToOne), a bare match of the
+        // annotation on the other side is not sufficient — the other side must also carry
+        // a non-empty mappedBy, which is the explicit marker that it is the inverse side.
+        // Without this extra check both sides would flag each other as the inverse.
+        String mirroredAnnotationFQ = getMirroredAnnotation(relAnnotationFQ);
+        boolean requiresMappedByOnTarget = mirroredAnnotationFQ.equals(relAnnotationFQ);
+        String declaringSimpleName = declaringType.getName();
+
+        for (PsiField field : targetType.getFields()) {
+            PsiAnnotation annotation = AnnotationUtils.getAnnotation(field, mirroredAnnotationFQ);
+            if (annotation != null) {
+                if (requiresMappedByOnTarget) {
+                    String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
+                            annotation, PersistenceConstants.MAPPED_BY);
+                    if (mappedByValue == null || mappedByValue.isEmpty()) {
+                        continue;
+                    }
+                }
+                if (declaringSimpleName.equals(
+                        DiagnosticsUtils.getElementTypeSimpleName(field.getType()))) {
+                    return true;
+                }
+            }
+        }
+
+        for (PsiMethod method : targetType.getMethods()) {
+            PsiAnnotation annotation = AnnotationUtils.getAnnotation(method, mirroredAnnotationFQ);
+            if (annotation != null) {
+                if (requiresMappedByOnTarget) {
+                    String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
+                            annotation, PersistenceConstants.MAPPED_BY);
+                    if (mappedByValue == null || mappedByValue.isEmpty()) {
+                        continue;
+                    }
+                }
+                PsiType returnType = method.getReturnType();
+                if (returnType != null
+                        && declaringSimpleName.equals(
+                                DiagnosticsUtils.getElementTypeSimpleName(returnType))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the mirrored relationship annotation FQ name.
+     * {@code @OneToMany} ↔ {@code @ManyToOne}; others are self-mirroring.
+     *
+     * @param relAnnotationFQ the fully-qualified annotation on the declaring side
+     * @return the mirrored fully-qualified annotation name
+     */
+    private String getMirroredAnnotation(String relAnnotationFQ) {
+        if (PersistenceConstants.ONE_TO_MANY.equals(relAnnotationFQ)) {
+            return PersistenceConstants.MANY_TO_ONE;
+        }
+        if (PersistenceConstants.MANY_TO_MANY.equals(relAnnotationFQ)) {
+            return PersistenceConstants.MANY_TO_MANY;
+        }
+        // ONE_TO_ONE is self-mirroring.
+        return relAnnotationFQ;
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
@@ -27,6 +27,7 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +45,7 @@ import java.util.Map;
  * </ol>
  *
  * <p>Cross-file analysis is performed via
- * {@link DiagnosticsUtils#findAnnotatedClassesInModule}, which traverses
+ * {@link DiagnosticsUtils#scanSourceClasses}, which traverses
  * the module's source roots directly and is always consistent with the
  * current workspace state.
  *
@@ -74,9 +75,15 @@ public class PersistenceBidirectionalDiagnosticsCollector extends AbstractDiagno
                 continue;
             }
 
-            // Build a module-wide map of all @Entity types keyed by simple name.
-            Map<String, PsiClass> entityTypeMap = DiagnosticsUtils.findAnnotatedClassesInModule(
-                    type, PersistenceConstants.ENTITY);
+            // Build a module-wide map of all @Entity types keyed by simple name using
+            // the generic scanner — populated once per entity class in the file.
+            Map<String, PsiClass> entityTypeMap = new HashMap<>();
+            DiagnosticsUtils.scanSourceClasses(type, scannedClass -> {
+                if (isMatchedAnnotation(scannedClass.getAnnotations(), PersistenceConstants.ENTITY)
+                        && scannedClass.getName() != null) {
+                    entityTypeMap.put(scannedClass.getName(), scannedClass);
+                }
+            });
 
             for (PsiField field : type.getFields()) {
                 validateRelationshipMember(field, field.getType(), type, unit,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
@@ -27,7 +27,6 @@ import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,10 +43,10 @@ import java.util.Map;
  *       annotation.</li>
  * </ol>
  *
- * <p>Cross-file analysis is performed via
- * {@link DiagnosticsUtils#scanSourceClasses}, which traverses
- * the module's source roots directly and is always consistent with the
- * current workspace state.
+ * <p>Cross-file analysis is performed via {@link PersistenceUtils#findAnnotatedEntityClasses},
+ * which uses {@link io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.SourceClassScanner} to
+ * traverse the module's source roots directly and is always consistent with the current
+ * workspace state.
  *
  * <p>Specification reference:
  * https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0
@@ -75,15 +74,8 @@ public class PersistenceBidirectionalDiagnosticsCollector extends AbstractDiagno
                 continue;
             }
 
-            // Build a module-wide map of all @Entity types keyed by simple name using
-            // the generic scanner — populated once per entity class in the file.
-            Map<String, PsiClass> entityTypeMap = new HashMap<>();
-            DiagnosticsUtils.scanSourceClasses(type, scannedClass -> {
-                if (isMatchedAnnotation(scannedClass.getAnnotations(), PersistenceConstants.ENTITY)
-                        && scannedClass.getName() != null) {
-                    entityTypeMap.put(scannedClass.getName(), scannedClass);
-                }
-            });
+            // Build a module-wide map of all @Entity types keyed by simple name.
+            Map<String, PsiClass> entityTypeMap = PersistenceUtils.findAnnotatedEntityClasses(type);
 
             for (PsiField field : type.getFields()) {
                 validateRelationshipMember(field, field.getType(), type, unit,

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceBidirectionalDiagnosticsCollector.java
@@ -117,7 +117,7 @@ public class PersistenceBidirectionalDiagnosticsCollector extends AbstractDiagno
 
             if (hasMappedBy) {
                 // Explicitly the inverse side — @JoinTable is forbidden here.
-                if (AnnotationUtils.getAnnotation(member, PersistenceConstants.JOIN_TABLE) != null) {
+                if (AnnotationUtils.hasAnnotation(member, PersistenceConstants.JOIN_TABLE)) {
                     diagnostics.add(createDiagnostic(member, unit,
                             Messages.getMessage("JoinTableOnInverseSide"),
                             PersistenceConstants.DIAGNOSTIC_CODE_JOIN_TABLE_ON_INVERSE, null,
@@ -167,42 +167,54 @@ public class PersistenceBidirectionalDiagnosticsCollector extends AbstractDiagno
         String declaringSimpleName = declaringType.getName();
 
         for (PsiField field : targetType.getFields()) {
-            PsiAnnotation annotation = AnnotationUtils.getAnnotation(field, mirroredAnnotationFQ);
-            if (annotation != null) {
-                if (requiresMappedByOnTarget) {
-                    String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
-                            annotation, PersistenceConstants.MAPPED_BY);
-                    if (mappedByValue == null || mappedByValue.isEmpty()) {
-                        continue;
-                    }
-                }
-                if (declaringSimpleName.equals(
-                        DiagnosticsUtils.getElementTypeSimpleName(field.getType()))) {
-                    return true;
-                }
+            if (hasMirroredBackReference(field, field.getType(), mirroredAnnotationFQ,
+                    requiresMappedByOnTarget, declaringSimpleName)) {
+                return true;
             }
         }
 
         for (PsiMethod method : targetType.getMethods()) {
-            PsiAnnotation annotation = AnnotationUtils.getAnnotation(method, mirroredAnnotationFQ);
-            if (annotation != null) {
-                if (requiresMappedByOnTarget) {
-                    String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
-                            annotation, PersistenceConstants.MAPPED_BY);
-                    if (mappedByValue == null || mappedByValue.isEmpty()) {
-                        continue;
-                    }
-                }
-                PsiType returnType = method.getReturnType();
-                if (returnType != null
-                        && declaringSimpleName.equals(
-                                DiagnosticsUtils.getElementTypeSimpleName(returnType))) {
-                    return true;
-                }
+            PsiType returnType = method.getReturnType();
+            if (returnType != null && hasMirroredBackReference(method, returnType,
+                    mirroredAnnotationFQ, requiresMappedByOnTarget, declaringSimpleName)) {
+                return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Returns {@code true} when {@code member} carries the given {@code mirroredAnnotationFQ}
+     * and its declared type matches {@code declaringSimpleName}.
+     *
+     * <p>When {@code requiresMappedByOnTarget} is {@code true} (self-mirroring annotations
+     * such as {@code @OneToOne} and {@code @ManyToMany}), the annotation must also have a
+     * non-empty {@code mappedBy} attribute to confirm the member is explicitly the inverse side.
+     *
+     * @param member                  the field or method to inspect
+     * @param memberType              the field type or method return type
+     * @param mirroredAnnotationFQ    the fully-qualified annotation to look for
+     * @param requiresMappedByOnTarget whether a non-empty {@code mappedBy} is required
+     * @param declaringSimpleName     the simple name of the declaring entity class
+     * @return {@code true} if this member is a matching back-reference
+     */
+    private boolean hasMirroredBackReference(PsiElement member, PsiType memberType,
+                                             String mirroredAnnotationFQ,
+                                             boolean requiresMappedByOnTarget,
+                                             String declaringSimpleName) {
+        PsiAnnotation annotation = AnnotationUtils.getAnnotation(member, mirroredAnnotationFQ);
+        if (annotation == null) {
+            return false;
+        }
+        if (requiresMappedByOnTarget) {
+            String mappedByValue = AnnotationUtils.getAnnotationMemberValue(
+                    annotation, PersistenceConstants.MAPPED_BY);
+            if (mappedByValue == null || mappedByValue.isEmpty()) {
+                return false;
+            }
+        }
+        return declaringSimpleName.equals(DiagnosticsUtils.getElementTypeSimpleName(memberType));
     }
 
     /**

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceConstants.java
@@ -34,6 +34,21 @@ public class PersistenceConstants {
     public static final String VERSION = "jakarta.persistence.Version";
     public static final String TEMPORAL_TYPE = "jakarta.persistence.TemporalType";
 
+    /* Bidirectional relationship annotation constants */
+    public static final String ONE_TO_MANY = "jakarta.persistence.OneToMany";
+    public static final String ONE_TO_ONE = "jakarta.persistence.OneToOne";
+    public static final String MANY_TO_MANY = "jakarta.persistence.ManyToMany";
+    public static final String MANY_TO_ONE = "jakarta.persistence.ManyToOne";
+    public static final String JOIN_TABLE = "jakarta.persistence.JoinTable";
+
+    /** All relationship annotations that support the {@code mappedBy} attribute. */
+    public static final String[] INVERSE_CAPABLE_RELATIONSHIP_ANNOTATIONS = {
+            ONE_TO_MANY, ONE_TO_ONE, MANY_TO_MANY
+    };
+
+    /** Annotation attribute name for the owning-side field reference. */
+    public static final String MAPPED_BY = "mappedBy";
+
     /* Type Constants */
     public static final String MAP_INTERFACE_FQDN = "java.util.Map";
 
@@ -62,6 +77,10 @@ public class PersistenceConstants {
 
     public static final String DIAGNOSTIC_CODE_INHERITANCE_ON_NON_ENTITY = "InheritanceAnnotationOnNonEntityClass";
     public static final String DIAGNOSTIC_CODE_INHERITANCE_ON_NON_ROOT = "InheritanceAnnotationOnNonRootEntity";
+
+    /* Bidirectional relationship diagnostic codes */
+    public static final String DIAGNOSTIC_CODE_INVERSE_MISSING_MAPPED_BY = "InverseSideMissingMappedBy";
+    public static final String DIAGNOSTIC_CODE_JOIN_TABLE_ON_INVERSE = "JoinTableOnInverseSide";
 
     /* MapKey Codes */
     public static final String DIAGNOSTIC_CODE_MAPKEYENUMERATED_NON_MAP = "MapKeyEnumeratedOnNonMapType";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceUtils.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceUtils.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence;
+
+import com.intellij.psi.PsiClass;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.SourceClassScanner;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for Jakarta Persistence diagnostic collectors.
+ *
+ * <p>Provides shared helpers used across persistence diagnostic collectors,
+ * such as module-wide entity class scanning.
+ */
+public class PersistenceUtils {
+
+    private PersistenceUtils() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Scans all source classes in the module that owns {@code context} and returns
+     * a map from simple class name to {@link PsiClass} for every class annotated
+     * with {@code @jakarta.persistence.Entity}.
+     *
+     * @param context any {@link PsiClass} from the module (used to locate it)
+     * @return a map from simple entity class name to its {@link PsiClass}
+     */
+    public static Map<String, PsiClass> findAnnotatedEntityClasses(PsiClass context) {
+        Map<String, PsiClass> entityTypeMap = new HashMap<>();
+        SourceClassScanner.scanSourceClasses(context, scannedClass -> {
+            if (AnnotationUtils.getAnnotation(scannedClass, PersistenceConstants.ENTITY) != null
+                    && scannedClass.getName() != null) {
+                entityTypeMap.put(scannedClass.getName(), scannedClass);
+            }
+        });
+        return entityTypeMap;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,9 @@
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceEntityDiagnosticsCollector"/>
         <javaDiagnosticsParticipant
                 group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceBidirectionalDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.persistence.PersistenceMapKeyDiagnosticsCollector"/>
         <javaDiagnosticsParticipant
                 group="jakarta"

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -223,6 +223,10 @@ MultipleEmbeddedIdAnnotations = An entity must not declare more than one @Embedd
 MixedIdentifierAnnotationsEmbeddedId = @EmbeddedId cannot be combined with @Id in the same entity.
 MixedIdentifierAnnotationsId = @Id cannot be combined with @EmbeddedId in the same entity.
 
+# PersistenceBidirectionalDiagnosticsCollector
+InverseSideMissingMappedBy = The inverse side of a bidirectional @{0} relationship must declare the mappedBy attribute to reference the owning side field.
+JoinTableOnInverseSide = The @JoinTable annotation must not be used on the inverse side of a relationship. Move @JoinTable to the owning side field or remove it.
+
 # PersistenceContextDiagnosticsCollector
 PersistenceContextNotInManagedComponent = @PersistenceContext can only be used in a container-managed component such as a CDI bean, EJB, or Servlet.
 ExtendedPersistenceContextInNonStatefulBean = PersistenceContextType.EXTENDED can only be used in a @Stateful EJB session bean.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/PersistenceBidirectionalTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/PersistenceBidirectionalTest.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.tools.intellij.lsp4jakarta.it.persistence;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+/**
+ * Integration tests for {@code PersistenceBidirectionalDiagnosticsCollector}
+ * — bidirectional JPA relationship validation (issue #726).
+ *
+ * <p>Two rules from Jakarta Persistence 3.0 §2.9 are verified:
+ * <ol>
+ * <li>The inverse side of a bidirectional {@code @OneToMany}, {@code @OneToOne},
+ * or {@code @ManyToMany} relationship must declare {@code mappedBy}.</li>
+ * <li>The inverse side must not carry a {@code @JoinTable} annotation.</li>
+ * </ol>
+ */
+@RunWith(JUnit4.class)
+public class PersistenceBidirectionalTest extends BaseJakartaTest {
+
+    private static final String BIDIRECTIONAL_PKG =
+            "/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/";
+
+    // -------------------------------------------------------------------------
+    // Rule 1 — inverse side missing mappedBy
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testBidirectionalMissingMappedByOneToMany() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalDepartment.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @OneToMany without mappedBy on the inverse side — BidirectionalEmployee has @ManyToOne back-ref.
+        Diagnostic missingMappedByDiagnostic = d(23, 40, 49,
+                "The inverse side of a bidirectional @OneToMany relationship must declare the mappedBy attribute to reference the owning side field.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "InverseSideMissingMappedBy");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, missingMappedByDiagnostic);
+    }
+
+    @Test
+    public void testBidirectionalMissingMappedByOneToOne() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalPerson.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @OneToOne without mappedBy — BidirectionalAddress has a @OneToOne(mappedBy="address") back-ref.
+        Diagnostic missingMappedByDiagnostic = d(21, 33, 40,
+                "The inverse side of a bidirectional @OneToOne relationship must declare the mappedBy attribute to reference the owning side field.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "InverseSideMissingMappedBy");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, missingMappedByDiagnostic);
+    }
+
+    @Test
+    public void testBidirectionalMissingMappedByManyToMany() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalCourse.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @ManyToMany without mappedBy — BidirectionalStudent has a @ManyToMany(mappedBy="students") back-ref.
+        Diagnostic manyToManyMissingMappedByDiagnostic = d(22, 39, 47,
+                "The inverse side of a bidirectional @ManyToMany relationship must declare the mappedBy attribute to reference the owning side field.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "InverseSideMissingMappedBy");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, manyToManyMissingMappedByDiagnostic);
+    }
+
+    // -------------------------------------------------------------------------
+    // Rule 2 — @JoinTable on the inverse side
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testBidirectionalJoinTableOnOneToManyInverse() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalInverseJoinTable.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @OneToMany(mappedBy=...) + @JoinTable on the inverse side — invalid.
+        Diagnostic joinTableOnInverseDiagnostic = d(25, 40, 49,
+                "The @JoinTable annotation must not be used on the inverse side of a relationship. Move @JoinTable to the owning side field or remove it.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "JoinTableOnInverseSide");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, joinTableOnInverseDiagnostic);
+    }
+
+    @Test
+    public void testBidirectionalJoinTableOnManyToManyInverse() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalPost.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @ManyToMany(mappedBy=...) + @JoinTable on the inverse side — invalid.
+        Diagnostic joinTableOnManyToManyInverseDiagnostic = d(24, 35, 39,
+                "The @JoinTable annotation must not be used on the inverse side of a relationship. Move @JoinTable to the owning side field or remove it.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "JoinTableOnInverseSide");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, joinTableOnManyToManyInverseDiagnostic);
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative tests — no diagnostic expected
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testBidirectionalValidOneToManyInverseSide() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalDepartmentValid.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @OneToMany(mappedBy="department") with no @JoinTable — valid inverse side.
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testBidirectionalValidOneToOneInverseSide() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalPersonValid.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @OneToOne(mappedBy="resident") — valid inverse side, no diagnostic expected.
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testBidirectionalUnidirectionalOneToMany() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalOrder.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Unidirectional @OneToMany — BidirectionalOrderItem has no back-reference.
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    @Test
+    public void testBidirectionalUnidirectionalManyToMany() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) + BIDIRECTIONAL_PKG + "BidirectionalProduct.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Unidirectional @ManyToMany — BidirectionalCategory has no back-reference.
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalAddress.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalAddress.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+ * Inverse side of a bidirectional @OneToOne — explicitly declares mappedBy,
+ * making BidirectionalPerson.address the owning-side field.
+ * No diagnostic expected here (mappedBy is correctly set).
+ */
+@Entity
+public class BidirectionalAddress {
+
+    @Id
+    private Long id;
+
+    private String street;
+
+    @OneToOne(mappedBy = "address")
+    private BidirectionalPerson resident;
+
+    public BidirectionalAddress() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalCategory.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalCategory.java
@@ -1,0 +1,21 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Category entity with no back-reference to BidirectionalProduct,
+ * confirming the relationship is unidirectional.
+ * No diagnostic expected.
+ */
+@Entity
+public class BidirectionalCategory {
+
+    @Id
+    private Long id;
+
+    private String label;
+
+    public BidirectionalCategory() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalCourse.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalCourse.java
@@ -1,0 +1,27 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+
+/**
+ * Course entity — the inverse side of a bidirectional @ManyToMany with
+ * BidirectionalStudent. mappedBy is MISSING.
+ * Expected to produce an InverseSideMissingMappedBy diagnostic.
+ */
+@Entity
+public class BidirectionalCourse {
+
+    @Id
+    private Long id;
+
+    private String title;
+
+    @ManyToMany
+    private List<BidirectionalStudent> students;
+
+    public BidirectionalCourse() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalDepartment.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalDepartment.java
@@ -1,0 +1,28 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+/**
+ * Inverse-side entity that is MISSING the mappedBy attribute.
+ * BidirectionalEmployee has a @ManyToOne back-reference to this class,
+ * so this is the inverse side and MUST declare mappedBy.
+ * This file is expected to produce an InverseSideMissingMappedBy diagnostic.
+ */
+@Entity
+public class BidirectionalDepartment {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @OneToMany
+    private List<BidirectionalEmployee> employees;
+
+    public BidirectionalDepartment() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalDepartmentValid.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalDepartmentValid.java
@@ -1,0 +1,26 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+/**
+ * Valid bidirectional @OneToMany inverse side — mappedBy is present and
+ * @JoinTable is not used. No diagnostics are expected.
+ */
+@Entity
+public class BidirectionalDepartmentValid {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "department")
+    private List<BidirectionalEmployee> employees;
+
+    public BidirectionalDepartmentValid() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalEmployee.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalEmployee.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * Owning-side entity used by bidirectional relationship tests.
+ * The @ManyToOne back-reference to BidirectionalDepartment makes the
+ * BidirectionalDepartment.employees field the inverse side of the relationship.
+ */
+@Entity
+public class BidirectionalEmployee {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    private BidirectionalDepartment department;
+
+    public BidirectionalEmployee() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalInverseJoinTable.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalInverseJoinTable.java
@@ -1,0 +1,30 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.OneToMany;
+
+/**
+ * Inverse-side entity that uses @JoinTable on the inverse side — invalid.
+ * The mappedBy attribute is set, confirming this is the inverse side,
+ * but @JoinTable is also present which is not allowed on the inverse side.
+ * This file is expected to produce a JoinTableOnInverseSide diagnostic.
+ */
+@Entity
+public class BidirectionalInverseJoinTable {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "department")
+    @JoinTable(name = "DEPT_EMP")
+    private List<BidirectionalEmployee> employees;
+
+    public BidirectionalInverseJoinTable() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalOrder.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalOrder.java
@@ -1,0 +1,24 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+/**
+ * Unidirectional @OneToMany relationship — no back-reference exists in BidirectionalOrderItem.
+ * This is perfectly valid and must NOT produce any diagnostic.
+ */
+@Entity
+public class BidirectionalOrder {
+
+    @Id
+    private Long id;
+
+    @OneToMany
+    private List<BidirectionalOrderItem> items;
+
+    public BidirectionalOrder() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalOrderItem.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalOrderItem.java
@@ -1,0 +1,20 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Item entity for unidirectional order test — has NO back-reference to
+ * BidirectionalOrder, confirming the relationship is unidirectional.
+ */
+@Entity
+public class BidirectionalOrderItem {
+
+    @Id
+    private Long id;
+
+    private String description;
+
+    public BidirectionalOrderItem() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPerson.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPerson.java
@@ -1,0 +1,26 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+ * Owning side of a bidirectional @OneToOne — mappedBy is MISSING.
+ * BidirectionalAddress has a @OneToOne(mappedBy="address") back-reference to this class,
+ * confirming this is the owning side without mappedBy declared.
+ * Expected to produce an InverseSideMissingMappedBy diagnostic.
+ */
+@Entity
+public class BidirectionalPerson {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @OneToOne
+    private BidirectionalAddress address;
+
+    public BidirectionalPerson() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPersonValid.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPersonValid.java
@@ -1,0 +1,24 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+ * Valid inverse side of a bidirectional @OneToOne — mappedBy is present.
+ * No diagnostic expected.
+ */
+@Entity
+public class BidirectionalPersonValid {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @OneToOne(mappedBy = "resident")
+    private BidirectionalAddress address;
+
+    public BidirectionalPersonValid() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPost.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalPost.java
@@ -1,0 +1,29 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+
+/**
+ * Inverse side of a bidirectional @ManyToMany — has mappedBy but ALSO
+ * has @JoinTable, which is invalid on the inverse side.
+ * Expected to produce a JoinTableOnInverseSide diagnostic.
+ */
+@Entity
+public class BidirectionalPost {
+
+    @Id
+    private Long id;
+
+    private String title;
+
+    @ManyToMany(mappedBy = "posts")
+    @JoinTable(name = "POST_TAG")
+    private List<BidirectionalTag> tags;
+
+    public BidirectionalPost() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalProduct.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalProduct.java
@@ -1,0 +1,27 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+
+/**
+ * Product entity with a unidirectional @ManyToMany relationship.
+ * BidirectionalCategory has no back-reference to Product,
+ * so no diagnostic is expected on either side.
+ */
+@Entity
+public class BidirectionalProduct {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @ManyToMany
+    private List<BidirectionalCategory> categories;
+
+    public BidirectionalProduct() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalStudent.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalStudent.java
@@ -1,0 +1,27 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+
+/**
+ * Student entity in a bidirectional @ManyToMany relationship with BidirectionalCourse.
+ * This is the inverse side — it has mappedBy referencing the owning-side field on Course.
+ * No diagnostic is expected on this file.
+ */
+@Entity
+public class BidirectionalStudent {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @ManyToMany(mappedBy = "students")
+    private List<BidirectionalCourse> courses;
+
+    public BidirectionalStudent() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalTag.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/bidirectional/BidirectionalTag.java
@@ -1,0 +1,26 @@
+package io.openliberty.sample.jakarta.persistence.bidirectional;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+
+/**
+ * Owning side of a bidirectional @ManyToMany with BidirectionalPost.
+ * No mappedBy — this is the owning side, so no diagnostic expected.
+ */
+@Entity
+public class BidirectionalTag {
+
+    @Id
+    private Long id;
+
+    private String label;
+
+    @ManyToMany
+    private List<BidirectionalPost> posts;
+
+    public BidirectionalTag() {
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/726

lsp4jakarta PR :- https://github.com/eclipse-lsp4jakarta/lsp4jakarta/pull/965

Implements Jakarta Persistence 3.0 §2.9 bidirectional relationship rules via a new PersistenceBidirectionalDiagnosticsCollector with cross-file (module-wide) entity scanning using recursive VirtualFile traversal.

Two rules are enforced:
- Rule 1: The inverse side of a bidirectional @OneToMany, @OneToOne, or @ManyToMany relationship must declare the mappedBy attribute.
- Rule 2: The inverse side must not carry a @JoinTable annotation.

The owning side is identified by scanning all @Entity-annotated classes in the module (via DiagnosticsUtils.findAnnotatedClassesInModule) for a mirrored back-reference annotation pointing back to the declaring class. For self-mirroring annotations (@OneToOne, @ManyToMany), the target's back-reference must itself carry a non-empty mappedBy to confirm it is the declared inverse side, preventing both sides from flagging each other.


Screen recording:- 


https://github.com/user-attachments/assets/8622535c-d395-4ee8-8cca-7e58f03bb643

