### PR TITLE
Inconsistent specialization diagnostics added

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/CdiSpecializesDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/CdiSpecializesDiagnosticsCollector.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi;
+
+import com.intellij.psi.*;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.searches.AllClassesSearch;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.AbstractDiagnosticsCollector;
+import io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.Messages;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.ManagedBeanConstants.*;
+
+/**
+ * Detects inconsistent specialization: two or more beans annotated with {@code @Specializes}
+ * sharing the same ultimate base bean (resolved transitively).
+ */
+public class CdiSpecializesDiagnosticsCollector extends AbstractDiagnosticsCollector {
+
+    public CdiSpecializesDiagnosticsCollector() {
+        super();
+    }
+
+    @Override
+    protected String getDiagnosticSource() {
+        return DIAGNOSTIC_SOURCE;
+    }
+
+    @Override
+    public void collectDiagnostics(PsiJavaFile unit, List<Diagnostic> diagnostics) {
+        if (unit == null) {
+            return;
+        }
+
+        // Collect @Specializes types in the current file
+        List<PsiClass> specializersInUnit = new ArrayList<>();
+        for (PsiClass type : unit.getClasses()) {
+            if (isMatchedAnnotation(type.getAnnotations(), SPECIALIZES_FQ_NAME)) {
+                specializersInUnit.add(type);
+            }
+        }
+
+        if (specializersInUnit.isEmpty()) {
+            return;
+        }
+
+        // Build a map of ultimate base FQ name → all @Specializes types in the project.
+        Map<String, List<PsiClass>> specializersByUltimateBase = collectProjectSpecializersByUltimateBase(
+                specializersInUnit.get(0).getProject());
+
+        // Report inconsistent specialization on each conflicting type in this file
+        for (PsiClass type : specializersInUnit) {
+            String ultimateBaseFqName = resolveUltimateBaseFqName(type);
+            if (ultimateBaseFqName == null) {
+                continue;
+            }
+            List<PsiClass> allSpecializersOfBase = specializersByUltimateBase.get(ultimateBaseFqName);
+            // Inconsistent specialization: more than one bean ultimately specializes the same base.
+            if (allSpecializersOfBase != null && allSpecializersOfBase.size() > 1) {
+                diagnostics.add(createDiagnostic(type, unit,
+                        Messages.getMessage("InconsistentSpecialization",
+                                type.getName(), ultimateBaseFqName),
+                        DIAGNOSTIC_CODE_INCONSISTENT_SPECIALIZATION, null,
+                        DiagnosticSeverity.Error));
+            }
+        }
+    }
+
+    /**
+     * Scans all project source types and returns a map from ultimate base FQ name to the
+     * list of {@code @Specializes} types (direct or transitive) that specialize that base.
+     */
+    private Map<String, List<PsiClass>> collectProjectSpecializersByUltimateBase(com.intellij.openapi.project.Project project) {
+        Map<String, List<PsiClass>> result = new HashMap<>();
+        GlobalSearchScope scope = GlobalSearchScope.projectScope(project);
+
+        AllClassesSearch.search(scope, project).forEach(type -> {
+            if (!isMatchedAnnotation(type.getAnnotations(), SPECIALIZES_FQ_NAME)) {
+                return true; // continue iteration
+            }
+            String ultimateBaseFqName = resolveUltimateBaseFqName(type);
+            if (ultimateBaseFqName != null) {
+                result.computeIfAbsent(ultimateBaseFqName, k -> new ArrayList<>()).add(type);
+            }
+            return true; // continue iteration
+        });
+
+        return result;
+    }
+
+    /**
+     * Walks the {@code @Specializes} chain transitively and returns the FQ name of the
+     * ultimate base bean (the first ancestor that does not itself carry {@code @Specializes}).
+     */
+    private String resolveUltimateBaseFqName(PsiClass type) {
+        PsiClass superClass = type.getSuperClass();
+        if (superClass == null) {
+            return null;
+        }
+        String fqName = superClass.getQualifiedName();
+        if (fqName == null || "java.lang.Object".equals(fqName)) {
+            return null;
+        }
+        // If the superclass also has @Specializes, keep walking up the chain.
+        if (isMatchedAnnotation(superClass.getAnnotations(), SPECIALIZES_FQ_NAME)) {
+            return resolveUltimateBaseFqName(superClass);
+        }
+        return fqName;
+    }
+}

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/cdi/ManagedBeanConstants.java
@@ -64,6 +64,7 @@ public class ManagedBeanConstants {
     public static final String DIAGNOSTIC_CODE_WILDCARD_PRODUCER_FIELD = "InvalidWildcardTypeInProducerField";
     public static final String DIAGNOSTIC_CODE_WILDCARD_PRODUCER_METHOD = "InvalidWildcardTypeInProducerMethod";
     public static final String DIAGNOSTIC_CODE_ORPHAN_DISPOSER = "InvalidOrphanDisposerMethod";
+    public static final String DIAGNOSTIC_CODE_INCONSISTENT_SPECIALIZATION = "InvalidInconsistentSpecialization";
     //Added as part of fix that adds two quick fixes which are mutually exclusive issue #540
     public static final String[] INVALID_DISPOSER_FQ_PARAMS = { DISPOSES_FQ_NAME };
     public static final String[] INVALID_DISPOSER_FQ_CONFLICTED_PARAMS = { OBSERVES_FQ_NAME, OBSERVES_ASYNC_FQ_NAME };

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -127,6 +127,9 @@
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.CdiWildcardDiagnosticsCollector"/>
         <javaDiagnosticsParticipant
                 group="jakarta"
+                implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.cdi.CdiSpecializesDiagnosticsCollector"/>
+        <javaDiagnosticsParticipant
+                group="jakarta"
                 implementationClass="io.openliberty.tools.intellij.lsp4jakarta.lsp4ij.di.DependencyInjectionDiagnosticsCollector"/>
         <javaDiagnosticsParticipant
                 group="jakarta"

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -103,6 +103,7 @@ AnnotationMinMaxMethods = The {0} annotation can only be used on \n- BigDecimal 
 AnnotationMinMaxFields = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type fields.
 ProducerFieldWithNamedAnnotation = Producer field ''{0}'' must not declare a bean name using @Named annotation.
 SpecializedBeanWithNamedAnnotation = Specialized bean ''{0}'' must not declare an explicit bean name using @Named. The name is inherited from the bean it specializes.
+InconsistentSpecialization = Inconsistent specialization: bean ''{0}'' and at least one other bean both specialize the same base type ''{1}''. Only one bean may specialize a given base bean.
 AnnotationMinMaxParams = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long (and their respective wrappers) \n type parameters.
 # The next two messages include float and double
 AnnotationPositiveMethods = The {0} annotation can only be used on \n- BigDecimal \n- BigInteger\n- byte, short, int, long, float, double (and their respective wrappers) \n type methods.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/InconsistentSpecializationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/cdi/InconsistentSpecializationTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package io.openliberty.tools.intellij.lsp4jakarta.it.cdi;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.lsp4jakarta.it.core.BaseJakartaTest;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import io.openliberty.tools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
+
+/** Tests for the inconsistent specialization diagnostic: only one bean may specialize a given base bean. */
+@RunWith(JUnit4.class)
+public class InconsistentSpecializationTest extends BaseJakartaTest {
+
+    private static String msg(String beanName, String baseTypeFqName) {
+        return "Inconsistent specialization: bean '" + beanName
+                + "' and at least one other bean both specialize the same base type '"
+                + baseTypeFqName + "'. Only one bean may specialize a given base bean.";
+    }
+
+    /** No diagnostic expected on a base bean that does not carry @Specializes. */
+    @Test
+    public void noDiagnosticOnBaseBeanWithoutSpecializes() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module)
+                        + "/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/BaseBean.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    /** No diagnostic expected when only one bean specializes a given base. */
+    @Test
+    public void noDiagnosticWhenOnlyOneBeanSpecializesABase() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module)
+                        + "/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/ValidSpecializer.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
+
+    /** Diagnostic expected on SpecializerA when SpecializerB also specializes BaseBean. */
+    @Test
+    public void inconsistentSpecializationOnFirstBean() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module)
+                        + "/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerA.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = d(8, 13, 25,
+                msg("SpecializerA",
+                        "io.openliberty.sample.jakarta.cdi.specializes.BaseBean"),
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidInconsistentSpecialization");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    /** Diagnostic expected on SpecializerB when SpecializerA also specializes BaseBean. */
+    @Test
+    public void inconsistentSpecializationOnSecondBean() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module)
+                        + "/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerB.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = d(8, 13, 25,
+                msg("SpecializerB",
+                        "io.openliberty.sample.jakarta.cdi.specializes.BaseBean"),
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidInconsistentSpecialization");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+
+    /** Diagnostic expected on TransitiveSpecializerB when it transitively specializes the same base as TransitiveSpecializerA. */
+    @Test
+    public void inconsistentSpecializationOnTransitiveBean() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module)
+                        + "/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveSpecializerB.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = d(8, 13, 35,
+                msg("TransitiveSpecializerB",
+                        "io.openliberty.sample.jakarta.cdi.specializes.TransitiveBaseBean"),
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidInconsistentSpecialization");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d);
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/BaseBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/BaseBean.java
@@ -1,0 +1,12 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** Base bean. SpecializerA and SpecializerB both specialize this — inconsistent specialization. */
+@ApplicationScoped
+public class BaseBean {
+
+    public void execute() {
+        System.out.println("Base execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerA.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerA.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Specializes;
+
+/** Invalid: two beans (this class and SpecializerB) both specialize BaseBean. */
+@Specializes
+@ApplicationScoped
+public class SpecializerA extends BaseBean {
+
+    @Override
+    public void execute() {
+        System.out.println("Specializer A execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerB.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/SpecializerB.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Specializes;
+
+/** Invalid: two beans (this class and SpecializerA) both specialize BaseBean. */
+@Specializes
+@ApplicationScoped
+public class SpecializerB extends BaseBean {
+
+    @Override
+    public void execute() {
+        System.out.println("Specializer B execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveBaseBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveBaseBean.java
@@ -1,0 +1,12 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** Base bean for the transitive test. TransitiveSpecializerA and TransitiveSpecializerB both ultimately specialize this. */
+@ApplicationScoped
+public class TransitiveBaseBean {
+
+    public void execute() {
+        System.out.println("Transitive base execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveSpecializerA.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveSpecializerA.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Specializes;
+
+/** Directly specializes TransitiveBaseBean. Superclass of TransitiveSpecializerB. */
+@Specializes
+@ApplicationScoped
+public class TransitiveSpecializerA extends TransitiveBaseBean {
+
+    @Override
+    public void execute() {
+        System.out.println("Transitive specializer A execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveSpecializerB.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/TransitiveSpecializerB.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Specializes;
+
+/** Invalid: transitively specializes TransitiveBaseBean via TransitiveSpecializerA. */
+@Specializes
+@ApplicationScoped
+public class TransitiveSpecializerB extends TransitiveSpecializerA {
+
+    @Override
+    public void execute() {
+        System.out.println("Transitive specializer B execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/ValidBaseBean.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/ValidBaseBean.java
@@ -1,0 +1,12 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/** Base bean. Only ValidSpecializer extends this — no conflict. */
+@ApplicationScoped
+public class ValidBaseBean {
+
+    public void process() {
+        System.out.println("Valid base execution");
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/ValidSpecializer.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/specializes/ValidSpecializer.java
@@ -1,0 +1,15 @@
+package io.openliberty.sample.jakarta.cdi.specializes;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Specializes;
+
+/** Valid: sole specializer of ValidBaseBean — no diagnostic expected. */
+@Specializes
+@ApplicationScoped
+public class ValidSpecializer extends ValidBaseBean {
+
+    @Override
+    public void process() {
+        System.out.println("Valid specialization");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/683

Implements the diagnostic for CDI inconsistent specialization. When two or more beans in a project annotate themselves with @specializes and ultimately specialize the same base bean (including through transitive chains), this is a deployment error.


https://github.com/user-attachments/assets/82fbd512-6366-4c25-8da4-f0865dbcf032

