### PR TITLE
Limit CI matrix on PRs; add weekly all-OS run

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
     needs: fetch_merge_commit_sha_from_lsp4ij_PR
     # Run for all test-groups when triggered via workflow_dispatch, workflow_call, or when 'run-ci' label is applied.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.label.name == 'run-ci'
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runtime == 'linux' && 'ubuntu-latest' || matrix.runtime == 'mac' && 'macOS-14' || matrix.runtime == 'windows' && 'windows-latest' }}
     name: ${{ matrix.runtime }} - ${{ matrix.test-group }}
     strategy:
       fail-fast: false
@@ -120,12 +120,6 @@ jobs:
           - runtime: windows
             test-group: LSP4Jakarta-Unit
         include:
-          - runtime: linux
-            os: ubuntu-latest
-          - runtime: mac
-            os: macOS-14
-          - runtime: windows
-            os: windows-latest
           - test-group: Maven-MicroProfile
             test-class: io.openliberty.tools.intellij.it.MavenSingleModMPProjectTest
           - test-group: Gradle-MicroProfile
@@ -164,7 +158,7 @@ jobs:
       TEST_CLASS: ${{ matrix.test-class }}
     steps:
       - name: Configure pagefile
-        if: contains(matrix.os, 'windows')
+        if: matrix.runtime == 'windows'
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 8GB

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,11 @@ on:
         type: string
         required: true
         default: main
+      allOS:
+        description: 'Run tests on all OS (linux, mac, windows). When false, runs linux only.'
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       useLocalPlugin:
@@ -105,9 +110,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # When triggered by a PR label (run-ci), run only on linux to limit job count.
-        # When triggered via workflow_dispatch or workflow_call (e.g. cron), run on all OS's.
-        runtime: ${{ fromJson(github.event_name == 'pull_request' && '["linux"]' || '["linux","mac","windows"]') }}
+        # Run on all OS's when allOS input is true (e.g. weekly build), otherwise linux only (PR/push).
+        runtime: ${{ fromJson(inputs.allOS && '["linux","mac","windows"]' || '["linux"]') }}
         test-group: [ LSP4Jakarta-Unit, Maven-MicroProfile, Gradle-MicroProfile, Maven-Custom-Liberty-Install, Gradle-Custom-Liberty-Install, Maven-MP-Config, Gradle-MP-Config, Maven-MP-SID, Gradle-MP-SID, Maven-NLT-REST, Gradle-NLT-REST, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server, Maven-Multi-Module-MP ]
         exclude:
           # Exclude LSP4Jakarta-Unit from mac and windows - only run on linux
@@ -223,7 +227,7 @@ jobs:
     needs: fetch_merge_commit_sha_from_lsp4ij_PR
     # Runs subset of test-groups for lsp4jakarta PRs when 'run-lsp4jakarta-it' label is applied.
     if: github.event_name == 'pull_request' && github.event.label.name == 'run-lsp4jakarta-it'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     name: ${{ matrix.runtime }} - ${{ matrix.test-group }}
     strategy:
       fail-fast: false
@@ -232,12 +236,6 @@ jobs:
         runtime: [ linux ]
         test-group: [ LSP4Jakarta-Unit, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server ]
         include:
-          - runtime: linux
-            os: ubuntu-latest
-          - runtime: mac
-            os: macOS-14
-          - runtime: windows
-            os: windows-latest
           - test-group: Gradle-Language-Server
             test-class: io.openliberty.tools.intellij.it.GradleSingleModLSTest
           - test-group: Gradle-MP-Language-Server
@@ -253,13 +251,6 @@ jobs:
       REF_LTI_TAG: ${{ inputs.refLTITag }}
       TEST_CLASS: ${{ matrix.test-class }}
     steps:
-      - name: Configure pagefile
-        if: contains(matrix.os, 'windows')
-        uses: al-cheb/configure-pagefile-action@v1.4
-        with:
-          minimum-size: 8GB
-          maximum-size: 10GB
-          disk-root: "C:"
       - name: 'Checkout liberty-tools-intellij'
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,21 @@ on:
         type: string
         required: false
         default: main
+      runLinux:
+        description: 'Run tests on Linux'
+        type: boolean
+        required: false
+        default: true
+      runMac:
+        description: 'Run tests on macOS'
+        type: boolean
+        required: false
+        default: false
+      runWindows:
+        description: 'Run tests on Windows'
+        type: boolean
+        required: false
+        default: false
   push:
     # Restricted to main to avoid triggering workflows on forks.
     branches: [ main ]
@@ -111,9 +126,18 @@ jobs:
       fail-fast: false
       matrix:
         # Limit PR/push CI to linux only to reduce the number of GHA jobs consumed by LTI.
-        # The full OS matrix (linux, mac, windows) runs only when allOS=true, which is set
-        # by the weekly scheduled workflow (weeklyBuildAllOS.yaml) or a manual trigger.
-        runtime: ${{ fromJson(inputs.allOS && '["linux","mac","windows"]' || '["linux"]') }}
+        # The full OS matrix (linux, mac, windows) runs only when allOS=true (set by the weekly
+        # scheduled workflow) or when specific OS inputs are selected via workflow_dispatch.
+        runtime: >-
+          ${{ fromJson(
+            github.event_name == 'workflow_call' && inputs.allOS && '["linux","mac","windows"]' ||
+            github.event_name == 'workflow_dispatch' && format('[{0}{1}{2}]',
+              inputs.runLinux  && '"linux",'  || '',
+              inputs.runMac    && '"mac",'    || '',
+              inputs.runWindows && '"windows"' || ''
+            ) ||
+            '["linux"]'
+          ) }}
         test-group: [ LSP4Jakarta-Unit, Maven-MicroProfile, Gradle-MicroProfile, Maven-Custom-Liberty-Install, Gradle-Custom-Liberty-Install, Maven-MP-Config, Gradle-MP-Config, Maven-MP-SID, Gradle-MP-SID, Maven-NLT-REST, Gradle-NLT-REST, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server, Maven-Multi-Module-MP ]
         exclude:
           # Exclude LSP4Jakarta-Unit from mac and windows - only run on linux

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ linux, mac, windows ]
+        # When triggered by a PR label (run-ci), run only on linux to limit job count.
+        # When triggered via workflow_dispatch or workflow_call (e.g. cron), run on all OS's.
+        runtime: ${{ fromJson(github.event_name == 'pull_request' && '["linux"]' || '["linux","mac","windows"]') }}
         test-group: [ LSP4Jakarta-Unit, Maven-MicroProfile, Gradle-MicroProfile, Maven-Custom-Liberty-Install, Gradle-Custom-Liberty-Install, Maven-MP-Config, Gradle-MP-Config, Maven-MP-SID, Gradle-MP-SID, Maven-NLT-REST, Gradle-NLT-REST, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server, Maven-Multi-Module-MP ]
         exclude:
           # Exclude LSP4Jakarta-Unit from mac and windows - only run on linux
@@ -226,14 +228,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ linux, mac, windows ]
+        # When triggered by the run-lsp4jakarta-it label, run only on linux to limit job count.
+        runtime: [ linux ]
         test-group: [ LSP4Jakarta-Unit, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server ]
-        exclude:
-          # Exclude LSP4Jakarta-Unit from mac and windows - only run on linux
-          - runtime: mac
-            test-group: LSP4Jakarta-Unit
-          - runtime: windows
-            test-group: LSP4Jakarta-Unit
         include:
           - runtime: linux
             os: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run on all OS's when allOS input is true (e.g. weekly build), otherwise linux only (PR/push).
+        # Limit PR/push CI to linux only to reduce the number of GHA jobs consumed by LTI.
+        # The full OS matrix (linux, mac, windows) runs only when allOS=true, which is set
+        # by the weekly scheduled workflow (weeklyBuildAllOS.yaml) or a manual trigger.
         runtime: ${{ fromJson(inputs.allOS && '["linux","mac","windows"]' || '["linux"]') }}
         test-group: [ LSP4Jakarta-Unit, Maven-MicroProfile, Gradle-MicroProfile, Maven-Custom-Liberty-Install, Gradle-Custom-Liberty-Install, Maven-MP-Config, Gradle-MP-Config, Maven-MP-SID, Gradle-MP-SID, Maven-NLT-REST, Gradle-NLT-REST, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server, Maven-Multi-Module-MP ]
         exclude:
@@ -226,7 +228,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # When triggered by the run-lsp4jakarta-it label, run only on linux to limit job count.
+        # When triggered by the run-lsp4jakarta-it label, run linux only to reduce the number of GHA jobs consumed by LTI.
         runtime: [ linux ]
         test-group: [ LSP4Jakarta-Unit, Gradle-Language-Server, Gradle-MP-Language-Server, Gradle-Jakarta-Language-Server ]
         include:

--- a/.github/workflows/weeklyBuildAllOS.yaml
+++ b/.github/workflows/weeklyBuildAllOS.yaml
@@ -3,9 +3,9 @@ name: Weekly Build - All OS
 on:
   workflow_dispatch:
   schedule:
-    # The job runs at 9:30 AM UTC every Monday, which is 3:00 PM IST and 4:30 AM EST.
+    # The job runs at 1:30 AM UTC every Monday, which is 7:00 AM IST and 8:30 PM EST (Sunday).
     # Ref - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
-    - cron: '30 9 * * 1'
+    - cron: '30 1 * * 1'
 
 jobs:
   # Run the LTI Tests on all OS's against lsp4ij main branch for main and feature branches in progress

--- a/.github/workflows/weeklyBuildAllOS.yaml
+++ b/.github/workflows/weeklyBuildAllOS.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # 'main' plus any feature branches currently in progress.
         # Add or remove branches here as feature work starts or completes.
-        tag: [ 'main', 'intellij-2026.2-test-automation' , 'lsp4jakarta-0.3.0-integration', 'lsp4jakarta-0.2.7-release-branch', 'lsp4mp-0.17.0-support', 'multi-module-support-feature-branch', 'open-liberty-starter-integration', ]
+        tag: [ 'main' , 'lsp4jakarta-0.3.0-integration', 'lsp4jakarta-0.2.7-release-branch', 'lsp4mp-0.17.0-support', 'multi-module-support-feature-branch', 'open-liberty-starter-integration', ]
     with:
       useLocalPlugin: false
       refLsp4ij: main

--- a/.github/workflows/weeklyBuildAllOS.yaml
+++ b/.github/workflows/weeklyBuildAllOS.yaml
@@ -1,0 +1,25 @@
+name: Weekly Build - All OS
+
+on:
+  workflow_dispatch:
+  schedule:
+    # The job runs at 9:30 AM UTC every Monday, which is 3:00 PM IST and 4:30 AM EST.
+    # Ref - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: '30 9 * * 1'
+
+jobs:
+  # Run the LTI Tests on all OS's against lsp4ij main branch for main and feature branches in progress
+  call-build-workflow-all-os:
+    uses: ./.github/workflows/build.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        # 'main' plus any feature branches currently in progress.
+        # Add or remove branches here as feature work starts or completes.
+        tag: [ 'main', 'intellij-2026.2-test-automation' , 'lsp4jakarta-0.3.0-integration', 'lsp4jakarta-0.2.7-release-branch', 'lsp4mp-0.17.0-support', 'multi-module-support-feature-branch', 'open-liberty-starter-integration', ]
+    with:
+      useLocalPlugin: false
+      refLsp4ij: main
+      lsp4ijBranch: main
+      refLTITag: ${{ matrix.tag }}
+    name: Weekly All-OS Build

--- a/.github/workflows/weeklyBuildAllOS.yaml
+++ b/.github/workflows/weeklyBuildAllOS.yaml
@@ -22,4 +22,5 @@ jobs:
       refLsp4ij: main
       lsp4ijBranch: main
       refLTITag: ${{ matrix.tag }}
+      allOS: true
     name: Weekly All-OS Build


### PR DESCRIPTION
Fixes #1746 

- A boolean input allOS (default: false) added to the workflow_call trigger. When true, tests run on all three OS; when false only Linux runs.

`run-ci` job
<img width="1728" height="867" alt="image" src="https://github.com/user-attachments/assets/bcea0ff0-84cf-4dc5-8938-1f8d5a79ac94" />

`run-lsp4jakarta-it` job
<img width="1714" height="587" alt="image" src="https://github.com/user-attachments/assets/58114cda-a8df-47d1-8744-e8e6044ad7c3" />

- weeklyBuildAllOS.yaml runs every Monday at 9:30 AM UTC via workflow_call into build.yaml. It runs against main and all active feature branches


