### PR TITLE
Implements diagnostics for @IdClass primary key class structure

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceConstants.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceConstants.java
@@ -30,6 +30,8 @@ public class PersistenceConstants {
     public static final String MAPKEYJOINCOLUMN = "jakarta.persistence.MapKeyJoinColumn";
     public static final String MAPKEYENUMERATED = "jakarta.persistence.MapKeyEnumerated";
     public static final String MAPKEYTEMPORAL = "jakarta.persistence.MapKeyTemporal";
+    public static final String IDCLASS = "jakarta.persistence.IdClass";
+    public static final String SERIALIZABLE = "java.io.Serializable";
     public static final String TEMPORAL = "jakarta.persistence.Temporal";
     public static final String VERSION = "jakarta.persistence.Version";
     public static final String TEMPORAL_TYPE = "jakarta.persistence.TemporalType";
@@ -62,6 +64,13 @@ public class PersistenceConstants {
 
     public static final String DIAGNOSTIC_CODE_INHERITANCE_ON_NON_ENTITY = "InheritanceAnnotationOnNonEntityClass";
     public static final String DIAGNOSTIC_CODE_INHERITANCE_ON_NON_ROOT = "InheritanceAnnotationOnNonRootEntity";
+
+    /* IdClass Codes */
+    public static final String DIAGNOSTIC_CODE_IDCLASS_MUST_BE_PUBLIC = "IdClassMustBePublic";
+    public static final String DIAGNOSTIC_CODE_IDCLASS_MUST_HAVE_PUBLIC_NO_ARG_CONSTRUCTOR = "IdClassMustHavePublicNoArgConstructor";
+    public static final String DIAGNOSTIC_CODE_IDCLASS_MUST_BE_SERIALIZABLE = "IdClassMustBeSerializable";
+    public static final String DIAGNOSTIC_CODE_IDCLASS_MUST_DECLARE_EQUALS = "IdClassMustDeclareEquals";
+    public static final String DIAGNOSTIC_CODE_IDCLASS_MUST_DECLARE_HASHCODE = "IdClassMustDeclareHashCode";
 
     /* MapKey Codes */
     public static final String DIAGNOSTIC_CODE_MAPKEYENUMERATED_NON_MAP = "MapKeyEnumeratedOnNonMapType";

--- a/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityDiagnosticsCollector.java
+++ b/src/main/java/io/openliberty/tools/intellij/lsp4jakarta/lsp4ij/persistence/PersistenceEntityDiagnosticsCollector.java
@@ -55,14 +55,29 @@ public class PersistenceEntityDiagnosticsCollector extends AbstractDiagnosticsCo
 
                 /* ============ Entity Annotation Diagnostics =========== */
                 PsiAnnotation EntityAnnotation = null;
+                PsiAnnotation mappedSuperclassAnnotation = null;
+                PsiAnnotation idClassAnnotation = null;
                 PsiAnnotation inheritanceAnnotation = null;
                 for (PsiAnnotation annotation : allAnnotations) {
                     if (isMatchedJavaElement(type, annotation.getQualifiedName(), PersistenceConstants.ENTITY)) {
                         EntityAnnotation = annotation;
                     }
+                    if (isMatchedJavaElement(type, annotation.getQualifiedName(), PersistenceConstants.MAPPEDSUPERCLASS)) {
+                        mappedSuperclassAnnotation = annotation;
+                    }
+                    if (isMatchedJavaElement(type, annotation.getQualifiedName(), PersistenceConstants.IDCLASS)) {
+                        idClassAnnotation = annotation;
+                    }
                     if (isMatchedJavaElement(type, annotation.getQualifiedName(), PersistenceConstants.INHERITANCE)) {
                         inheritanceAnnotation = annotation;
                     }
+                }
+
+                boolean hasEntity = EntityAnnotation != null;
+                boolean hasMappedSuperclass = mappedSuperclassAnnotation != null;
+
+                if (idClassAnnotation != null && (hasEntity || hasMappedSuperclass)) {
+                    validateIdClass(idClassAnnotation, unit, diagnostics);
                 }
 
                 if (EntityAnnotation != null) {
@@ -540,5 +555,96 @@ public class PersistenceEntityDiagnosticsCollector extends AbstractDiagnosticsCo
             }
         }
 
+    }
+
+    /**
+     * Validates the structural requirements of the class referenced by @IdClass.
+     * Per Jakarta Persistence 3.0 spec section 2.4, the primary key class must be:
+     * <ol>
+     *   <li>public</li>
+     *   <li>have a public no-arg constructor</li>
+     *   <li>implement java.io.Serializable</li>
+     *   <li>define an equals(Object) method</li>
+     *   <li>define a hashCode() method</li>
+     * </ol>
+     *
+     * @param idClassAnnotation the @IdClass annotation
+     * @param unit              the compilation unit being analysed
+     * @param diagnostics       the list to add diagnostics to
+     */
+    private void validateIdClass(PsiAnnotation idClassAnnotation,
+                                 PsiJavaFile unit, List<Diagnostic> diagnostics) {
+        PsiAnnotationMemberValue value = idClassAnnotation.findAttributeValue("value");
+        if (!(value instanceof PsiClassObjectAccessExpression)) {
+            return;
+        }
+        PsiType keyType = ((PsiClassObjectAccessExpression) value).getOperand().getType();
+        if (!(keyType instanceof PsiClassType)) {
+            return;
+        }
+        PsiClass idClass = ((PsiClassType) keyType).resolve();
+        if (idClass == null) {
+            return;
+        }
+
+        // Diagnostics are placed on the @IdClass annotation in the entity file so that
+        // the range is always within the file currently being analysed.
+        if (!idClass.hasModifierProperty(PsiModifier.PUBLIC)) {
+            diagnostics.add(createDiagnostic(idClassAnnotation, unit,
+                    Messages.getMessage("IdClassMustBePublic"),
+                    PersistenceConstants.DIAGNOSTIC_CODE_IDCLASS_MUST_BE_PUBLIC, null,
+                    DiagnosticSeverity.Error));
+        }
+
+        boolean hasPublicNoArgConstructor = false;
+        for (PsiMethod method : idClass.getMethods()) {
+            if (method.isConstructor()
+                    && method.getParameterList().getParametersCount() == 0
+                    && method.hasModifierProperty(PsiModifier.PUBLIC)) {
+                hasPublicNoArgConstructor = true;
+                break;
+            }
+        }
+        if (!hasPublicNoArgConstructor) {
+            diagnostics.add(createDiagnostic(idClassAnnotation, unit,
+                    Messages.getMessage("IdClassMustHavePublicNoArgConstructor"),
+                    PersistenceConstants.DIAGNOSTIC_CODE_IDCLASS_MUST_HAVE_PUBLIC_NO_ARG_CONSTRUCTOR, null,
+                    DiagnosticSeverity.Error));
+        }
+
+        if (!doesImplementInterfaces(idClass, new String[]{PersistenceConstants.SERIALIZABLE})) {
+            diagnostics.add(createDiagnostic(idClassAnnotation, unit,
+                    Messages.getMessage("IdClassMustBeSerializable"),
+                    PersistenceConstants.DIAGNOSTIC_CODE_IDCLASS_MUST_BE_SERIALIZABLE, null,
+                    DiagnosticSeverity.Error));
+        }
+
+        boolean hasEquals = false;
+        boolean hasHashCode = false;
+        for (PsiMethod method : idClass.getMethods()) {
+            if (!idClass.equals(method.getContainingClass())) {
+                continue;
+            }
+            if ("equals".equals(method.getName())
+                    && method.getParameterList().getParametersCount() == 1
+                    && "java.lang.Object".equals(method.getParameterList().getParameters()[0].getType().getCanonicalText())) {
+                hasEquals = true;
+            } else if ("hashCode".equals(method.getName())
+                    && method.getParameterList().getParametersCount() == 0) {
+                hasHashCode = true;
+            }
+        }
+        if (!hasEquals) {
+            diagnostics.add(createDiagnostic(idClassAnnotation, unit,
+                    Messages.getMessage("IdClassMustDeclareEquals"),
+                    PersistenceConstants.DIAGNOSTIC_CODE_IDCLASS_MUST_DECLARE_EQUALS, null,
+                    DiagnosticSeverity.Error));
+        }
+        if (!hasHashCode) {
+            diagnostics.add(createDiagnostic(idClassAnnotation, unit,
+                    Messages.getMessage("IdClassMustDeclareHashCode"),
+                    PersistenceConstants.DIAGNOSTIC_CODE_IDCLASS_MUST_DECLARE_HASHCODE, null,
+                    DiagnosticSeverity.Error));
+        }
     }
 }

--- a/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
+++ b/src/main/resources/io/openliberty/tools/intellij/lsp4jakarta/messages/messages.properties
@@ -222,6 +222,11 @@ InvalidIdType = The @Id annotation must use a valid identifier type (primitives,
 MultipleEmbeddedIdAnnotations = An entity must not declare more than one @EmbeddedId annotation.
 MixedIdentifierAnnotationsEmbeddedId = @EmbeddedId cannot be combined with @Id in the same entity.
 MixedIdentifierAnnotationsId = @Id cannot be combined with @EmbeddedId in the same entity.
+IdClassMustBePublic = A class referenced by @IdClass must be public.
+IdClassMustHavePublicNoArgConstructor = A class referenced by @IdClass must have a public no-argument constructor.
+IdClassMustBeSerializable = A class referenced by @IdClass must implement java.io.Serializable.
+IdClassMustDeclareEquals = A class referenced by @IdClass must declare an equals method.
+IdClassMustDeclareHashCode = A class referenced by @IdClass must declare a hashCode method.
 
 # PersistenceContextDiagnosticsCollector
 PersistenceContextNotInManagedComponent = @PersistenceContext can only be used in a container-managed component such as a CDI bean, EJB, or Servlet.

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/persistence/JakartaPersistenceTest.java
@@ -1168,4 +1168,96 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
         // Valid: @Entity + @Inheritance extending @MappedSuperclass — no @Entity ancestor
         assertJavaDiagnostics(diagnosticsParams, utils);
     }
+
+    // =========================================================================
+    // @IdClass Diagnostic Tests
+    // =========================================================================
+
+    @Test
+    public void testInvalidIdClassStructure() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidIdClassStructure.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @IdClass(InvalidIdClass.class) at line 13 (0-based), col 0-30
+        // InvalidIdClass: not public, no public no-arg constructor, not Serializable,
+        // no equals, no hashCode → 5 diagnostics on the @IdClass annotation
+        Diagnostic idClassNotPublicError = d(13, 0, 30,
+                "A class referenced by @IdClass must be public.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustBePublic");
+        Diagnostic idClassNoPublicNoArgConstructorError = d(13, 0, 30,
+                "A class referenced by @IdClass must have a public no-argument constructor.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustHavePublicNoArgConstructor");
+        Diagnostic idClassNotSerializableError = d(13, 0, 30,
+                "A class referenced by @IdClass must implement java.io.Serializable.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustBeSerializable");
+        Diagnostic idClassNoEqualsError = d(13, 0, 30,
+                "A class referenced by @IdClass must declare an equals method.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustDeclareEquals");
+        Diagnostic idClassNoHashCodeError = d(13, 0, 30,
+                "A class referenced by @IdClass must declare a hashCode method.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustDeclareHashCode");
+
+        assertJavaDiagnostics(diagnosticsParams, utils,
+                idClassNotPublicError, idClassNoPublicNoArgConstructorError,
+                idClassNotSerializableError, idClassNoEqualsError, idClassNoHashCodeError);
+    }
+
+    @Test
+    public void testInvalidMappedSuperclassIdClassStructure() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidMappedSuperclassIdClassStructure.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @IdClass(InvalidMappedSuperclassIdClass.class) at line 13 (0-based), col 0-46
+        // InvalidMappedSuperclassIdClass: not public, no public no-arg constructor,
+        // not Serializable, no equals, no hashCode → 5 diagnostics on the @IdClass annotation
+        Diagnostic idClassNotPublicError = d(13, 0, 46,
+                "A class referenced by @IdClass must be public.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustBePublic");
+        Diagnostic idClassNoPublicNoArgConstructorError = d(13, 0, 46,
+                "A class referenced by @IdClass must have a public no-argument constructor.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustHavePublicNoArgConstructor");
+        Diagnostic idClassNotSerializableError = d(13, 0, 46,
+                "A class referenced by @IdClass must implement java.io.Serializable.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustBeSerializable");
+        Diagnostic idClassNoEqualsError = d(13, 0, 46,
+                "A class referenced by @IdClass must declare an equals method.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustDeclareEquals");
+        Diagnostic idClassNoHashCodeError = d(13, 0, 46,
+                "A class referenced by @IdClass must declare a hashCode method.",
+                DiagnosticSeverity.Error, "jakarta-persistence", "IdClassMustDeclareHashCode");
+
+        assertJavaDiagnostics(diagnosticsParams, utils,
+                idClassNotPublicError, idClassNoPublicNoArgConstructorError,
+                idClassNotSerializableError, idClassNoEqualsError, idClassNoHashCodeError);
+    }
+
+    @Test
+    public void testValidIdClassStructure() throws Exception {
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module)
+                + "/src/main/java/io/openliberty/sample/jakarta/persistence/ValidIdClassStructure.java");
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // ValidIdClass is properly structured — no diagnostics expected
+        assertJavaDiagnostics(diagnosticsParams, utils);
+    }
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidIdClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidIdClass.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.persistence;
+
+/**
+ * An invalid @IdClass key class: package-private, has only a private constructor,
+ * does not implement Serializable, and does not declare equals or hashCode.
+ * Expected diagnostics (5): not public, no public no-arg constructor,
+ * not Serializable, no equals, no hashCode.
+ */
+class InvalidIdClass {
+
+    private InvalidIdClass(String value) {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidIdClassStructure.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidIdClassStructure.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+/**
+ * Entity with @IdClass referencing an invalid primary key class.
+ * InvalidIdClass is: not public, has no public no-arg constructor, does not
+ * implement Serializable, and does not declare equals or hashCode.
+ * Expected: 5 diagnostics on the @IdClass annotation.
+ */
+@Entity
+@IdClass(InvalidIdClass.class)
+public class InvalidIdClassStructure {
+
+    @Id
+    private String firstName;
+
+    @Id
+    private String lastName;
+
+    public InvalidIdClassStructure() {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidMappedSuperclassIdClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidMappedSuperclassIdClass.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.persistence;
+
+/**
+ * An invalid @IdClass key class for the MappedSuperclass test: not public,
+ * has only a private constructor, does not implement Serializable,
+ * and does not declare equals or hashCode.
+ * Expected diagnostics (5) on the @IdClass annotation in InvalidMappedSuperclassIdClassStructure.
+ */
+class InvalidMappedSuperclassIdClass {
+
+    private InvalidMappedSuperclassIdClass(String value) {
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidMappedSuperclassIdClassStructure.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/InvalidMappedSuperclassIdClassStructure.java
@@ -1,0 +1,22 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.MappedSuperclass;
+
+/**
+ * MappedSuperclass with @IdClass referencing an invalid primary key class.
+ * InvalidMappedSuperclassIdClass is: not public, has no public no-arg constructor,
+ * does not implement Serializable, and does not declare equals or hashCode.
+ * Expected: 5 diagnostics on the @IdClass annotation.
+ */
+@MappedSuperclass
+@IdClass(InvalidMappedSuperclassIdClass.class)
+public class InvalidMappedSuperclassIdClassStructure {
+
+    @Id
+    private String firstName;
+
+    @Id
+    private String lastName;
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/ValidIdClass.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/ValidIdClass.java
@@ -1,0 +1,26 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import java.io.Serializable;
+
+/**
+ * A valid @IdClass key class: public, has a public no-arg constructor,
+ * implements Serializable, and declares both equals and hashCode.
+ * No diagnostics expected when this class is referenced by @IdClass.
+ */
+public class ValidIdClass implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public ValidIdClass() {
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ValidIdClass;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/ValidIdClassStructure.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/ValidIdClassStructure.java
@@ -1,0 +1,20 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+/**
+ * Valid entity with @IdClass referencing a properly structured primary key class.
+ * No diagnostics expected.
+ */
+@Entity
+@IdClass(ValidIdClass.class)
+public class ValidIdClassStructure {
+
+    @Id
+    private String firstName;
+
+    @Id
+    private String lastName;
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/973

A primary key class referenced by @IdClass on an @Entity or @MappedSuperclass must satisfy five structural requirements per the spec. This PR validates each one and reports a targeted diagnostic on the @IdClass annotation when violated:

- IdClassMustBePublic - the referenced class must be public
- IdClassMustHavePublicNoArgConstructor - must have a public no-argument constructor
- IdClassMustBeSerializable - must implement java.io.Serializable
- IdClassMustDeclareEquals - must declare an equals(Object) method
- IdClassMustDeclareHashCode - must declare a hashCode() method