### PR TITLE
Fix runtime matrix expression for weekly all-OS build and workflow dispatch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,11 +130,11 @@ jobs:
         # scheduled workflow) or when specific OS inputs are selected via workflow_dispatch.
         runtime: >-
           ${{ fromJson(
-            github.event_name == 'workflow_call' && inputs.allOS && '["linux","mac","windows"]' ||
-            github.event_name == 'workflow_dispatch' && format('[{0}{1}{2}]',
-              inputs.runLinux  && '"linux",'  || '',
-              inputs.runMac    && '"mac",'    || '',
-              inputs.runWindows && '"windows"' || ''
+            inputs.allOS && '["linux","mac","windows"]' ||
+            (inputs.runLinux || inputs.runMac || inputs.runWindows) && format('[{0}{1}{2}]',
+              inputs.runLinux && '"linux"' || '',
+              inputs.runMac && (inputs.runLinux && ',"mac"' || '"mac"') || '',
+              inputs.runWindows && ((inputs.runLinux || inputs.runMac) && ',"windows"' || '"windows"') || ''
             ) ||
             '["linux"]'
           ) }}


### PR DESCRIPTION
An error occurred while running the weekly all-OS build. I’ve resolved the issue, and the build now runs as shown below against main and each feature branch:

<img width="858" height="531" alt="image" src="https://github.com/user-attachments/assets/304eb559-a319-43b9-841b-fb349bab46d6" />

I’ve cancelled the job for now.
The failure when checking out the feature branch is because the feature branch does not exist in my fork. Only the checkout of the `main` branch works correctly in my fork. This should work as expected in the `openliberty` repository.

Build link: https://github.com/anusreelakshmi934/liberty-tools-intellij/actions/runs/34450102188
