### PR TITLE
Replace "Open Liberty" with "Liberty" in user-facing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Downloads](https://img.shields.io/jetbrains/plugin/d/14856-liberty-tools?style=for-the-badge&)
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?style=for-the-badge&label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 
-Liberty Tools for IntelliJ IDEA is an IntelliJ IDEA plugin for developing cloud-native Java applications with [Open Liberty](https://openliberty.io/) and [WebSphere Liberty](https://www.ibm.com/products/websphere-liberty). Iterate fast with Liberty dev mode, code with assistance for MicroProfile and Jakarta EE APIs, and easily edit Liberty configuration files.
+Liberty Tools for IntelliJ IDEA is an IntelliJ IDEA plugin for developing cloud-native Java applications with [WebSphere Liberty](https://www.ibm.com/products/websphere-liberty). Iterate fast with Liberty dev mode, code with assistance for MicroProfile and Jakarta EE APIs, and easily edit Liberty configuration files.
 
 Liberty Tools for IntelliJ has an external dependency on [LSP4IJ](https://github.com/redhat-developer/lsp4ij), which is automatically installed from the JetBrains Marketplace when Liberty Tools is installed. LSP4IJ is a free and open-source IntelliJ plugin that enables Language Server Protocol (LSP) support for language server integration in IntelliJ IDEA.
 

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -96,7 +96,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
     }
 
     /**
-     * Builds the Open Liberty Tools Dashboard tree
+     * Builds the Liberty Tools Dashboard tree
      *
      * @param project         current project
      * @param backgroundColor

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,7 @@
     <category>Framework Integration</category>
 
     <description><![CDATA[
-    Liberty Tools for IntelliJ IDEA offers features for developing cloud-native Java applications with <a href="https://openliberty.io/">Open Liberty</a> and <a href="https://www.ibm.com/products/websphere-liberty">WebSphere Liberty</a>. Iterate fast with Liberty dev mode, code with assistance for MicroProfile and Jakarta EE APIs, and easily edit Liberty configuration files.
+    Liberty Tools for IntelliJ IDEA offers features for developing cloud-native Java applications with <a href="https://www.ibm.com/products/websphere-liberty">WebSphere Liberty</a>. Iterate fast with Liberty dev mode, code with assistance for MicroProfile and Jakarta EE APIs, and easily edit Liberty configuration files.
     For more information, see the <a href="https://github.com/OpenLiberty/liberty-tools-intellij#liberty-tools-for-intellij-idea">project documentation in GitHub</a>.
     ]]></description>
 


### PR DESCRIPTION
Fixes https://github.ibm.com/liberty-dev-ex/team/issues/452

- All user-facing string references to "Open Liberty" in the plugin descriptor, README, and source comments are replaced with "Liberty"
- No package names, artifact IDs, or URLs are modified